### PR TITLE
Feat: auth and session foundation 구현

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,9 +21,11 @@
     "@nestjs/common": "^10.4.15",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^10.4.15",
+    "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^10.4.15",
     "@prisma/client": "5",
     "joi": "^18.0.2",
+    "passport": "^0.7.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+
+import { ConfigModule } from '../config/config.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthSerializer } from './auth.serializer';
+import { AuthService } from './auth.service';
+import { SessionAuthGuard } from './guards/session-auth.guard';
+import { TokenCryptoUtil } from './utils/token-crypto.util';
+
+@Module({
+  imports: [ConfigModule, PrismaModule, PassportModule.register({ session: true })],
+  providers: [AuthService, AuthSerializer, SessionAuthGuard, TokenCryptoUtil],
+  exports: [AuthService, AuthSerializer, SessionAuthGuard, TokenCryptoUtil, PassportModule]
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.serializer.ts
+++ b/apps/api/src/auth/auth.serializer.ts
@@ -1,0 +1,31 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportSerializer } from '@nestjs/passport';
+import type { AuthUser } from '@aegisai/shared';
+
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AuthSerializer extends PassportSerializer {
+  constructor(private readonly authService: AuthService) {
+    super();
+  }
+
+  serializeUser(user: AuthUser, done: (err: Error | null, payload?: string) => void): void {
+    done(null, user.id);
+  }
+
+  async deserializeUser(payload: string, done: (err: Error | null, user?: AuthUser) => void): Promise<void> {
+    try {
+      const user = await this.authService.getSessionUserById(payload);
+
+      if (!user) {
+        done(new UnauthorizedException({ message: '인증된 사용자를 찾을 수 없습니다.', errorCode: 'UNAUTHORIZED' }));
+        return;
+      }
+
+      done(null, user);
+    } catch (error) {
+      done(error as Error);
+    }
+  }
+}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,33 @@
+import type { AuthUser, Provider } from '@aegisai/shared';
+import { Injectable } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSessionUserById(userId: string): Promise<AuthUser | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { oauthTokens: { select: { provider: true } } }
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      avatarUrl: user.avatarUrl,
+      connectedProviders: user.oauthTokens.map((token) => token.provider.toLowerCase() as Provider)
+    };
+  }
+
+  createCsrfToken(): string {
+    return randomBytes(32).toString('hex');
+  }
+}

--- a/apps/api/src/auth/decorators/current-user.decorator.ts
+++ b/apps/api/src/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,15 @@
+import type { AuthUser } from '@aegisai/shared';
+import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
+
+type RequestWithUser = {
+  user?: AuthUser;
+};
+
+export function getCurrentUserFromRequest(request: RequestWithUser): AuthUser | undefined {
+  return request.user;
+}
+
+export const CurrentUser = createParamDecorator((_data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest<RequestWithUser>();
+  return getCurrentUserFromRequest(request);
+});

--- a/apps/api/src/auth/guards/session-auth.guard.ts
+++ b/apps/api/src/auth/guards/session-auth.guard.ts
@@ -1,0 +1,61 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+
+import { ConfigService } from '../../config/config.service';
+
+type RequestWithSession = {
+  method?: string;
+  cookies?: Record<string, string | undefined>;
+  headers?: Record<string, string | string[] | undefined>;
+  isAuthenticated?: () => boolean;
+  user?: unknown;
+};
+
+@Injectable()
+export class SessionAuthGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestWithSession>();
+
+    if (!this.isAuthenticated(request)) {
+      throw new UnauthorizedException({ message: '인증이 필요합니다.', errorCode: 'UNAUTHORIZED' });
+    }
+
+    if (this.isSafeMethod(request.method)) {
+      return true;
+    }
+
+    const csrfCookieName = this.config.get('CSRF_COOKIE_NAME');
+    const csrfCookie = request.cookies?.[csrfCookieName];
+    const csrfHeader = this.getHeaderValue(request.headers?.['x-csrf-token']);
+
+    if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {
+      throw new ForbiddenException({
+        message: 'CSRF 검증에 실패했습니다.',
+        errorCode: 'CSRF_TOKEN_INVALID'
+      });
+    }
+
+    return true;
+  }
+
+  private isAuthenticated(request: RequestWithSession): boolean {
+    if (typeof request.isAuthenticated === 'function') {
+      return request.isAuthenticated();
+    }
+
+    return request.user !== undefined;
+  }
+
+  private isSafeMethod(method?: string): boolean {
+    return ['GET', 'HEAD', 'OPTIONS'].includes((method ?? 'GET').toUpperCase());
+  }
+
+  private getHeaderValue(value: string | string[] | undefined): string | undefined {
+    if (Array.isArray(value)) {
+      return value[0];
+    }
+
+    return value;
+  }
+}

--- a/apps/api/src/auth/utils/token-crypto.util.ts
+++ b/apps/api/src/auth/utils/token-crypto.util.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+import { ConfigService } from '../../config/config.service';
+
+@Injectable()
+export class TokenCryptoUtil {
+  private readonly encryptionKey: Buffer;
+
+  constructor(private readonly config: ConfigService) {
+    const key = this.config.get('TOKEN_ENCRYPTION_KEY');
+
+    if (!/^[a-f0-9]{64}$/i.test(key)) {
+      throw new Error('TOKEN_ENCRYPTION_KEY must be a 64-character hex string');
+    }
+
+    this.encryptionKey = Buffer.from(key, 'hex');
+  }
+
+  encrypt(value: string): string {
+    const iv = randomBytes(16);
+    const cipher = createCipheriv('aes-256-gcm', this.encryptionKey, iv);
+    const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+  }
+
+  decrypt(payload: string): string {
+    const [ivHex, authTagHex, encryptedHex] = payload.split(':');
+
+    if (!ivHex || !authTagHex || !encryptedHex) {
+      throw new Error('Encrypted token payload is malformed');
+    }
+
+    const decipher = createDecipheriv('aes-256-gcm', this.encryptionKey, Buffer.from(ivHex, 'hex'));
+    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(encryptedHex, 'hex')),
+      decipher.final()
+    ]);
+
+    return decrypted.toString('utf8');
+  }
+}

--- a/apps/api/test/auth/auth.serializer.e2e-spec.ts
+++ b/apps/api/test/auth/auth.serializer.e2e-spec.ts
@@ -1,0 +1,51 @@
+import type { AuthUser } from '@aegisai/shared';
+import { UnauthorizedException } from '@nestjs/common';
+
+import { AuthSerializer } from '../../src/auth/auth.serializer';
+
+describe('AuthSerializer', () => {
+  const authUser: AuthUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'Aegis User',
+    avatarUrl: null,
+    connectedProviders: ['github']
+  };
+
+  it('serializes the authenticated user id into the session', () => {
+    const serializer = new AuthSerializer({
+      getSessionUserById: jest.fn()
+    } as never);
+
+    const done = jest.fn();
+
+    serializer.serializeUser(authUser, done);
+
+    expect(done).toHaveBeenCalledWith(null, 'user-1');
+  });
+
+  it('deserializes the user from the auth service', async () => {
+    const serializer = new AuthSerializer({
+      getSessionUserById: jest.fn().mockResolvedValue(authUser)
+    } as never);
+
+    const done = jest.fn();
+
+    await serializer.deserializeUser('user-1', done);
+
+    expect(done).toHaveBeenCalledWith(null, authUser);
+  });
+
+  it('fails deserialization when the user is missing', async () => {
+    const serializer = new AuthSerializer({
+      getSessionUserById: jest.fn().mockResolvedValue(null)
+    } as never);
+
+    const done = jest.fn();
+
+    await serializer.deserializeUser('missing-user', done);
+
+    expect(done).toHaveBeenCalled();
+    expect(done.mock.calls[0][0]).toBeInstanceOf(UnauthorizedException);
+  });
+});

--- a/apps/api/test/auth/auth.service.e2e-spec.ts
+++ b/apps/api/test/auth/auth.service.e2e-spec.ts
@@ -1,0 +1,53 @@
+import { AuthService } from '../../src/auth/auth.service';
+
+describe('AuthService', () => {
+  it('maps a persisted user into the shared session shape', async () => {
+    const prisma = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'user@example.com',
+          name: 'Aegis User',
+          avatarUrl: 'https://example.com/avatar.png',
+          oauthTokens: [{ provider: 'GITHUB' }, { provider: 'GITLAB' }]
+        })
+      }
+    };
+
+    const service = new AuthService(prisma as never);
+
+    await expect(service.getSessionUserById('user-1')).resolves.toEqual({
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: 'https://example.com/avatar.png',
+      connectedProviders: ['github', 'gitlab']
+    });
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      include: { oauthTokens: { select: { provider: true } } }
+    });
+  });
+
+  it('returns null when the user no longer exists', async () => {
+    const service = new AuthService({
+      user: {
+        findUnique: jest.fn().mockResolvedValue(null)
+      }
+    } as never);
+
+    await expect(service.getSessionUserById('missing-user')).resolves.toBeNull();
+  });
+
+  it('creates distinct csrf token values', () => {
+    const service = new AuthService({} as never);
+
+    const first = service.createCsrfToken();
+    const second = service.createCsrfToken();
+
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(second).toMatch(/^[a-f0-9]{64}$/);
+    expect(first).not.toBe(second);
+  });
+});

--- a/apps/api/test/auth/current-user.decorator.e2e-spec.ts
+++ b/apps/api/test/auth/current-user.decorator.e2e-spec.ts
@@ -1,0 +1,17 @@
+import type { AuthUser } from '@aegisai/shared';
+
+import { getCurrentUserFromRequest } from '../../src/auth/decorators/current-user.decorator';
+
+describe('CurrentUser helper', () => {
+  it('returns the authenticated user from the request object', () => {
+    const user: AuthUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: null,
+      connectedProviders: ['github']
+    };
+
+    expect(getCurrentUserFromRequest({ user })).toEqual(user);
+  });
+});

--- a/apps/api/test/auth/session-auth.guard.e2e-spec.ts
+++ b/apps/api/test/auth/session-auth.guard.e2e-spec.ts
@@ -1,0 +1,89 @@
+import { ForbiddenException, UnauthorizedException, type ExecutionContext } from '@nestjs/common';
+
+import { SessionAuthGuard } from '../../src/auth/guards/session-auth.guard';
+
+function createHttpContext(request: Record<string, unknown>): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => undefined,
+      getNext: () => undefined
+    })
+  } as ExecutionContext;
+}
+
+describe('SessionAuthGuard', () => {
+  const guard = new SessionAuthGuard({
+    get: (key: string) => {
+      if (key === 'CSRF_COOKIE_NAME') {
+        return 'csrf_token';
+      }
+
+      throw new Error(`Unexpected key: ${key}`);
+    }
+  } as never);
+
+  it('rejects unauthenticated requests', async () => {
+    const context = createHttpContext({
+      method: 'GET',
+      isAuthenticated: () => false,
+      cookies: {},
+      headers: {}
+    });
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('allows authenticated safe requests without csrf validation', async () => {
+    const context = createHttpContext({
+      method: 'GET',
+      isAuthenticated: () => true,
+      cookies: {},
+      headers: {}
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+
+  it('rejects mutating requests when csrf data is missing', async () => {
+    const context = createHttpContext({
+      method: 'POST',
+      isAuthenticated: () => true,
+      cookies: {},
+      headers: {}
+    });
+
+    await expect(guard.canActivate(context)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects mutating requests when csrf values differ', async () => {
+    const context = createHttpContext({
+      method: 'PATCH',
+      isAuthenticated: () => true,
+      cookies: { csrf_token: 'cookie-token' },
+      headers: { 'x-csrf-token': 'header-token' }
+    });
+
+    try {
+      await guard.canActivate(context);
+      fail('Expected guard to reject mismatched CSRF values');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ForbiddenException);
+      expect((error as ForbiddenException).getResponse()).toMatchObject({
+        message: 'CSRF 검증에 실패했습니다.',
+        errorCode: 'CSRF_TOKEN_INVALID'
+      });
+    }
+  });
+
+  it('allows authenticated mutating requests when csrf values match', async () => {
+    const context = createHttpContext({
+      method: 'DELETE',
+      isAuthenticated: () => true,
+      cookies: { csrf_token: 'same-token' },
+      headers: { 'x-csrf-token': 'same-token' }
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+});

--- a/apps/api/test/auth/token-crypto.util.e2e-spec.ts
+++ b/apps/api/test/auth/token-crypto.util.e2e-spec.ts
@@ -1,0 +1,28 @@
+import { TokenCryptoUtil } from '../../src/auth/utils/token-crypto.util';
+
+describe('TokenCryptoUtil', () => {
+  const validKey = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  it('encrypts and decrypts provider tokens', () => {
+    const service = new TokenCryptoUtil({
+      get: (key: string) => {
+        if (key === 'TOKEN_ENCRYPTION_KEY') {
+          return validKey;
+        }
+
+        throw new Error(`Unexpected key: ${key}`);
+      }
+    } as never);
+
+    const encrypted = service.encrypt('provider-access-token');
+
+    expect(encrypted).not.toBe('provider-access-token');
+    expect(service.decrypt(encrypted)).toBe('provider-access-token');
+  });
+
+  it('rejects invalid encryption keys', () => {
+    expect(() => new TokenCryptoUtil({
+      get: () => 'too-short'
+    } as never)).toThrow('TOKEN_ENCRYPTION_KEY must be a 64-character hex string');
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,6 +9,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@aegisai/shared": ["../../packages/shared/src/index.ts"]
+    },
     "incremental": true,
     "types": ["jest", "node"]
   },

--- a/docs/superpowers/plans/2026-03-18-auth-session-foundation.md
+++ b/docs/superpowers/plans/2026-03-18-auth-session-foundation.md
@@ -1,0 +1,105 @@
+# Auth And Session Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the NestJS auth/session core infrastructure required before OAuth strategies and full bootstrap wiring.
+
+**Architecture:** Keep the issue aligned to `T010` only. `AuthModule` owns reusable auth services, Passport session serialization, CSRF-aware session guard behavior, and token encryption. Global middleware setup and provider strategies remain outside this issue.
+
+**Tech Stack:** NestJS 10.x, Passport session patterns, Prisma 5.x, Node crypto, Jest, pnpm workspace
+
+---
+
+### Task 1: Write Failing Tests For Auth Core
+
+**Files:**
+- Create: `apps/api/test/auth/auth.serializer.e2e-spec.ts`
+- Create: `apps/api/test/auth/session-auth.guard.e2e-spec.ts`
+- Create: `apps/api/test/auth/token-crypto.util.e2e-spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Cover:
+- `TokenCryptoUtil` encrypts and decrypts a token using `TOKEN_ENCRYPTION_KEY`
+- `AuthSerializer.serializeUser()` stores the user id
+- `AuthSerializer.deserializeUser()` loads a user and maps connected providers to lowercase strings
+- `SessionAuthGuard` rejects unauthenticated requests with `401`
+- `SessionAuthGuard` rejects mutating authenticated requests with missing or mismatched CSRF values using `403`
+- `SessionAuthGuard` allows authenticated safe requests and valid CSRF-protected mutating requests
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run:
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/token-crypto.util.e2e-spec.ts`
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/auth.serializer.e2e-spec.ts`
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/session-auth.guard.e2e-spec.ts`
+
+Expected: FAIL because auth files do not exist yet
+
+### Task 2: Implement Token Encryption And Auth Service
+
+**Files:**
+- Modify: `apps/api/package.json`
+- Create: `apps/api/src/auth/auth.service.ts`
+- Create: `apps/api/src/auth/utils/token-crypto.util.ts`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement:
+- auth service method for fetching a user by id with provider metadata
+- auth service helper for generating CSRF token values
+- AES-256-GCM token encryption/decryption with key validation against the configured 64-hex secret
+
+- [ ] **Step 4: Run targeted token crypto test**
+
+Run:
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/token-crypto.util.e2e-spec.ts`
+
+Expected: token crypto test passes while serializer/guard tests still fail
+
+### Task 3: Implement Serializer, Guard, And Decorator
+
+**Files:**
+- Create: `apps/api/src/auth/auth.serializer.ts`
+- Create: `apps/api/src/auth/guards/session-auth.guard.ts`
+- Create: `apps/api/src/auth/decorators/current-user.decorator.ts`
+- Create: `apps/api/src/auth/auth.module.ts`
+
+- [ ] **Step 5: Write minimal implementation**
+
+Implement:
+- Passport serializer/deserializer backed by `AuthService`
+- session guard with safe-method bypass for CSRF and explicit `CSRF_TOKEN_INVALID` failure payload
+- current-user decorator reading `req.user`
+- auth module exporting the reusable auth pieces
+
+- [ ] **Step 6: Run targeted auth tests**
+
+Run:
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/auth.serializer.e2e-spec.ts`
+- `corepack pnpm --filter @aegisai/api exec jest --config ./test/jest-e2e.json --runInBand test/auth/session-auth.guard.e2e-spec.ts`
+
+Expected: all targeted auth tests pass
+
+### Task 4: Verify Workspace Baseline
+
+**Files:**
+- Modify if needed: `pnpm-lock.yaml`
+
+- [ ] **Step 7: Run workspace verification**
+
+Run:
+- `corepack pnpm lint`
+- `corepack pnpm test`
+- `corepack pnpm typecheck`
+- `corepack pnpm build`
+
+Expected: all commands exit successfully
+
+- [ ] **Step 8: Commit**
+
+Run:
+`git add apps/api/package.json apps/api/src/auth apps/api/test/auth pnpm-lock.yaml docs/superpowers/specs/2026-03-18-auth-session-foundation-design.md docs/superpowers/plans/2026-03-18-auth-session-foundation.md`
+
+Commit:
+`git commit -m "feat: implement auth and session foundation"`

--- a/docs/superpowers/specs/2026-03-18-auth-session-foundation-design.md
+++ b/docs/superpowers/specs/2026-03-18-auth-session-foundation-design.md
@@ -1,0 +1,65 @@
+# Auth And Session Foundation Design
+
+**Issue**: `#31`  
+**Title**: `Feat: auth and session foundation ±¸Çö`  
+**Date**: `2026-03-18`
+
+## Goal
+
+Add the backend auth/session core infrastructure needed before OAuth provider strategies and
+full bootstrap wiring, while keeping the issue aligned to `T010` only.
+
+## Scope
+
+- Create `apps/api/src/auth/auth.module.ts`
+- Create `apps/api/src/auth/auth.service.ts`
+- Create `apps/api/src/auth/auth.serializer.ts`
+- Create `apps/api/src/auth/guards/session-auth.guard.ts`
+- Create `apps/api/src/auth/decorators/current-user.decorator.ts`
+- Create `apps/api/src/auth/utils/token-crypto.util.ts`
+- Add focused tests for serializer, session guard, and token crypto behavior
+
+## Recommended Approach
+
+Keep `#31` as a narrow auth infrastructure slice and defer OAuth strategies and global
+middleware setup to later issues.
+
+- `AuthModule` owns the auth runtime boundary and exports the reusable pieces needed by
+  later controllers and strategies
+- `AuthService` provides user lookup methods for session deserialization and a CSRF token
+  helper for later controller integration
+- `AuthSerializer` implements the required Passport session serializer/deserializer so later
+  OAuth login can persist sessions correctly
+- `SessionAuthGuard` centralizes session presence checks and CSRF validation for mutating
+  requests
+- `CurrentUser` exposes the authenticated user object from `req.user`
+- `TokenCryptoUtil` encapsulates AES-256-GCM encryption and decryption for provider tokens
+
+This gives the backend a clean auth/session core without pulling `main.ts` Redis session
+store setup, OAuth strategies, or full app wiring into the same issue.
+
+## Alternatives Considered
+
+### 1. Include `main.ts` session middleware wiring now
+
+- Pros: more visible progress toward login flow
+- Cons: mixes `T010` with later bootstrap work and pulls Redis/session store concerns into
+  the wrong issue boundary
+
+### 2. Implement OAuth strategies together with auth core
+
+- Pros: fewer follow-up issues before login works end to end
+- Cons: collapses `T010` and `T011`, increases dependency surface, and makes review harder
+
+## Non-Goals
+
+- No GitHub or GitLab Passport strategies
+- No `AuthController` endpoints yet
+- No `main.ts` session middleware, Redis store, or Passport bootstrap wiring
+- No `AppModule` integration beyond what later issues will handle
+
+## Validation
+
+- Targeted tests prove token encryption round-trips, serializer behavior, and CSRF/session
+  guard decisions
+- Workspace `lint`, `test`, `typecheck`, and `build` stay green

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@nestjs/core':
         specifier: ^10.4.15
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/passport':
+        specifier: ^11.0.5
+        version: 11.0.5(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
       '@nestjs/platform-express':
         specifier: ^10.4.15
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
@@ -47,6 +50,9 @@ importers:
       joi:
         specifier: ^18.0.2
         version: 18.0.2
+      passport:
+        specifier: ^0.7.0
+        version: 0.7.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -760,6 +766,12 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/passport@11.0.5':
+    resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      passport: ^0.5.0 || ^0.6.0 || ^0.7.0
 
   '@nestjs/platform-express@10.4.22':
     resolution: {integrity: sha512-ySSq7Py/DFozzZdNDH67m/vHoeVdphDniWBnl6q5QVoXldDdrZIHLXLRMPayTDh5A95nt7jjJzmD4qpTbNQ6tA==}
@@ -2757,6 +2769,14 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-strategy@1.0.0:
+    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
+    engines: {node: '>= 0.4.0'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2792,6 +2812,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pause@0.0.1:
+    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4304,6 +4327,11 @@ snapshots:
       '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
     transitivePeerDependencies:
       - encoding
+
+  '@nestjs/passport@11.0.5(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
+    dependencies:
+      '@nestjs/common': 10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      passport: 0.7.0
 
   '@nestjs/platform-express@10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
     dependencies:
@@ -6619,6 +6647,14 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  passport-strategy@1.0.0: {}
+
+  passport@0.7.0:
+    dependencies:
+      passport-strategy: 1.0.0
+      pause: 0.0.1
+      utils-merge: 1.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6641,6 +6677,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pause@0.0.1: {}
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/31-auth-session-foundation`
- 이슈: `#31`

## 🔎 주요 변경 사항

- `AuthModule`, `AuthService`, `AuthSerializer`를 추가해 세션 인증 핵심 인프라를 구성했습니다.
- `SessionAuthGuard`를 추가해 세션 인증 여부와 mutating 요청의 CSRF 검증을 처리하도록 했습니다.
- `CurrentUser` 데코레이터와 `TokenCryptoUtil`을 추가했습니다.
- `@aegisai/shared` auth 계약 타입을 API에서 사용할 수 있도록 API tsconfig 경로 해상도를 보완했습니다.
- Passport 기반 serializer 구성을 위해 `@nestjs/passport`, `passport`, `@types/passport`를 추가했습니다.
- auth service, serializer, current-user helper, session guard, token crypto에 대한 집중 테스트를 추가했습니다.
- OAuth provider strategy와 `main.ts` 전역 session/passport wiring은 다음 이슈 범위로 의도적으로 제외했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [ ] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced session-based authentication framework with persistent user sessions.
  * Added CSRF protection for non-safe HTTP requests.
  * Implemented secure token encryption for authentication tokens.
  * Added current user context extraction for authenticated requests.

* **Documentation**
  * Added design specifications and implementation plan for authentication and session foundation.

* **Tests**
  * Added comprehensive end-to-end tests for authentication components and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->