### PR TITLE
Fix: Oracle ARM64 배포 이미지 manifest 누락 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,6 +64,30 @@ jobs:
           push: true
           tags: ghcr.io/${{ steps.prep.outputs.ghcr_owner }}/aegisai-web:${{ steps.prep.outputs.image_tag }}
 
+      - name: Verify multi-arch image manifests
+        shell: bash
+        run: |
+          verify_manifest() {
+            image="$1"
+
+            echo "Inspecting $image"
+            manifest="$(docker buildx imagetools inspect "$image")"
+            printf '%s\n' "$manifest"
+
+            printf '%s\n' "$manifest" | grep -q 'linux/amd64' || {
+              echo "Missing linux/amd64 manifest for $image" >&2
+              exit 1
+            }
+
+            printf '%s\n' "$manifest" | grep -q 'linux/arm64' || {
+              echo "Missing linux/arm64 manifest for $image" >&2
+              exit 1
+            }
+          }
+
+          verify_manifest "ghcr.io/${{ steps.prep.outputs.ghcr_owner }}/aegisai-api:${{ steps.prep.outputs.image_tag }}"
+          verify_manifest "ghcr.io/${{ steps.prep.outputs.ghcr_owner }}/aegisai-web:${{ steps.prep.outputs.image_tag }}"
+
   deploy:
     name: Deploy to Oracle Cloud VPS
     needs: build-and-push

--- a/docs/superpowers/plans/2026-03-19-oracle-arm64-manifest.md
+++ b/docs/superpowers/plans/2026-03-19-oracle-arm64-manifest.md
@@ -1,0 +1,50 @@
+# Oracle ARM64 Manifest Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fail CD before SSH deploy whenever a pushed GHCR image tag is missing either the `amd64` or `arm64` manifest needed by Oracle ARM64 production.
+
+**Architecture:** Keep the current build-and-push workflow, then add an explicit manifest verification gate inside the same job so deploy cannot start with an incomplete image tag. Back the guard with a regression test that asserts the workflow contains the inspection step and architecture checks.
+
+**Tech Stack:** GitHub Actions, Docker Buildx, Node test runner
+
+---
+
+## Chunk 1: Regression Test
+
+### Task 1: Require Manifest Guard In Workflow Test
+
+**Files:**
+- Modify: `test/github-actions/cd-workflow.test.mjs`
+
+- [ ] **Step 1: Write the failing test**
+- [ ] **Step 2: Run the targeted workflow test to verify it fails**
+- [ ] **Step 3: Update assertions only as needed to express the intended guard**
+- [ ] **Step 4: Re-run the targeted workflow test and keep it red until workflow code is added**
+
+## Chunk 2: Workflow Guard
+
+### Task 2: Verify Multi-Arch Manifests Before Deploy
+
+**Files:**
+- Modify: `.github/workflows/cd.yml`
+
+- [ ] **Step 1: Add a manifest verification step after both image pushes**
+- [ ] **Step 2: Inspect both API and web tags with `docker buildx imagetools inspect`**
+- [ ] **Step 3: Assert both `linux/amd64` and `linux/arm64` exist for each image**
+- [ ] **Step 4: Keep deploy blocked if verification fails**
+
+## Chunk 3: Verification
+
+### Task 3: Prove The Guard Works
+
+**Files:**
+- Verify: `test/github-actions/cd-workflow.test.mjs`
+- Verify: `.github/workflows/cd.yml`
+
+- [ ] **Step 1: Run `node --test test/github-actions/cd-workflow.test.mjs`**
+- [ ] **Step 2: Run `corepack pnpm test`**
+- [ ] **Step 3: Run `corepack pnpm lint`**
+- [ ] **Step 4: Run `corepack pnpm typecheck`**
+- [ ] **Step 5: Run `corepack pnpm build`**
+- [ ] **Step 6: Commit with `fix: verify multi-arch manifests before deploy`**

--- a/docs/superpowers/specs/2026-03-19-oracle-arm64-manifest-design.md
+++ b/docs/superpowers/specs/2026-03-19-oracle-arm64-manifest-design.md
@@ -1,0 +1,33 @@
+# Oracle ARM64 Manifest Guard Design
+
+## Goal
+
+Prevent Oracle Cloud ARM64 deployments from reaching the SSH deploy step when the pushed GHCR images do not actually include both `linux/amd64` and `linux/arm64` manifests.
+
+## Problem
+
+The CD pipeline now requests multi-architecture builds, but the failure mode shown in production happened later during `docker compose pull` on the Oracle VPS:
+
+- the VPS is `linux/arm64`
+- the image tag being deployed did not contain a matching `arm64` manifest
+- the workflow only discovered this after connecting to the server
+
+That means we need a guard inside GitHub Actions that verifies the published manifests before any remote deploy work starts.
+
+## Approach
+
+Add an explicit verification step in `.github/workflows/cd.yml` after the API and web images are pushed. The step will:
+
+1. inspect each pushed GHCR tag with `docker buildx imagetools inspect`
+2. assert that both `linux/amd64` and `linux/arm64` are present
+3. fail the workflow before the deploy job if either architecture is missing
+
+## Testing
+
+Add a regression assertion in `test/github-actions/cd-workflow.test.mjs` that requires:
+
+- a manifest verification step in the CD workflow
+- `docker buildx imagetools inspect`
+- checks for both `linux/amd64` and `linux/arm64`
+
+This keeps the manifest guard from silently disappearing in future workflow edits.

--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -41,6 +41,10 @@ test('cd workflow and oracle deployment files enforce the split infra/app deploy
   assert.match(workflow, /docker\/build-push-action@v6/);
   assert.match(workflow, /ghcr\.io/);
   assert.match(workflow, /platforms:\s*linux\/amd64,linux\/arm64/m);
+  assert.match(workflow, /Verify multi-arch image manifests/);
+  assert.match(workflow, /docker buildx imagetools inspect/);
+  assert.match(workflow, /grep -q 'linux\/amd64'/);
+  assert.match(workflow, /grep -q 'linux\/arm64'/);
   assert.match(workflow, /Validate deployment secrets/);
   assert.match(workflow, /Missing required GitHub Actions secrets for production deploy/);
   assert.match(workflow, /ssh-keyscan/);


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/41-oracle-arm64-manifest`
- 이슈: `#41`

## 🔎 주요 변경 사항

- CD workflow에 `Verify multi-arch image manifests` 단계를 추가했습니다.
- API/WEB 이미지를 push한 뒤 `docker buildx imagetools inspect`로 실제 manifest를 검사하도록 구성했습니다.
- 각 이미지 태그에 `linux/amd64`, `linux/arm64`가 모두 없으면 deploy 전에 실패하도록 막았습니다.
- CD workflow 회귀 테스트를 보강해 manifest 검증 guard가 빠지지 않도록 고정했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment pipeline with enhanced validation to verify Docker images include builds for both AMD64 and ARM64 processor architectures before deployment, improving release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->