### PR TITLE
Fix: cd-workflow test CRLF 민감도 수정

### DIFF
--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -14,18 +14,20 @@ const files = {
   envExample: new URL('../../deploy/oracle/.env.example', import.meta.url)
 };
 
+const readNormalizedText = (fileUrl) => readFileSync(fileUrl, 'utf8').replace(/\r\n/g, '\n');
+
 test('cd workflow and oracle deployment files enforce the split infra/app deploy path', () => {
   for (const [name, fileUrl] of Object.entries(files)) {
     assert.equal(existsSync(fileUrl), true, `Expected ${name} file to exist at ${fileUrl.pathname}`);
   }
 
-  const workflow = readFileSync(files.workflow, 'utf8');
-  const apiDockerfile = readFileSync(files.apiDockerfile, 'utf8');
-  const webDockerfile = readFileSync(files.webDockerfile, 'utf8');
-  const infraCompose = readFileSync(files.infraCompose, 'utf8');
-  const appCompose = readFileSync(files.appCompose, 'utf8');
-  const deployScript = readFileSync(files.deployScript, 'utf8');
-  const envExample = readFileSync(files.envExample, 'utf8');
+  const workflow = readNormalizedText(files.workflow);
+  const apiDockerfile = readNormalizedText(files.apiDockerfile);
+  const webDockerfile = readNormalizedText(files.webDockerfile);
+  const infraCompose = readNormalizedText(files.infraCompose);
+  const appCompose = readNormalizedText(files.appCompose);
+  const deployScript = readNormalizedText(files.deployScript);
+  const envExample = readNormalizedText(files.envExample);
 
   assert.match(workflow, /^name:\s*CD/m);
   assert.match(workflow, /push:\s*[\s\S]*branches:\s*[\s\S]*- main/m);


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/29-cd-workflow-crlf`
- 이슈: `#29`

## 🔎 주요 변경 사항

- Windows CRLF checkout에서도 CD workflow 회귀 테스트가 동일하게 동작하도록 테스트 입력 텍스트를 줄바꿈 정규화하도록 수정했습니다.
- `docker-compose.app.yml` 내용은 그대로 두고, 테스트가 LF 전용 정규식에 묶여 실패하던 문제만 최소 범위로 보정했습니다.
- 최신 `dev`에서 실제 실패를 재현한 뒤 같은 테스트를 green으로 되돌려 회귀를 막았습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by ensuring consistent file handling across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->