### PR TITLE
Refactor: docker-compose 스택 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Upload deployment files
         shell: bash
         run: |
-          scp -i ~/.ssh/id_ed25519 deploy/oracle/docker-compose.prod.yml deploy/oracle/deploy.sh '${{ secrets.ORACLE_VPS_USER }}@${{ secrets.ORACLE_VPS_HOST }}:${{ secrets.ORACLE_DEPLOY_PATH }}/'
+          scp -i ~/.ssh/id_ed25519 deploy/oracle/docker-compose.infra.yml deploy/oracle/docker-compose.app.yml deploy/oracle/deploy.sh '${{ secrets.ORACLE_VPS_USER }}@${{ secrets.ORACLE_VPS_HOST }}:${{ secrets.ORACLE_DEPLOY_PATH }}/'
           scp -i ~/.ssh/id_ed25519 .oracle-deploy.env '${{ secrets.ORACLE_VPS_USER }}@${{ secrets.ORACLE_VPS_HOST }}:${{ secrets.ORACLE_DEPLOY_PATH }}/.oracle-deploy.env'
 
       - name: Deploy over SSH

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Production CD targets a single Oracle Cloud VPS.
 - Registry: `ghcr.io`
 - Trigger: `main` push or manual `workflow_dispatch`
 - Runtime: Docker Compose on the VPS
-- Deploy path files: `deploy/oracle/docker-compose.prod.yml`, `deploy/oracle/deploy.sh`, and a server-managed `.env`
+- Deploy path files: `deploy/oracle/docker-compose.infra.yml`, `deploy/oracle/docker-compose.app.yml`, `deploy/oracle/deploy.sh`, and a server-managed `.env`
+- Automated rollout scope: app stack only (`api`, `web`)
+- Manual bootstrap scope: infra stack (`postgres`, `redis`)
 
 Required GitHub secrets for CD:
 
@@ -59,4 +61,6 @@ One-time VPS setup:
 1. Install Docker Engine and Docker Compose plugin.
 2. Create the deploy directory (for example `/opt/aegisai`).
 3. Copy `deploy/oracle/.env.example` to `.env` on the VPS and fill in production values.
-4. Open ports `80` (web) and any additional ports you intentionally expose.
+4. Copy `deploy/oracle/docker-compose.infra.yml`, `deploy/oracle/docker-compose.app.yml`, and `deploy/oracle/deploy.sh` to the VPS deploy directory.
+5. Start infra once with `docker compose -f docker-compose.infra.yml up -d`.
+6. Open ports `80` (web) and any additional ports you intentionally expose.

--- a/deploy/oracle/.env.example
+++ b/deploy/oracle/.env.example
@@ -1,3 +1,4 @@
+# Shared runtime environment for Oracle infra/app compose stacks.
 POSTGRES_DB=aegisai
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=change-me-postgres-password

--- a/deploy/oracle/deploy.sh
+++ b/deploy/oracle/deploy.sh
@@ -10,15 +10,17 @@ for var in $required_vars; do
   fi
 done
 
-if [ ! -f .env ]; then
-  echo "Missing runtime .env file in $(pwd)" >&2
-  exit 1
-fi
+for required_file in .env docker-compose.infra.yml docker-compose.app.yml; do
+  if [ ! -f "$required_file" ]; then
+    echo "Missing required deployment file: $required_file in $(pwd)" >&2
+    exit 1
+  fi
+done
 
 export GHCR_OWNER
 export IMAGE_TAG
 
 echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d --remove-orphans
+docker compose -f docker-compose.app.yml pull
+docker compose -f docker-compose.app.yml up -d --remove-orphans
 docker image prune -f

--- a/deploy/oracle/docker-compose.app.yml
+++ b/deploy/oracle/docker-compose.app.yml
@@ -1,0 +1,25 @@
+services:
+  api:
+    image: ghcr.io/${GHCR_OWNER}/aegisai-api:${IMAGE_TAG}
+    restart: unless-stopped
+    env_file:
+      - .env
+    networks:
+      - platform
+    expose:
+      - "3000"
+
+  web:
+    image: ghcr.io/${GHCR_OWNER}/aegisai-web:${IMAGE_TAG}
+    restart: unless-stopped
+    depends_on:
+      - api
+    networks:
+      - platform
+    ports:
+      - "80:80"
+
+networks:
+  platform:
+    external: true
+    name: aegisai-platform

--- a/deploy/oracle/docker-compose.infra.yml
+++ b/deploy/oracle/docker-compose.infra.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    networks:
+      - platform
 
   redis:
     image: redis:7-alpine
@@ -15,26 +17,13 @@ services:
     command: redis-server --appendonly yes
     volumes:
       - redis-data:/data
-
-  api:
-    image: ghcr.io/${GHCR_OWNER}/aegisai-api:${IMAGE_TAG}
-    restart: unless-stopped
-    env_file:
-      - .env
-    depends_on:
-      - postgres
-      - redis
-    expose:
-      - "3000"
-
-  web:
-    image: ghcr.io/${GHCR_OWNER}/aegisai-web:${IMAGE_TAG}
-    restart: unless-stopped
-    depends_on:
-      - api
-    ports:
-      - "80:80"
+    networks:
+      - platform
 
 volumes:
   postgres-data:
   redis-data:
+
+networks:
+  platform:
+    name: aegisai-platform

--- a/docs/superpowers/plans/2026-03-16-oracle-compose-stack-split.md
+++ b/docs/superpowers/plans/2026-03-16-oracle-compose-stack-split.md
@@ -1,0 +1,54 @@
+# Oracle Compose Stack Split Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split Oracle VPS deployment into infra and app compose stacks so CD only restarts application services.
+
+**Architecture:** Keep `postgres` and `redis` in an infra compose file that owns the shared network and volumes. Move `api` and `web` into a separate app compose file that joins the shared network externally, then update the CD workflow and deploy script to upload both files but only pull/up the app stack.
+
+**Tech Stack:** Docker Compose, GitHub Actions, GHCR, OpenSSH, Node test runner
+
+---
+
+### Task 1: Lock the split-stack regression
+
+**Files:**
+- Modify: `test/github-actions/cd-workflow.test.mjs`
+
+- [ ] Change the CD regression test to expect `docker-compose.infra.yml` and `docker-compose.app.yml` instead of a single prod compose file.
+- [ ] Assert the deploy script only pulls and restarts the app stack.
+- [ ] Assert the workflow uploads both compose files.
+- [ ] Run the targeted regression test and confirm it fails before implementation.
+
+### Task 2: Split Oracle deployment files
+
+**Files:**
+- Create: `deploy/oracle/docker-compose.infra.yml`
+- Create: `deploy/oracle/docker-compose.app.yml`
+- Modify: `deploy/oracle/deploy.sh`
+- Delete: `deploy/oracle/docker-compose.prod.yml`
+
+- [ ] Move `postgres` and `redis` into the infra compose file with volumes and a named shared network.
+- [ ] Move `api` and `web` into the app compose file and attach them to the shared network.
+- [ ] Update the deploy script so CD only runs `pull` and `up` against the app compose file.
+
+### Task 3: Update workflow and docs
+
+**Files:**
+- Modify: `.github/workflows/cd.yml`
+- Modify: `README.md`
+- Modify: `deploy/oracle/.env.example`
+
+- [ ] Upload both compose files during CD.
+- [ ] Document that infra bootstrap is a one-time/manual server task and app rollout is automated.
+- [ ] Keep the existing secret model intact.
+
+### Task 4: Verify end to end
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-16-oracle-compose-stack-split-design.md`
+- Modify: `docs/superpowers/plans/2026-03-16-oracle-compose-stack-split.md`
+
+- [ ] Run the targeted CD regression test.
+- [ ] Run workspace `lint`, `test`, `typecheck`, and `build`.
+- [ ] Review the diff to confirm only app deployment behavior changed.

--- a/docs/superpowers/specs/2026-03-16-oracle-compose-stack-split-design.md
+++ b/docs/superpowers/specs/2026-03-16-oracle-compose-stack-split-design.md
@@ -1,0 +1,37 @@
+# Oracle Compose Stack Split Design
+
+**Issue**: `#23`
+**Title**: `Refactor: docker-compose 스택 분리`
+**Date**: `2026-03-16`
+
+## Goal
+
+Split the Oracle Cloud VPS deployment into separate infrastructure and application Docker Compose stacks so routine app deployments do not touch PostgreSQL or Redis.
+
+## Scope
+
+- Replace the single production compose file with `docker-compose.infra.yml` and `docker-compose.app.yml`
+- Keep PostgreSQL and Redis in the infra stack
+- Keep API and web in the app stack
+- Update the deploy script and CD workflow so GitHub Actions only pulls and restarts the app stack
+- Update regression coverage and deployment documentation for the new split layout
+
+## Design Choices
+
+1. Use a named shared Docker network created by the infra stack so the app stack can attach to existing `postgres` and `redis` services without bundling them into app deploys.
+2. Leave runtime secrets in the same server-managed `.env` file so the split is operational, not a secret-management redesign.
+3. Upload both compose files on every CD run so the VPS always has the latest infra/app definitions, even though only the app stack is restarted automatically.
+4. Keep infra lifecycle manual for now: the VPS bootstrap flow will bring up `docker-compose.infra.yml`, while GitHub Actions continues to handle only image rollout for `docker-compose.app.yml`.
+5. Add repository regression tests that assert the workflow, compose files, and deploy script all preserve the split-stack contract.
+
+## Non-Goals
+
+- No managed database migration or backup automation in this issue
+- No change to GHCR image naming or build behavior
+- No staging environment or multi-host orchestration
+
+## Validation
+
+- Split-stack regression test passes locally
+- Workspace `lint`, `test`, `typecheck`, and `build` still pass
+- CD workflow uploads both compose files and only restarts the app stack

--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -8,12 +8,13 @@ const files = {
   apiDockerfile: new URL('../../apps/api/Dockerfile', import.meta.url),
   webDockerfile: new URL('../../apps/web/Dockerfile', import.meta.url),
   webNginx: new URL('../../apps/web/nginx.conf', import.meta.url),
-  compose: new URL('../../deploy/oracle/docker-compose.prod.yml', import.meta.url),
+  infraCompose: new URL('../../deploy/oracle/docker-compose.infra.yml', import.meta.url),
+  appCompose: new URL('../../deploy/oracle/docker-compose.app.yml', import.meta.url),
   deployScript: new URL('../../deploy/oracle/deploy.sh', import.meta.url),
   envExample: new URL('../../deploy/oracle/.env.example', import.meta.url)
 };
 
-test('cd workflow and oracle deployment files exist and describe the GHCR deploy path', () => {
+test('cd workflow and oracle deployment files enforce the split infra/app deploy path', () => {
   for (const [name, fileUrl] of Object.entries(files)) {
     assert.equal(existsSync(fileUrl), true, `Expected ${name} file to exist at ${fileUrl.pathname}`);
   }
@@ -21,7 +22,8 @@ test('cd workflow and oracle deployment files exist and describe the GHCR deploy
   const workflow = readFileSync(files.workflow, 'utf8');
   const apiDockerfile = readFileSync(files.apiDockerfile, 'utf8');
   const webDockerfile = readFileSync(files.webDockerfile, 'utf8');
-  const compose = readFileSync(files.compose, 'utf8');
+  const infraCompose = readFileSync(files.infraCompose, 'utf8');
+  const appCompose = readFileSync(files.appCompose, 'utf8');
   const deployScript = readFileSync(files.deployScript, 'utf8');
   const envExample = readFileSync(files.envExample, 'utf8');
 
@@ -34,6 +36,8 @@ test('cd workflow and oracle deployment files exist and describe the GHCR deploy
   assert.match(workflow, /ssh-keyscan/);
   assert.match(workflow, /scp /);
   assert.match(workflow, /ssh /);
+  assert.match(workflow, /docker-compose\.infra\.yml/);
+  assert.match(workflow, /docker-compose\.app\.yml/);
 
   assert.match(apiDockerfile, /FROM node:20-alpine/);
   assert.match(apiDockerfile, /corepack pnpm --filter @aegisai\/api build/);
@@ -42,14 +46,22 @@ test('cd workflow and oracle deployment files exist and describe the GHCR deploy
   assert.match(webDockerfile, /FROM nginx:1\.27-alpine/);
   assert.match(webDockerfile, /COPY --from=builder \/app\/apps\/web\/dist/);
 
-  assert.match(compose, /ghcr\.io\/\$\{GHCR_OWNER\}\/aegisai-api:\$\{IMAGE_TAG\}/);
-  assert.match(compose, /ghcr\.io\/\$\{GHCR_OWNER\}\/aegisai-web:\$\{IMAGE_TAG\}/);
-  assert.match(compose, /postgres:16-alpine/);
-  assert.match(compose, /redis:7-alpine/);
+  assert.match(infraCompose, /postgres:16-alpine/);
+  assert.match(infraCompose, /redis:7-alpine/);
+  assert.match(infraCompose, /postgres-data:/);
+  assert.match(infraCompose, /redis-data:/);
+  assert.match(infraCompose, /name:\s*aegisai-platform/m);
+
+  assert.match(appCompose, /ghcr\.io\/\$\{GHCR_OWNER\}\/aegisai-api:\$\{IMAGE_TAG\}/);
+  assert.match(appCompose, /ghcr\.io\/\$\{GHCR_OWNER\}\/aegisai-web:\$\{IMAGE_TAG\}/);
+  assert.match(appCompose, /external:\s*true/);
+  assert.match(appCompose, /api:\n[\s\S]*env_file:/m);
+  assert.match(appCompose, /web:\n[\s\S]*ports:\n[\s\S]*- "80:80"/m);
 
   assert.match(deployScript, /docker login ghcr\.io/);
-  assert.match(deployScript, /docker compose -f docker-compose\.prod\.yml pull/);
-  assert.match(deployScript, /docker compose -f docker-compose\.prod\.yml up -d --remove-orphans/);
+  assert.match(deployScript, /docker compose -f docker-compose\.app\.yml pull/);
+  assert.match(deployScript, /docker compose -f docker-compose\.app\.yml up -d --remove-orphans/);
+  assert.doesNotMatch(deployScript, /docker-compose\.prod\.yml/);
 
   assert.match(envExample, /DATABASE_URL=postgresql:\/\/postgres:/);
   assert.match(envExample, /REDIS_URL=redis:\/\/redis:6379/);


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `refactor/23-compose-stack-split`
- 이슈: `#23`

## 🔎 주요 변경 사항

- Oracle VPS 배포를 `docker-compose.infra.yml`과 `docker-compose.app.yml`로 분리했습니다.
- infra 스택에는 `postgres`, `redis`와 shared network/volume을 두고, app 스택에는 `api`, `web`만 두도록 재구성했습니다.
- CD workflow가 두 compose 파일을 모두 서버에 업로드하도록 수정했습니다.
- deploy 스크립트는 app 스택만 `pull`/`up` 하도록 변경해 일반 배포가 DB/Redis를 건드리지 않게 했습니다.
- README와 `.env.example`를 split-stack 운영 흐름에 맞게 정리했습니다.
- split-stack 계약이 다시 깨지지 않도록 CD 회귀 테스트를 갱신했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured deployment configuration to separate infrastructure and application container stacks for independent management.
  * Modified automated deployment process to update the application stack while managing infrastructure components separately.

* **Documentation**
  * Added implementation plan and design documentation for split-stack deployment architecture.
  * Updated deployment procedures with infrastructure and application stack guidance.

* **Tests**
  * Updated deployment validation tests to verify split-stack configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->