### PR TITLE
Fix: provider 이메일 누락 시 기존 이메일 보존

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -15,6 +15,12 @@ interface NormalizedProviderProfile {
   avatarUrl: string | null;
 }
 
+interface UserUpdateData {
+  email?: string | null;
+  name: string;
+  avatarUrl: string | null;
+}
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -41,13 +47,10 @@ export class AuthService {
     let userId: string;
 
     if (existingToken) {
+      const userUpdateData = this.buildUserUpdateData(normalizedProfile);
       const user = await this.prisma.user.update({
         where: { id: existingToken.userId },
-        data: {
-          email: normalizedProfile.email,
-          name: normalizedProfile.name,
-          avatarUrl: normalizedProfile.avatarUrl
-        }
+        data: userUpdateData
       });
 
       userId = user.id;
@@ -60,13 +63,10 @@ export class AuthService {
         : null;
 
       if (existingUser) {
+        const userUpdateData = this.buildUserUpdateData(normalizedProfile);
         const user = await this.prisma.user.update({
           where: { id: existingUser.id },
-          data: {
-            email: normalizedProfile.email,
-            name: normalizedProfile.name,
-            avatarUrl: normalizedProfile.avatarUrl
-          }
+          data: userUpdateData
         });
 
         userId = user.id;
@@ -161,5 +161,18 @@ export class AuthService {
       name: profile.displayName ?? profile.username ?? `gitlab-${String(profile.id)}`,
       avatarUrl: 'avatarUrl' in profile ? profile.avatarUrl ?? null : null
     };
+  }
+
+  private buildUserUpdateData(normalizedProfile: NormalizedProviderProfile): UserUpdateData {
+    const userUpdateData: UserUpdateData = {
+      name: normalizedProfile.name,
+      avatarUrl: normalizedProfile.avatarUrl
+    };
+
+    if (normalizedProfile.email !== null) {
+      userUpdateData.email = normalizedProfile.email;
+    }
+
+    return userUpdateData;
   }
 }

--- a/apps/api/test/auth/auth.service.e2e-spec.ts
+++ b/apps/api/test/auth/auth.service.e2e-spec.ts
@@ -88,6 +88,61 @@ describe('AuthService', () => {
     });
   });
 
+  it('preserves the stored email when a returning provider profile omits it', async () => {
+    const prisma = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'user-1',
+          email: 'stored@example.com',
+          name: 'Stored User',
+          avatarUrl: 'https://example.com/stored.png',
+          oauthTokens: [{ provider: 'GITHUB' }]
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'user-1' })
+      },
+      oAuthToken: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'token-1',
+          userId: 'user-1'
+        }),
+        upsert: jest.fn().mockResolvedValue({ id: 'token-1' })
+      }
+    };
+    const tokenCrypto = {
+      encrypt: jest.fn((value: string) => `enc(${value})`)
+    };
+
+    const service = new AuthService(prisma as never, tokenCrypto as never);
+
+    await expect(
+      service.findOrCreateUser(
+        'github',
+        {
+          id: 'github-123',
+          username: 'octocat',
+          displayName: 'Octo Cat',
+          emails: [],
+          photos: [{ value: 'https://example.com/octo.png' }]
+        },
+        'github-access-token'
+      )
+    ).resolves.toEqual({
+      id: 'user-1',
+      email: 'stored@example.com',
+      name: 'Stored User',
+      avatarUrl: 'https://example.com/stored.png',
+      connectedProviders: ['github']
+    });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: {
+        name: 'Octo Cat',
+        avatarUrl: 'https://example.com/octo.png'
+      }
+    });
+  });
+
   it('reuses an existing email-matched user for a gitlab login', async () => {
     const prisma = {
       user: {


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/47-preserve-provider-email`
- 이슈: `#47`

## 🔎 주요 변경 사항

- returning OAuth 사용자 갱신 시 provider 응답에 이메일이 없으면 기존 저장 이메일을 유지하도록 `AuthService`를 수정했습니다.
- 사용자 update payload를 공통 helper로 정리해 `email: null`이 무심코 덮어써지지 않도록 했습니다.
- provider 이메일 누락 회귀를 검증하는 `AuthService` 테스트를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
