### PR TITLE
Feat: OAuth strategy 구현

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,8 @@
     "@prisma/client": "5",
     "joi": "^18.0.2",
     "passport": "^0.7.0",
+    "passport-github2": "^0.1.12",
+    "passport-gitlab2": "^5.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -35,6 +37,7 @@
     "@nestjs/testing": "^10.4.15",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.10",
+    "@types/passport-github2": "^1.2.9",
     "@types/supertest": "^6.0.2",
     "jest": "^29.7.0",
     "prisma": "5",

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -6,11 +6,20 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { AuthSerializer } from './auth.serializer';
 import { AuthService } from './auth.service';
 import { SessionAuthGuard } from './guards/session-auth.guard';
+import { GithubStrategy } from './strategies/github.strategy';
+import { GitlabStrategy } from './strategies/gitlab.strategy';
 import { TokenCryptoUtil } from './utils/token-crypto.util';
 
 @Module({
   imports: [ConfigModule, PrismaModule, PassportModule.register({ session: true })],
-  providers: [AuthService, AuthSerializer, SessionAuthGuard, TokenCryptoUtil],
+  providers: [
+    AuthService,
+    AuthSerializer,
+    SessionAuthGuard,
+    TokenCryptoUtil,
+    GithubStrategy,
+    GitlabStrategy
+  ],
   exports: [AuthService, AuthSerializer, SessionAuthGuard, TokenCryptoUtil, PassportModule]
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,12 +1,121 @@
 import type { AuthUser, Provider } from '@aegisai/shared';
 import { Injectable } from '@nestjs/common';
+import { RepoProvider } from '@prisma/client';
 import { randomBytes } from 'node:crypto';
 
 import { PrismaService } from '../prisma/prisma.service';
+import { TokenCryptoUtil } from './utils/token-crypto.util';
+import type { OAuthProviderProfile } from './oauth-profile.types';
+
+interface NormalizedProviderProfile {
+  provider: RepoProvider;
+  providerUserId: string;
+  email: string | null;
+  name: string;
+  avatarUrl: string | null;
+}
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly tokenCrypto: TokenCryptoUtil
+  ) {}
+
+  async findOrCreateUser(
+    provider: Provider,
+    profile: OAuthProviderProfile,
+    accessToken: string,
+    refreshToken?: string
+  ): Promise<AuthUser> {
+    const normalizedProfile = this.normalizeProviderProfile(provider, profile);
+    const existingToken = await this.prisma.oAuthToken.findUnique({
+      where: {
+        provider_providerUserId: {
+          provider: normalizedProfile.provider,
+          providerUserId: normalizedProfile.providerUserId
+        }
+      }
+    });
+
+    let userId: string;
+
+    if (existingToken) {
+      const user = await this.prisma.user.update({
+        where: { id: existingToken.userId },
+        data: {
+          email: normalizedProfile.email,
+          name: normalizedProfile.name,
+          avatarUrl: normalizedProfile.avatarUrl
+        }
+      });
+
+      userId = user.id;
+    } else {
+      const existingUser = normalizedProfile.email
+        ? await this.prisma.user.findUnique({
+            where: { email: normalizedProfile.email },
+            include: { oauthTokens: { select: { provider: true } } }
+          })
+        : null;
+
+      if (existingUser) {
+        const user = await this.prisma.user.update({
+          where: { id: existingUser.id },
+          data: {
+            email: normalizedProfile.email,
+            name: normalizedProfile.name,
+            avatarUrl: normalizedProfile.avatarUrl
+          }
+        });
+
+        userId = user.id;
+      } else {
+        const user = await this.prisma.user.create({
+          data: {
+            email: normalizedProfile.email,
+            name: normalizedProfile.name,
+            avatarUrl: normalizedProfile.avatarUrl
+          }
+        });
+
+        userId = user.id;
+      }
+    }
+
+    const encryptedAccessToken = this.tokenCrypto.encrypt(accessToken);
+    const encryptedRefreshToken = refreshToken ? this.tokenCrypto.encrypt(refreshToken) : null;
+
+    await this.prisma.oAuthToken.upsert({
+      where: {
+        provider_providerUserId: {
+          provider: normalizedProfile.provider,
+          providerUserId: normalizedProfile.providerUserId
+        }
+      },
+      update: {
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        expiresAt: null
+      },
+      create: {
+        userId,
+        provider: normalizedProfile.provider,
+        providerUserId: normalizedProfile.providerUserId,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        expiresAt: null
+      }
+    });
+
+    const sessionUser = await this.getSessionUserById(userId);
+
+    if (!sessionUser) {
+      throw new Error('Authenticated user could not be loaded after provider login');
+    }
+
+    return sessionUser;
+  }
 
   async getSessionUserById(userId: string): Promise<AuthUser | null> {
     const user = await this.prisma.user.findUnique({
@@ -29,5 +138,28 @@ export class AuthService {
 
   createCsrfToken(): string {
     return randomBytes(32).toString('hex');
+  }
+
+  private normalizeProviderProfile(
+    provider: Provider,
+    profile: OAuthProviderProfile
+  ): NormalizedProviderProfile {
+    if (provider === 'github') {
+      return {
+        provider: RepoProvider.GITHUB,
+        providerUserId: String(profile.id),
+        email: profile.emails?.[0]?.value ?? null,
+        name: profile.displayName ?? profile.username ?? `github-${String(profile.id)}`,
+        avatarUrl: 'photos' in profile ? profile.photos?.[0]?.value ?? null : null
+      };
+    }
+
+    return {
+      provider: RepoProvider.GITLAB,
+      providerUserId: String(profile.id),
+      email: profile.emails?.[0]?.value ?? null,
+      name: profile.displayName ?? profile.username ?? `gitlab-${String(profile.id)}`,
+      avatarUrl: 'avatarUrl' in profile ? profile.avatarUrl ?? null : null
+    };
   }
 }

--- a/apps/api/src/auth/oauth-profile.types.ts
+++ b/apps/api/src/auth/oauth-profile.types.ts
@@ -1,0 +1,25 @@
+export interface OAuthProfileEmail {
+  value?: string | null;
+}
+
+export interface OAuthProfilePhoto {
+  value?: string | null;
+}
+
+export interface GithubOAuthProfile {
+  id: string | number;
+  username?: string;
+  displayName?: string;
+  emails?: OAuthProfileEmail[];
+  photos?: OAuthProfilePhoto[];
+}
+
+export interface GitlabOAuthProfile {
+  id: string | number;
+  username?: string;
+  displayName?: string;
+  emails?: OAuthProfileEmail[];
+  avatarUrl?: string | null;
+}
+
+export type OAuthProviderProfile = GithubOAuthProfile | GitlabOAuthProfile;

--- a/apps/api/src/auth/strategies/github.strategy.ts
+++ b/apps/api/src/auth/strategies/github.strategy.ts
@@ -1,0 +1,35 @@
+import type { AuthUser } from '@aegisai/shared';
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy as GitHubPassportStrategy } from 'passport-github2';
+
+import { ConfigService } from '../../config/config.service';
+import { AuthService } from '../auth.service';
+import type { GithubOAuthProfile } from '../oauth-profile.types';
+
+@Injectable()
+export class GithubStrategy extends PassportStrategy(GitHubPassportStrategy, 'github') {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly authService: AuthService
+  ) {
+    super(
+      {
+        clientID: config.get('GITHUB_CLIENT_ID'),
+        clientSecret: config.get('GITHUB_CLIENT_SECRET'),
+        callbackURL: new URL('/api/auth/github/callback', config.get('APP_URL')).toString(),
+        scope: ['read:user', 'user:email', 'repo'],
+        state: true,
+        userAgent: new URL(config.get('APP_URL')).host
+      } as never
+    );
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: GithubOAuthProfile
+  ): Promise<AuthUser> {
+    return this.authService.findOrCreateUser('github', profile, accessToken, refreshToken);
+  }
+}

--- a/apps/api/src/auth/strategies/gitlab.strategy.ts
+++ b/apps/api/src/auth/strategies/gitlab.strategy.ts
@@ -1,0 +1,34 @@
+import type { AuthUser } from '@aegisai/shared';
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+
+import { ConfigService } from '../../config/config.service';
+import { AuthService } from '../auth.service';
+import type { GitlabOAuthProfile } from '../oauth-profile.types';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const GitLabPassportStrategy = require('passport-gitlab2');
+
+@Injectable()
+export class GitlabStrategy extends PassportStrategy(GitLabPassportStrategy, 'gitlab') {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly authService: AuthService
+  ) {
+    super({
+      clientID: config.get('GITLAB_CLIENT_ID'),
+      clientSecret: config.get('GITLAB_CLIENT_SECRET'),
+      callbackURL: new URL('/api/auth/gitlab/callback', config.get('APP_URL')).toString(),
+      scope: ['read_user', 'read_api'],
+      state: true
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string | undefined,
+    profile: GitlabOAuthProfile
+  ): Promise<AuthUser> {
+    return this.authService.findOrCreateUser('gitlab', profile, accessToken, refreshToken);
+  }
+}

--- a/apps/api/test/auth/auth.service.e2e-spec.ts
+++ b/apps/api/test/auth/auth.service.e2e-spec.ts
@@ -1,6 +1,180 @@
 import { AuthService } from '../../src/auth/auth.service';
 
 describe('AuthService', () => {
+  it('creates a github-backed user and stores encrypted provider tokens', async () => {
+    const prisma = {
+      user: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'user-1',
+            email: 'octo@example.com',
+            name: 'Octo Cat',
+            avatarUrl: 'https://example.com/octo.png',
+            oauthTokens: [{ provider: 'GITHUB' }]
+          }),
+        create: jest.fn().mockResolvedValue({ id: 'user-1' })
+      },
+      oAuthToken: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn().mockResolvedValue({ id: 'token-1' })
+      }
+    };
+    const tokenCrypto = {
+      encrypt: jest.fn((value: string) => `enc(${value})`)
+    };
+
+    const service = new AuthService(prisma as never, tokenCrypto as never);
+
+    await expect(
+      service.findOrCreateUser(
+        'github',
+        {
+          id: 'github-123',
+          username: 'octocat',
+          displayName: 'Octo Cat',
+          emails: [{ value: 'octo@example.com' }],
+          photos: [{ value: 'https://example.com/octo.png' }]
+        },
+        'github-access-token',
+        'github-refresh-token'
+      )
+    ).resolves.toEqual({
+      id: 'user-1',
+      email: 'octo@example.com',
+      name: 'Octo Cat',
+      avatarUrl: 'https://example.com/octo.png',
+      connectedProviders: ['github']
+    });
+
+    expect(prisma.oAuthToken.findUnique).toHaveBeenCalledWith({
+      where: {
+        provider_providerUserId: {
+          provider: 'GITHUB',
+          providerUserId: 'github-123'
+        }
+      }
+    });
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'octo@example.com',
+        name: 'Octo Cat',
+        avatarUrl: 'https://example.com/octo.png'
+      }
+    });
+    expect(tokenCrypto.encrypt).toHaveBeenNthCalledWith(1, 'github-access-token');
+    expect(tokenCrypto.encrypt).toHaveBeenNthCalledWith(2, 'github-refresh-token');
+    expect(prisma.oAuthToken.upsert).toHaveBeenCalledWith({
+      where: {
+        provider_providerUserId: {
+          provider: 'GITHUB',
+          providerUserId: 'github-123'
+        }
+      },
+      update: {
+        accessToken: 'enc(github-access-token)',
+        refreshToken: 'enc(github-refresh-token)',
+        expiresAt: null
+      },
+      create: {
+        userId: 'user-1',
+        provider: 'GITHUB',
+        providerUserId: 'github-123',
+        accessToken: 'enc(github-access-token)',
+        refreshToken: 'enc(github-refresh-token)',
+        expiresAt: null
+      }
+    });
+  });
+
+  it('reuses an existing email-matched user for a gitlab login', async () => {
+    const prisma = {
+      user: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'user-1',
+            email: 'gitlab@example.com',
+            name: 'Existing User',
+            avatarUrl: null,
+            oauthTokens: [{ provider: 'GITHUB' }]
+          })
+          .mockResolvedValueOnce({
+            id: 'user-1',
+            email: 'gitlab@example.com',
+            name: 'GitLab User',
+            avatarUrl: 'https://example.com/gitlab.png',
+            oauthTokens: [{ provider: 'GITHUB' }, { provider: 'GITLAB' }]
+          }),
+        create: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: 'user-1' })
+      },
+      oAuthToken: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn().mockResolvedValue({ id: 'token-2' })
+      }
+    };
+    const tokenCrypto = {
+      encrypt: jest.fn((value: string) => `enc(${value})`)
+    };
+
+    const service = new AuthService(prisma as never, tokenCrypto as never);
+
+    await expect(
+      service.findOrCreateUser(
+        'gitlab',
+        {
+          id: 'gitlab-456',
+          username: 'gitlab-user',
+          displayName: 'GitLab User',
+          emails: [{ value: 'gitlab@example.com' }],
+          avatarUrl: 'https://example.com/gitlab.png'
+        },
+        'gitlab-access-token'
+      )
+    ).resolves.toEqual({
+      id: 'user-1',
+      email: 'gitlab@example.com',
+      name: 'GitLab User',
+      avatarUrl: 'https://example.com/gitlab.png',
+      connectedProviders: ['github', 'gitlab']
+    });
+
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: {
+        email: 'gitlab@example.com',
+        name: 'GitLab User',
+        avatarUrl: 'https://example.com/gitlab.png'
+      }
+    });
+    expect(tokenCrypto.encrypt).toHaveBeenCalledTimes(1);
+    expect(tokenCrypto.encrypt).toHaveBeenCalledWith('gitlab-access-token');
+    expect(prisma.oAuthToken.upsert).toHaveBeenCalledWith({
+      where: {
+        provider_providerUserId: {
+          provider: 'GITLAB',
+          providerUserId: 'gitlab-456'
+        }
+      },
+      update: {
+        accessToken: 'enc(gitlab-access-token)',
+        refreshToken: null,
+        expiresAt: null
+      },
+      create: {
+        userId: 'user-1',
+        provider: 'GITLAB',
+        providerUserId: 'gitlab-456',
+        accessToken: 'enc(gitlab-access-token)',
+        refreshToken: null,
+        expiresAt: null
+      }
+    });
+  });
+
   it('maps a persisted user into the shared session shape', async () => {
     const prisma = {
       user: {
@@ -14,7 +188,7 @@ describe('AuthService', () => {
       }
     };
 
-    const service = new AuthService(prisma as never);
+    const service = new AuthService(prisma as never, {} as never);
 
     await expect(service.getSessionUserById('user-1')).resolves.toEqual({
       id: 'user-1',
@@ -35,13 +209,13 @@ describe('AuthService', () => {
       user: {
         findUnique: jest.fn().mockResolvedValue(null)
       }
-    } as never);
+    } as never, {} as never);
 
     await expect(service.getSessionUserById('missing-user')).resolves.toBeNull();
   });
 
   it('creates distinct csrf token values', () => {
-    const service = new AuthService({} as never);
+    const service = new AuthService({} as never, {} as never);
 
     const first = service.createCsrfToken();
     const second = service.createCsrfToken();

--- a/apps/api/test/auth/github.strategy.e2e-spec.ts
+++ b/apps/api/test/auth/github.strategy.e2e-spec.ts
@@ -1,0 +1,87 @@
+const githubStrategyCapture: { options?: Record<string, unknown> } = {};
+
+jest.mock('passport-github2', () => {
+  class MockGithubPassportStrategy {
+    name = 'github';
+
+    constructor(options: Record<string, unknown>) {
+      githubStrategyCapture.options = options;
+    }
+
+    authenticate(): void {}
+  }
+
+  return { Strategy: MockGithubPassportStrategy };
+});
+
+import type { AuthUser } from '@aegisai/shared';
+
+import { GithubStrategy } from '../../src/auth/strategies/github.strategy';
+
+describe('GithubStrategy', () => {
+  const env = {
+    APP_URL: 'http://localhost:3000',
+    GITHUB_CLIENT_ID: 'github-client-id',
+    GITHUB_CLIENT_SECRET: 'github-client-secret'
+  } as const;
+
+  beforeEach(() => {
+    githubStrategyCapture.options = undefined;
+  });
+
+  it('builds the github passport strategy from config', () => {
+    const config = {
+      get: jest.fn((key: keyof typeof env) => env[key])
+    };
+    const authService = {
+      findOrCreateUser: jest.fn()
+    };
+
+    new GithubStrategy(config as never, authService as never);
+
+    expect(githubStrategyCapture.options).toEqual(
+      expect.objectContaining({
+        clientID: 'github-client-id',
+        clientSecret: 'github-client-secret',
+        callbackURL: 'http://localhost:3000/api/auth/github/callback',
+        scope: ['read:user', 'user:email', 'repo'],
+        state: true
+      })
+    );
+  });
+
+  it('delegates validated github logins to AuthService', async () => {
+    const expectedUser: AuthUser = {
+      id: 'user-1',
+      email: 'octo@example.com',
+      name: 'Octo Cat',
+      avatarUrl: 'https://example.com/octo.png',
+      connectedProviders: ['github']
+    };
+    const config = {
+      get: jest.fn((key: keyof typeof env) => env[key])
+    };
+    const authService = {
+      findOrCreateUser: jest.fn().mockResolvedValue(expectedUser)
+    };
+    const strategy = new GithubStrategy(config as never, authService as never);
+    const profile = {
+      id: 'github-123',
+      username: 'octocat',
+      displayName: 'Octo Cat',
+      emails: [{ value: 'octo@example.com' }],
+      photos: [{ value: 'https://example.com/octo.png' }]
+    };
+
+    await expect(
+      strategy.validate('github-access-token', 'github-refresh-token', profile)
+    ).resolves.toEqual(expectedUser);
+
+    expect(authService.findOrCreateUser).toHaveBeenCalledWith(
+      'github',
+      profile,
+      'github-access-token',
+      'github-refresh-token'
+    );
+  });
+});

--- a/apps/api/test/auth/gitlab.strategy.e2e-spec.ts
+++ b/apps/api/test/auth/gitlab.strategy.e2e-spec.ts
@@ -1,0 +1,85 @@
+const gitlabStrategyCapture: { options?: Record<string, unknown> } = {};
+
+jest.mock('passport-gitlab2', () => {
+  return class MockGitlabPassportStrategy {
+    name = 'gitlab';
+
+    constructor(options: Record<string, unknown>) {
+      gitlabStrategyCapture.options = options;
+    }
+
+    authenticate(): void {}
+  };
+});
+
+import type { AuthUser } from '@aegisai/shared';
+
+import { GitlabStrategy } from '../../src/auth/strategies/gitlab.strategy';
+
+describe('GitlabStrategy', () => {
+  const env = {
+    APP_URL: 'http://localhost:3000',
+    GITLAB_CLIENT_ID: 'gitlab-client-id',
+    GITLAB_CLIENT_SECRET: 'gitlab-client-secret'
+  } as const;
+
+  beforeEach(() => {
+    gitlabStrategyCapture.options = undefined;
+  });
+
+  it('builds the gitlab passport strategy from config', () => {
+    const config = {
+      get: jest.fn((key: keyof typeof env) => env[key])
+    };
+    const authService = {
+      findOrCreateUser: jest.fn()
+    };
+
+    new GitlabStrategy(config as never, authService as never);
+
+    expect(gitlabStrategyCapture.options).toEqual(
+      expect.objectContaining({
+        clientID: 'gitlab-client-id',
+        clientSecret: 'gitlab-client-secret',
+        callbackURL: 'http://localhost:3000/api/auth/gitlab/callback',
+        scope: ['read_user', 'read_api'],
+        state: true
+      })
+    );
+  });
+
+  it('delegates validated gitlab logins to AuthService', async () => {
+    const expectedUser: AuthUser = {
+      id: 'user-1',
+      email: 'gitlab@example.com',
+      name: 'GitLab User',
+      avatarUrl: 'https://example.com/gitlab.png',
+      connectedProviders: ['gitlab']
+    };
+    const config = {
+      get: jest.fn((key: keyof typeof env) => env[key])
+    };
+    const authService = {
+      findOrCreateUser: jest.fn().mockResolvedValue(expectedUser)
+    };
+    const strategy = new GitlabStrategy(config as never, authService as never);
+    const profile = {
+      id: 'gitlab-456',
+      username: 'gitlab-user',
+      displayName: 'GitLab User',
+      emails: [{ value: 'gitlab@example.com' }],
+      avatarUrl: 'https://example.com/gitlab.png'
+    };
+
+    await expect(strategy.validate('gitlab-access-token', undefined, profile)).resolves.toEqual(
+      expectedUser
+    );
+
+    expect(authService.findOrCreateUser).toHaveBeenCalledWith(
+      'gitlab',
+      profile,
+      'gitlab-access-token',
+      undefined
+    );
+  });
+});

--- a/docs/superpowers/plans/2026-03-19-oauth-strategies.md
+++ b/docs/superpowers/plans/2026-03-19-oauth-strategies.md
@@ -1,0 +1,68 @@
+# OAuth Strategies Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement GitHub and GitLab Passport strategies that normalize provider profiles, persist OAuth tokens, and return shared session users.
+
+**Architecture:** Keep the strategy classes provider-thin and push profile normalization plus Prisma persistence into `AuthService`. Cover the behavior with focused auth tests so controller and middleware wiring can be added in a later issue without reworking provider internals.
+
+**Tech Stack:** NestJS, Passport, Prisma, Jest
+
+---
+
+## Chunk 1: Provider Dependencies And Regression Tests
+
+### Task 1: Add failing OAuth strategy tests
+
+**Files:**
+- Modify: `apps/api/package.json`
+- Modify: `apps/api/test/auth/auth.service.e2e-spec.ts`
+- Create: `apps/api/test/auth/github.strategy.e2e-spec.ts`
+- Create: `apps/api/test/auth/gitlab.strategy.e2e-spec.ts`
+
+- [ ] **Step 1: Add provider package dependencies needed for GitHub and GitLab strategies**
+- [ ] **Step 2: Write failing tests for provider profile mapping in `AuthService`**
+- [ ] **Step 3: Write failing tests for GitHub strategy configuration and validate delegation**
+- [ ] **Step 4: Write failing tests for GitLab strategy configuration and validate delegation**
+- [ ] **Step 5: Run targeted auth tests and confirm the new cases fail for the expected missing behavior**
+
+## Chunk 2: Auth Service Provider Flow
+
+### Task 2: Normalize provider profiles and persist OAuth identities
+
+**Files:**
+- Modify: `apps/api/src/auth/auth.service.ts`
+
+- [ ] **Step 1: Add provider profile normalization helpers for GitHub and GitLab**
+- [ ] **Step 2: Add `findOrCreateUser` flow that upserts `User` and encrypted `OAuthToken` records**
+- [ ] **Step 3: Return the shared `AuthUser` shape with connected providers after persistence**
+- [ ] **Step 4: Re-run the targeted auth service tests and make them pass**
+
+## Chunk 3: Passport Strategies
+
+### Task 3: Implement GitHub and GitLab strategy classes
+
+**Files:**
+- Modify: `apps/api/src/auth/auth.module.ts`
+- Create: `apps/api/src/auth/strategies/github.strategy.ts`
+- Create: `apps/api/src/auth/strategies/gitlab.strategy.ts`
+
+- [ ] **Step 1: Implement GitHub strategy with config-driven callback URL, state, and scopes**
+- [ ] **Step 2: Implement GitLab strategy with config-driven callback URL, state, and scopes**
+- [ ] **Step 3: Register both strategies in `AuthModule`**
+- [ ] **Step 4: Re-run targeted strategy tests and make them pass**
+
+## Chunk 4: Verification
+
+### Task 4: Prove the feature is stable
+
+**Files:**
+- Verify: `apps/api/test/auth/*.e2e-spec.ts`
+- Verify: `apps/api/src/auth/*.ts`
+
+- [ ] **Step 1: Run `corepack pnpm --filter @aegisai/api test -- --runInBand test/auth`**
+- [ ] **Step 2: Run `corepack pnpm lint`**
+- [ ] **Step 3: Run `corepack pnpm test`**
+- [ ] **Step 4: Run `corepack pnpm typecheck`**
+- [ ] **Step 5: Run `corepack pnpm build`**
+- [ ] **Step 6: Commit with `feat: implement oauth provider strategies`**

--- a/docs/superpowers/specs/2026-03-19-oauth-strategies-design.md
+++ b/docs/superpowers/specs/2026-03-19-oauth-strategies-design.md
@@ -1,0 +1,45 @@
+# OAuth Strategies Design
+
+## Goal
+
+Add GitHub and GitLab Passport strategies on top of the existing session-based auth foundation so later auth controller endpoints can initiate OAuth and receive validated users without rebuilding provider-specific logic.
+
+## Scope
+
+This issue only covers:
+
+- GitHub and GitLab Passport strategy classes
+- provider profile normalization and persistence in `AuthService`
+- `AuthModule` wiring for the new strategies
+- focused tests for provider mapping and strategy validation
+
+This issue does not cover:
+
+- auth controller endpoints
+- `main.ts` passport/session middleware wiring
+- redirect handling after successful OAuth login
+
+## Approach
+
+`AuthService` will gain a provider-aware `findOrCreateUser` flow that:
+
+1. normalizes GitHub/GitLab profile objects into a shared internal shape
+2. upserts `User`
+3. upserts the encrypted `OAuthToken`
+4. returns the shared `AuthUser` session payload
+
+Each strategy will stay thin:
+
+- read credentials and callback URL from config
+- enable OAuth `state`
+- define provider scopes
+- delegate provider profile handling to `AuthService`
+
+## Testing
+
+Tests will cover:
+
+- GitHub profile normalization and persisted `AuthUser` mapping
+- GitLab profile normalization and persisted `AuthUser` mapping
+- strategy `validate()` delegation to `AuthService`
+- strategy configuration expectations such as callback URL, state, and scopes

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       passport:
         specifier: ^0.7.0
         version: 0.7.0
+      passport-github2:
+        specifier: ^0.1.12
+        version: 0.1.12
+      passport-gitlab2:
+        specifier: ^5.0.0
+        version: 5.0.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -75,6 +81,9 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.19.15
+      '@types/passport-github2':
+        specifier: ^1.2.9
+        version: 1.2.9
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
@@ -1040,8 +1049,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
@@ -1058,8 +1073,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1082,8 +1106,26 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
+  '@types/oauth@0.9.6':
+    resolution: {integrity: sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==}
+
+  '@types/passport-github2@1.2.9':
+    resolution: {integrity: sha512-/nMfiPK2E6GKttwBzwj0Wjaot8eHrM57hnWxu52o6becr5/kXlH/4yE2v2rh234WGvSgEEzIII02Nc5oC5xEHA==}
+
+  '@types/passport-oauth2@1.8.0':
+    resolution: {integrity: sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ==}
+
+  '@types/passport@1.0.17':
+    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
@@ -1092,6 +1134,12 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1403,6 +1451,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
 
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
@@ -2700,6 +2752,9 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  oauth@0.10.2:
+    resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2768,6 +2823,18 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  passport-github2@0.1.12:
+    resolution: {integrity: sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==}
+    engines: {node: '>= 0.8.0'}
+
+  passport-gitlab2@5.0.0:
+    resolution: {integrity: sha512-cXQMgM6JQx9wHVh7JLH30D8fplfwjsDwRz+zS0pqC8JS+4bNmc1J04NGp5g2M4yfwylH9kQRrMN98GxMw7q7cg==}
+    engines: {node: '>= 6.0.0'}
+
+  passport-oauth2@1.8.0:
+    resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
+    engines: {node: '>= 0.4.0'}
 
   passport-strategy@1.0.0:
     resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
@@ -3387,6 +3454,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uid2@0.0.4:
+    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
 
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
@@ -4581,10 +4651,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.15
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/cookiejar@2.1.5': {}
 
@@ -4602,9 +4681,24 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4629,7 +4723,31 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/oauth@0.9.6':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/passport-github2@1.2.9':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/passport': 1.0.17
+      '@types/passport-oauth2': 1.8.0
+
+  '@types/passport-oauth2@1.8.0':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/oauth': 0.9.6
+      '@types/passport': 1.0.17
+
+  '@types/passport@1.0.17':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/prop-types@15.7.15': {}
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
@@ -4639,6 +4757,15 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.15
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5049,6 +5176,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
+
+  base64url@3.0.1: {}
 
   baseline-browser-mapping@2.10.8: {}
 
@@ -6571,6 +6700,8 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  oauth@0.10.2: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -6646,6 +6777,22 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  passport-github2@0.1.12:
+    dependencies:
+      passport-oauth2: 1.8.0
+
+  passport-gitlab2@5.0.0:
+    dependencies:
+      passport-oauth2: 1.8.0
+
+  passport-oauth2@1.8.0:
+    dependencies:
+      base64url: 3.0.1
+      oauth: 0.10.2
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
+      utils-merge: 1.0.1
 
   passport-strategy@1.0.0: {}
 
@@ -7251,6 +7398,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uid2@0.0.4: {}
 
   uid@2.0.2:
     dependencies:


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/44-oauth-strategies`
- 이슈: `#44`

## 🔎 주요 변경 사항

- GitHub, GitLab OAuth strategy를 추가했습니다.
- provider별 callback URL, scope, `state` 설정을 config 기반으로 구성했습니다.
- `AuthService.findOrCreateUser`를 추가해 provider profile 정규화, 사용자 조회/생성, OAuth token 암호화 저장을 처리하도록 했습니다.
- `AuthModule`에 OAuth strategy를 등록했습니다.
- auth service와 각 strategy의 회귀 테스트를 추가했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- `/api/auth/...` 엔드포인트와 `main.ts`의 전역 session/passport wiring은 다음 이슈 범위로 의도적으로 제외했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub and GitLab OAuth authentication options
  * Encrypted OAuth token storage for enhanced security
  * Automatic user account linking via OAuth provider profiles

* **Documentation**
  * Added OAuth strategy implementation plan and design specifications

* **Tests**
  * Added end-to-end tests for authentication and OAuth strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->