### PR TITLE
feat: add shared contract type surface

### DIFF
--- a/docs/superpowers/plans/2026-03-16-shared-contract-types.md
+++ b/docs/superpowers/plans/2026-03-16-shared-contract-types.md
@@ -1,0 +1,49 @@
+# Shared Contract Types Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the baseline `@aegisai/shared` contract modules used by both the API and web apps.
+
+**Architecture:** Split shared contracts by domain under `packages/shared/src/types/`, keep common pagination and envelope contracts in `common.ts`, and re-export everything from the package root. Lock the surface with a source-level regression test so future changes cannot silently drop files or exports.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Node test runner
+
+---
+
+### Task 1: Lock the export surface with a failing regression test
+
+**Files:**
+- Create: `packages/shared/test/shared-contract-exports.test.mjs`
+- Modify: `packages/shared/package.json`
+
+- [ ] Add a Node test that expects all shared type modules to exist.
+- [ ] Assert the package root re-exports each shared type module.
+- [ ] Run the targeted shared test and confirm it fails before implementation.
+
+### Task 2: Implement shared type modules
+
+**Files:**
+- Create: `packages/shared/src/types/common.ts`
+- Create: `packages/shared/src/types/auth.ts`
+- Create: `packages/shared/src/types/repo.ts`
+- Create: `packages/shared/src/types/scan.ts`
+- Create: `packages/shared/src/types/vulnerability.ts`
+- Create: `packages/shared/src/types/dashboard.ts`
+- Create: `packages/shared/src/types/report.ts`
+- Modify: `packages/shared/src/index.ts`
+
+- [ ] Add pagination and API envelope contracts in `common.ts`.
+- [ ] Add auth, repo, scan, vulnerability, dashboard, and report DTOs around the MVP API payloads.
+- [ ] Re-export the full surface from `index.ts`.
+
+### Task 3: Verify package and workspace health
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-16-shared-contract-types-design.md`
+- Modify: `docs/superpowers/plans/2026-03-16-shared-contract-types.md`
+
+- [ ] Run the targeted shared regression test and confirm it passes.
+- [ ] Run `corepack pnpm --filter @aegisai/shared lint`.
+- [ ] Run `corepack pnpm --filter @aegisai/shared test`.
+- [ ] Run `corepack pnpm --filter @aegisai/shared typecheck`.
+- [ ] Run workspace `lint`, `test`, `typecheck`, and `build`.

--- a/docs/superpowers/specs/2026-03-16-shared-contract-types-design.md
+++ b/docs/superpowers/specs/2026-03-16-shared-contract-types-design.md
@@ -1,0 +1,36 @@
+# Shared Contract Types Design
+
+**Issue**: `#27`
+**Title**: `Feat: shared contract types 생성`
+**Date**: `2026-03-16`
+
+## Goal
+
+Create the baseline `@aegisai/shared` type surface that both `apps/api` and `apps/web` can use as the single source of truth for MVP request and response contracts.
+
+## Scope
+
+- Add shared type modules under `packages/shared/src/types/`
+- Cover the MVP contract areas: common, auth, repo, scan, vulnerability, dashboard, and report
+- Re-export the shared type surface from `packages/shared/src/index.ts`
+- Add regression coverage so the shared package cannot silently lose contract modules or root exports
+
+## Design Choices
+
+1. Keep this issue type-only. No runtime validators or schema libraries are introduced here.
+2. Model contracts around API payloads and view-facing DTOs rather than Prisma entities, so backend and frontend stay decoupled from persistence details.
+3. Use string union types for shared enums (`Provider`, `ScanStatus`, `Severity`, `VulnStatus`, `UserFeedback`, `ReportStatus`) to match the existing spec examples and keep interop simple across apps.
+4. Include both offset and cursor pagination contracts in `common.ts` because repo and branch listings are explicitly cursor-based in the spec while scans and vulnerabilities are page-based.
+5. Keep response aliases and request payload shapes close to their domains so later API client/controller work can import narrow, intention-revealing types.
+
+## Non-Goals
+
+- No API implementation or DTO validation logic
+- No Prisma model generation or backend entity mapping helpers
+- No subpath package exports beyond the package root in this issue
+
+## Validation
+
+- Shared type regression test passes
+- `@aegisai/shared` build, lint, test, and typecheck pass
+- Workspace `lint`, `test`, `typecheck`, and `build` still pass

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts\"",
-    "test": "node -e \"process.exit(0)\"",
+    "test": "node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,9 @@
-export const sharedPackageName = "@aegisai/shared";
+export const sharedPackageName = '@aegisai/shared';
+
+export * from './types/common';
+export * from './types/auth';
+export * from './types/repo';
+export * from './types/scan';
+export * from './types/vulnerability';
+export * from './types/dashboard';
+export * from './types/report';

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -1,0 +1,12 @@
+import type { Provider } from './common';
+
+export interface AuthUser {
+  id: string;
+  email: string | null;
+  name: string;
+  avatarUrl: string | null;
+  connectedProviders: Provider[];
+}
+
+export type AuthMeResponse = AuthUser;
+export type LogoutResponse = null;

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,0 +1,38 @@
+export type Provider = 'github' | 'gitlab';
+
+export interface SuccessResponse<T> {
+  success: true;
+  data: T;
+  message: string | null;
+  timestamp: string;
+}
+
+export interface ErrorResponse {
+  success: false;
+  data: null;
+  message: string;
+  errorCode: string;
+  timestamp: string;
+}
+
+export type ApiResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+export interface PageResponse<T> {
+  items: T[];
+  totalCount: number;
+  page: number;
+  totalPages: number;
+}
+
+export interface CursorPageResponse<T> {
+  items: T[];
+  page: number;
+  size: number;
+  hasNextPage: boolean;
+  nextPage: number | null;
+}
+
+export interface PageQuery {
+  page?: number;
+  size?: number;
+}

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -1,0 +1,16 @@
+import type { ScanSummary, ScanSeveritySummary } from './scan';
+
+export interface TrendItem {
+  date: string;
+  critical: number;
+  high: number;
+  medium: number;
+}
+
+export interface DashboardData {
+  totalRepos: number;
+  totalScans: number;
+  openVulnerabilities: ScanSeveritySummary;
+  recentScans: ScanSummary[];
+  trend: TrendItem[];
+}

--- a/packages/shared/src/types/repo.ts
+++ b/packages/shared/src/types/repo.ts
@@ -1,0 +1,44 @@
+import type { CursorPageResponse, Provider } from './common';
+import type { ScanStatus, ScanSummary } from './scan';
+
+export interface ConnectedRepoItem {
+  id: string;
+  provider: Provider;
+  fullName: string;
+  cloneUrl: string;
+  defaultBranch: string;
+  isPrivate: boolean;
+  lastScanAt: string | null;
+  lastScanStatus: ScanStatus | null;
+}
+
+export interface RepoBranchItem {
+  name: string;
+  isDefault: boolean;
+  lastCommitSha: string | null;
+}
+
+export interface AvailableRepoItem {
+  providerRepoId: string;
+  fullName: string;
+  cloneUrl: string;
+  defaultBranch: string;
+  isPrivate: boolean;
+  alreadyConnected: boolean;
+}
+
+export interface ConnectRepoRequest {
+  provider: Provider;
+  providerRepoId: string;
+}
+
+export interface ConnectRepoResponse {
+  id: string;
+  fullName: string;
+  connectedAt: string;
+}
+
+export type ConnectedRepoListResponse = ConnectedRepoItem[];
+export type RepoBranchListResponse = CursorPageResponse<RepoBranchItem>;
+export type AvailableRepoListResponse = CursorPageResponse<AvailableRepoItem>;
+export type RepoScanListItem = ScanSummary;

--- a/packages/shared/src/types/report.ts
+++ b/packages/shared/src/types/report.ts
@@ -1,0 +1,17 @@
+export type ReportStatus = 'GENERATING' | 'READY' | 'FAILED';
+
+export interface ReportRequestResponse {
+  reportId: string;
+  status: 'GENERATING' | 'READY';
+  message: string;
+}
+
+export interface ReportDetail {
+  id: string;
+  scanId: string;
+  status: ReportStatus;
+  downloadUrl: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+}

--- a/packages/shared/src/types/scan.ts
+++ b/packages/shared/src/types/scan.ts
@@ -1,0 +1,38 @@
+export interface ScanSeveritySummary {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+}
+
+export type ScanStatus = 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED';
+
+export interface ScanSummary {
+  id: string;
+  repoFullName: string;
+  branch: string;
+  commitSha: string | null;
+  status: ScanStatus;
+  language: string;
+  totalFiles: number | null;
+  totalLines: number | null;
+  summary: ScanSeveritySummary;
+  startedAt: string | null;
+  completedAt: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export type ScanDetail = ScanSummary;
+
+export interface ScanRequestBody {
+  repoId: string;
+  branch: string;
+}
+
+export interface ScanRequestResponse {
+  scanId: string;
+  status: 'PENDING';
+  message: string;
+}

--- a/packages/shared/src/types/vulnerability.ts
+++ b/packages/shared/src/types/vulnerability.ts
@@ -1,0 +1,58 @@
+export type Severity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO';
+export type VulnStatus = 'OPEN' | 'FIXED' | 'ACCEPTED' | 'REJECTED';
+export type UserFeedback = 'ACCEPTED' | 'REJECTED';
+
+export interface ModelResultView {
+  model: string;
+  detected: boolean;
+  severity: string;
+  reasoning: string;
+}
+
+export interface ReferenceLink {
+  title: string;
+  url: string;
+}
+
+export interface VulnerabilityListItem {
+  id: string;
+  title: string;
+  severity: Severity;
+  filePath: string;
+  lineStart: number;
+  lineEnd: number | null;
+  cweId: string | null;
+  owaspCategory: string | null;
+  status: VulnStatus;
+}
+
+export interface VulnerabilityDetail {
+  id: string;
+  title: string;
+  description: string;
+  severity: Severity;
+  filePath: string;
+  lineStart: number;
+  lineEnd: number | null;
+  codeSnippet: string | null;
+  fixSuggestion: string | null;
+  fixExplanation: string | null;
+  cweId: string | null;
+  cveId: string | null;
+  owaspCategory: string | null;
+  referenceLinks: ReferenceLink[] | null;
+  consensusScore: number | null;
+  modelResults: ModelResultView[] | null;
+  status: VulnStatus;
+  userFeedback: UserFeedback | null;
+}
+
+export interface VulnerabilityFeedbackRequest {
+  feedback: UserFeedback;
+}
+
+export interface VulnerabilityFeedbackResponse {
+  id: string;
+  status: Extract<VulnStatus, 'ACCEPTED' | 'REJECTED'>;
+  userFeedback: UserFeedback;
+}

--- a/packages/shared/test/shared-contract-exports.test.mjs
+++ b/packages/shared/test/shared-contract-exports.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const files = {
+  common: new URL('../src/types/common.ts', import.meta.url),
+  auth: new URL('../src/types/auth.ts', import.meta.url),
+  repo: new URL('../src/types/repo.ts', import.meta.url),
+  scan: new URL('../src/types/scan.ts', import.meta.url),
+  vulnerability: new URL('../src/types/vulnerability.ts', import.meta.url),
+  dashboard: new URL('../src/types/dashboard.ts', import.meta.url),
+  report: new URL('../src/types/report.ts', import.meta.url),
+  index: new URL('../src/index.ts', import.meta.url)
+};
+
+test('shared contract modules exist and are re-exported from the package root', () => {
+  for (const [name, fileUrl] of Object.entries(files)) {
+    assert.equal(existsSync(fileUrl), true, `Expected ${name} file to exist at ${fileUrl.pathname}`);
+  }
+
+  const indexContent = readFileSync(files.index, 'utf8');
+
+  for (const moduleName of ['common', 'auth', 'repo', 'scan', 'vulnerability', 'dashboard', 'report']) {
+    assert.match(
+      indexContent,
+      new RegExp(`export \\* from './types/${moduleName}'`),
+      `Expected packages/shared/src/index.ts to re-export ./types/${moduleName}`
+    );
+  }
+});


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/27-shared-contract-types`
- 이슈: `#27`

## 🔎 주요 변경 사항

- `packages/shared/src/types/` 아래에 common, auth, repo, scan, vulnerability, dashboard, report 공유 계약 타입을 추가했습니다.
- `packages/shared/src/index.ts`에서 shared contract surface를 일괄 re-export 하도록 정리했습니다.
- shared 패키지의 export surface가 다시 깨지지 않도록 회귀 테스트를 추가하고 `packages/shared` test 스크립트를 연결했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
