### PR TITLE
Feat: repository service and controller 구현

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { ConfigService } from './config/config.service';
 import { HealthModule } from './health/health.module';
 import { LanguageModule } from './language/language.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { RepoModule } from './repo/repo.module';
 import { ScanModule } from './scan/scan.module';
 
 const runtimeFeatureModules = process.env.NODE_ENV === 'test' ? [HealthModule] : [ScanModule, HealthModule];
@@ -44,6 +45,7 @@ const runtimeFeatureModules = process.env.NODE_ENV === 'test' ? [HealthModule] :
     ]),
     PrismaModule,
     AuthModule,
+    RepoModule,
     GitClientModule,
     LanguageModule,
     AnalysisApiModule,

--- a/apps/api/src/client/git/git-provider-client.interface.ts
+++ b/apps/api/src/client/git/git-provider-client.interface.ts
@@ -45,6 +45,7 @@ export interface IGitProviderClient {
   readonly provider: Provider;
 
   getRepositories(accessToken: string, page: number, size: number): Promise<RepoListResult>;
+  getRepository(providerRepoId: string, accessToken: string): Promise<ProviderRepoListItem>;
   getBranches(
     fullName: string,
     page: number,

--- a/apps/api/src/client/git/github.client.ts
+++ b/apps/api/src/client/git/github.client.ts
@@ -13,6 +13,7 @@ import type {
   BranchListResult,
   FileTreeItem,
   IGitProviderClient,
+  ProviderRepoListItem,
   RepoListResult
 } from './git-provider-client.interface';
 
@@ -81,6 +82,33 @@ export class GithubClient implements IGitProviderClient {
           isPrivate: repository.private
         })),
         hasNextPage: this.hasNextLink(response.headers?.link)
+      };
+    });
+  }
+
+  async getRepository(
+    providerRepoId: string,
+    accessToken: string
+  ): Promise<ProviderRepoListItem> {
+    return this.wrapRequest(async () => {
+      const response = await firstValueFrom(
+        this.http.get<GithubRepositoryResponse>(
+          `${this.baseUrl}/repositories/${encodeURIComponent(providerRepoId)}`,
+          {
+            headers: this.buildHeaders(accessToken)
+          }
+        )
+      );
+
+      return {
+        providerRepoId: String(response.data.id),
+        fullName: response.data.full_name,
+        cloneUrl: response.data.clone_url,
+        defaultBranch: this.requireString(
+          response.data.default_branch,
+          `GitHub repository ${response.data.full_name} is missing a default branch`
+        ),
+        isPrivate: response.data.private
       };
     });
   }

--- a/apps/api/src/client/git/gitlab.client.ts
+++ b/apps/api/src/client/git/gitlab.client.ts
@@ -13,6 +13,7 @@ import type {
   BranchListResult,
   FileTreeItem,
   IGitProviderClient,
+  ProviderRepoListItem,
   RepoListResult
 } from './git-provider-client.interface';
 
@@ -72,6 +73,33 @@ export class GitlabClient implements IGitProviderClient {
           isPrivate: project.visibility !== 'public'
         })),
         hasNextPage: this.hasNextPage(response.headers)
+      };
+    });
+  }
+
+  async getRepository(
+    providerRepoId: string,
+    accessToken: string
+  ): Promise<ProviderRepoListItem> {
+    return this.wrapRequest(async () => {
+      const response = await firstValueFrom(
+        this.http.get<GitlabProjectResponse>(
+          `${this.baseUrl}/projects/${encodeURIComponent(providerRepoId)}`,
+          {
+            headers: this.buildHeaders(accessToken)
+          }
+        )
+      );
+
+      return {
+        providerRepoId: String(response.data.id),
+        fullName: response.data.path_with_namespace,
+        cloneUrl: response.data.http_url_to_repo,
+        defaultBranch: this.requireString(
+          response.data.default_branch,
+          `GitLab project ${response.data.path_with_namespace} is missing a default branch`
+        ),
+        isPrivate: response.data.visibility !== 'public'
       };
     });
   }

--- a/apps/api/src/repo/repo.controller.ts
+++ b/apps/api/src/repo/repo.controller.ts
@@ -1,0 +1,134 @@
+import type {
+  AuthUser,
+  ConnectRepoRequest,
+  ListAvailableReposQuery,
+  ListRepoBranchesQuery,
+  Provider
+} from '@aegisai/shared';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards
+} from '@nestjs/common';
+
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SessionAuthGuard } from '../auth/guards/session-auth.guard';
+import { SkipTransform } from '../common/decorators/skip-transform.decorator';
+import { RepoService } from './repo.service';
+
+const VALID_PROVIDERS: Provider[] = ['github', 'gitlab'];
+
+@Controller('repos')
+@UseGuards(SessionAuthGuard)
+export class RepoController {
+  constructor(private readonly repoService: RepoService) {}
+
+  @Get()
+  async listConnectedRepos(@CurrentUser() user: AuthUser) {
+    return this.repoService.listConnectedRepos(user.id);
+  }
+
+  @Get('available')
+  async listAvailableRepos(
+    @CurrentUser() user: AuthUser,
+    @Query('provider') provider: string | undefined,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('size', new DefaultValuePipe(30), ParseIntPipe) size: number
+  ) {
+    return this.repoService.listAvailableRepos({
+      userId: user.id,
+      provider: this.parseProvider(provider),
+      ...this.normalizePagination({ page, size })
+    });
+  }
+
+  @Post()
+  async connectRepo(
+    @CurrentUser() user: AuthUser,
+    @Body() body: Partial<ConnectRepoRequest>
+  ) {
+    const provider = this.parseProvider(body.provider);
+    const providerRepoId = body.providerRepoId?.trim();
+
+    if (!providerRepoId) {
+      throw new BadRequestException({
+        message: 'providerRepoId is required.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    return this.repoService.connectRepo({
+      userId: user.id,
+      provider,
+      providerRepoId
+    });
+  }
+
+  @Delete(':repoId')
+  @HttpCode(204)
+  @SkipTransform()
+  async disconnectRepo(
+    @CurrentUser() user: AuthUser,
+    @Param('repoId') repoId: string
+  ): Promise<void> {
+    await this.repoService.disconnectRepo({
+      userId: user.id,
+      repoId
+    });
+  }
+
+  @Get(':repoId/branches')
+  async listBranches(
+    @CurrentUser() user: AuthUser,
+    @Param('repoId') repoId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('size', new DefaultValuePipe(30), ParseIntPipe) size: number
+  ) {
+    return this.repoService.listBranches({
+      userId: user.id,
+      repoId,
+      ...this.normalizePagination({ page, size })
+    });
+  }
+
+  private parseProvider(provider: string | undefined): Provider {
+    if (provider && VALID_PROVIDERS.includes(provider as Provider)) {
+      return provider as Provider;
+    }
+
+    throw new BadRequestException({
+      message: 'provider must be github or gitlab.',
+      errorCode: 'BAD_REQUEST'
+    });
+  }
+
+  private normalizePagination(input: ListAvailableReposQuery | ListRepoBranchesQuery) {
+    if (!input.page || input.page < 1) {
+      throw new BadRequestException({
+        message: 'page must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    if (!input.size || input.size < 1) {
+      throw new BadRequestException({
+        message: 'size must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    return {
+      page: input.page,
+      size: input.size
+    };
+  }
+}

--- a/apps/api/src/repo/repo.module.ts
+++ b/apps/api/src/repo/repo.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { GitClientModule } from '../client/git/git-client.module';
+import { ConfigModule } from '../config/config.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { RepoController } from './repo.controller';
+import { RepoService } from './repo.service';
+
+@Module({
+  imports: [AuthModule, ConfigModule, PrismaModule, GitClientModule],
+  controllers: [RepoController],
+  providers: [RepoService],
+  exports: [RepoService]
+})
+export class RepoModule {}

--- a/apps/api/src/repo/repo.service.ts
+++ b/apps/api/src/repo/repo.service.ts
@@ -1,0 +1,290 @@
+import type {
+  AvailableRepoListResponse,
+  ConnectRepoRequest,
+  ConnectRepoResponse,
+  ConnectedRepoListResponse,
+  Provider,
+  RepoBranchListResponse
+} from '@aegisai/shared';
+import {
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException
+} from '@nestjs/common';
+import { RepoProvider } from '@prisma/client';
+
+import {
+  GitProviderNotFoundError,
+  GitProviderRateLimitError,
+  GitProviderUnauthorizedError,
+  GitProviderUnavailableError
+} from '../client/git/git-provider-client.errors';
+import { GitClientRegistry } from '../client/git/git-client.registry';
+import { PrismaService } from '../prisma/prisma.service';
+import { TokenCryptoUtil } from '../auth/utils/token-crypto.util';
+
+interface ListAvailableReposInput {
+  userId: string;
+  provider: Provider;
+  page: number;
+  size: number;
+}
+
+interface ListBranchesInput {
+  userId: string;
+  repoId: string;
+  page: number;
+  size: number;
+}
+
+interface DisconnectRepoInput {
+  userId: string;
+  repoId: string;
+}
+
+@Injectable()
+export class RepoService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly gitClients: GitClientRegistry,
+    private readonly tokenCrypto: TokenCryptoUtil
+  ) {}
+
+  async listConnectedRepos(userId: string): Promise<ConnectedRepoListResponse> {
+    const connectedRepos = await this.prisma.connectedRepo.findMany({
+      where: { userId },
+      include: {
+        scans: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: {
+            createdAt: true,
+            status: true
+          }
+        }
+      },
+      orderBy: {
+        connectedAt: 'desc'
+      }
+    });
+
+    return connectedRepos.map((connectedRepo) => {
+      const [latestScan] = connectedRepo.scans;
+
+      return {
+        id: connectedRepo.id,
+        provider: this.fromRepoProvider(connectedRepo.provider),
+        fullName: connectedRepo.fullName,
+        cloneUrl: connectedRepo.cloneUrl,
+        defaultBranch: connectedRepo.defaultBranch,
+        isPrivate: connectedRepo.isPrivate,
+        lastScanAt: latestScan?.createdAt.toISOString() ?? null,
+        lastScanStatus: latestScan?.status ?? null
+      };
+    });
+  }
+
+  async listAvailableRepos(input: ListAvailableReposInput): Promise<AvailableRepoListResponse> {
+    const { client, accessToken, providerEnum } = await this.resolveProviderClient(input.userId, input.provider);
+
+    try {
+      const [providerRepos, connectedRepos] = await Promise.all([
+        client.getRepositories(accessToken, input.page, input.size),
+        this.prisma.connectedRepo.findMany({
+          where: {
+            userId: input.userId,
+            provider: providerEnum
+          },
+          select: {
+            providerRepoId: true
+          }
+        })
+      ]);
+
+      const connectedRepoIds = new Set(connectedRepos.map((repo) => repo.providerRepoId));
+
+      return {
+        items: providerRepos.items.map((repo) => ({
+          ...repo,
+          alreadyConnected: connectedRepoIds.has(repo.providerRepoId)
+        })),
+        page: input.page,
+        size: input.size,
+        hasNextPage: providerRepos.hasNextPage,
+        nextPage: providerRepos.hasNextPage ? input.page + 1 : null
+      };
+    } catch (error) {
+      this.throwProviderError(error, input.provider);
+    }
+  }
+
+  async connectRepo(input: { userId: string } & ConnectRepoRequest): Promise<ConnectRepoResponse> {
+    const { client, accessToken, providerEnum } = await this.resolveProviderClient(input.userId, input.provider);
+    const existingRepo = await this.prisma.connectedRepo.findUnique({
+      where: {
+        userId_provider_providerRepoId: {
+          userId: input.userId,
+          provider: providerEnum,
+          providerRepoId: input.providerRepoId
+        }
+      }
+    });
+
+    if (existingRepo) {
+      throw new ConflictException({
+        message: 'Repository is already connected.',
+        errorCode: 'REPO_ALREADY_CONNECTED'
+      });
+    }
+
+    try {
+      const repository = await client.getRepository(input.providerRepoId, accessToken);
+      const connectedRepo = await this.prisma.connectedRepo.create({
+        data: {
+          userId: input.userId,
+          provider: providerEnum,
+          providerRepoId: repository.providerRepoId,
+          fullName: repository.fullName,
+          cloneUrl: repository.cloneUrl,
+          defaultBranch: repository.defaultBranch,
+          isPrivate: repository.isPrivate
+        }
+      });
+
+      return {
+        id: connectedRepo.id,
+        fullName: connectedRepo.fullName,
+        connectedAt: connectedRepo.connectedAt.toISOString()
+      };
+    } catch (error) {
+      this.throwProviderError(error, input.provider);
+    }
+  }
+
+  async listBranches(input: ListBranchesInput): Promise<RepoBranchListResponse> {
+    const connectedRepo = await this.prisma.connectedRepo.findFirst({
+      where: {
+        id: input.repoId,
+        userId: input.userId
+      }
+    });
+
+    if (!connectedRepo) {
+      throw new NotFoundException({
+        message: 'Connected repository not found.',
+        errorCode: 'REPO_NOT_FOUND'
+      });
+    }
+
+    const provider = this.fromRepoProvider(connectedRepo.provider);
+    const { client, accessToken } = await this.resolveProviderClient(input.userId, provider);
+
+    try {
+      const branches = await client.getBranches(
+        connectedRepo.fullName,
+        input.page,
+        input.size,
+        accessToken
+      );
+
+      return {
+        items: branches.items,
+        page: input.page,
+        size: input.size,
+        hasNextPage: branches.hasNextPage,
+        nextPage: branches.hasNextPage ? input.page + 1 : null
+      };
+    } catch (error) {
+      this.throwProviderError(error, provider);
+    }
+  }
+
+  async disconnectRepo(input: DisconnectRepoInput): Promise<void> {
+    const connectedRepo = await this.prisma.connectedRepo.findFirst({
+      where: {
+        id: input.repoId,
+        userId: input.userId
+      }
+    });
+
+    if (!connectedRepo) {
+      throw new NotFoundException({
+        message: 'Connected repository not found.',
+        errorCode: 'REPO_NOT_FOUND'
+      });
+    }
+
+    await this.prisma.connectedRepo.delete({
+      where: { id: input.repoId }
+    });
+  }
+
+  private async resolveProviderClient(userId: string, provider: Provider) {
+    const providerEnum = this.toRepoProvider(provider);
+    const persistedToken = await this.prisma.oAuthToken.findFirst({
+      where: {
+        userId,
+        provider: providerEnum
+      }
+    });
+
+    if (!persistedToken) {
+      throw new ForbiddenException({
+        message: 'Provider account is not connected.',
+        errorCode: 'PROVIDER_NOT_CONNECTED'
+      });
+    }
+
+    return {
+      providerEnum,
+      client: this.gitClients.get(provider),
+      accessToken: this.tokenCrypto.decrypt(persistedToken.accessToken)
+    };
+  }
+
+  private toRepoProvider(provider: Provider): RepoProvider {
+    return provider === 'github' ? RepoProvider.GITHUB : RepoProvider.GITLAB;
+  }
+
+  private fromRepoProvider(provider: RepoProvider): Provider {
+    return provider.toLowerCase() as Provider;
+  }
+
+  private throwProviderError(error: unknown, provider: Provider): never {
+    if (error instanceof GitProviderUnauthorizedError) {
+      throw new ForbiddenException({
+        message: `${provider} provider token is invalid or expired.`,
+        errorCode: 'PROVIDER_TOKEN_INVALID'
+      });
+    }
+
+    if (error instanceof GitProviderNotFoundError) {
+      throw new NotFoundException({
+        message: `${provider} repository resource was not found.`,
+        errorCode: 'PROVIDER_RESOURCE_NOT_FOUND'
+      });
+    }
+
+    if (error instanceof GitProviderRateLimitError) {
+      throw new HttpException(
+        {
+          message: `${provider} provider rate limit exceeded.`,
+          errorCode: 'PROVIDER_RATE_LIMITED'
+        },
+        429
+      );
+    }
+
+    if (error instanceof GitProviderUnavailableError) {
+      throw new ServiceUnavailableException({
+        message: `${provider} provider is unavailable.`,
+        errorCode: 'PROVIDER_UNAVAILABLE'
+      });
+    }
+
+    throw error;
+  }
+}

--- a/apps/api/test/client/git/github.client.e2e-spec.ts
+++ b/apps/api/test/client/git/github.client.e2e-spec.ts
@@ -92,6 +92,39 @@ describe('GithubClient', () => {
     });
   });
 
+  it('loads repository metadata directly by provider repo id', async () => {
+    const http = createHttpService();
+    http.get.mockReturnValueOnce(
+      of(
+        createAxiosResponse({
+          id: 101,
+          full_name: 'aegisai/platform',
+          clone_url: 'https://github.com/aegisai/platform.git',
+          default_branch: 'main',
+          private: true
+        })
+      )
+    );
+    const client = new GithubClient(http as never);
+
+    await expect(client.getRepository('101', 'github-token')).resolves.toEqual({
+      providerRepoId: '101',
+      fullName: 'aegisai/platform',
+      cloneUrl: 'https://github.com/aegisai/platform.git',
+      defaultBranch: 'main',
+      isPrivate: true
+    });
+
+    expect(http.get).toHaveBeenCalledWith(
+      'https://api.github.com/repositories/101',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer github-token'
+        })
+      })
+    );
+  });
+
   it('decodes repository file contents from GitHub base64 payloads', async () => {
     const http = createHttpService();
     http.get.mockReturnValueOnce(

--- a/apps/api/test/client/git/gitlab.client.e2e-spec.ts
+++ b/apps/api/test/client/git/gitlab.client.e2e-spec.ts
@@ -68,6 +68,39 @@ describe('GitlabClient', () => {
     ]);
   });
 
+  it('loads repository metadata directly by provider repo id', async () => {
+    const http = createHttpService();
+    http.get.mockReturnValueOnce(
+      of(
+        createAxiosResponse({
+          id: 55,
+          path_with_namespace: 'aegisai/platform',
+          http_url_to_repo: 'https://gitlab.com/aegisai/platform.git',
+          default_branch: 'main',
+          visibility: 'private'
+        })
+      )
+    );
+    const client = new GitlabClient(http as never);
+
+    await expect(client.getRepository('55', 'gitlab-token')).resolves.toEqual({
+      providerRepoId: '55',
+      fullName: 'aegisai/platform',
+      cloneUrl: 'https://gitlab.com/aegisai/platform.git',
+      defaultBranch: 'main',
+      isPrivate: true
+    });
+
+    expect(http.get).toHaveBeenCalledWith(
+      'https://gitlab.com/api/v4/projects/55',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer gitlab-token'
+        })
+      })
+    );
+  });
+
   it('fetches raw file contents from GitLab', async () => {
     const http = createHttpService();
     http.get.mockReturnValueOnce(of(createAxiosResponse('class Main {}')));

--- a/apps/api/test/repo/repo.e2e-spec.ts
+++ b/apps/api/test/repo/repo.e2e-spec.ts
@@ -1,0 +1,266 @@
+import type { AuthUser } from '@aegisai/shared';
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+class MockSessionAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ user?: AuthUser }>();
+
+    request.user = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: null,
+      connectedProviders: ['github', 'gitlab']
+    };
+
+    return true;
+  }
+}
+
+describe('RepoController (e2e)', () => {
+  let app: INestApplication;
+  const repoService = {
+    listConnectedRepos: jest.fn(),
+    listAvailableRepos: jest.fn(),
+    connectRepo: jest.fn(),
+    disconnectRepo: jest.fn(),
+    listBranches: jest.fn()
+  };
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.PORT = '3000';
+    process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/aegisai';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.SESSION_SECRET = 'test-session-secret-value';
+    process.env.CSRF_SECRET = 'test-csrf-secret-value';
+    process.env.GITHUB_CLIENT_ID = 'github-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'github-client-secret';
+    process.env.GITLAB_CLIENT_ID = 'gitlab-client-id';
+    process.env.GITLAB_CLIENT_SECRET = 'gitlab-client-secret';
+    process.env.APP_URL = 'http://localhost:3000';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+    process.env.SESSION_COOKIE_NAME = 'connect.sid';
+    process.env.CSRF_COOKIE_NAME = 'csrf_token';
+    process.env.COOKIE_DOMAIN = '';
+    process.env.TOKEN_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    process.env.ANALYSIS_CLIENT_MODE = 'mock';
+    process.env.AI_SERVER_URL = 'http://localhost:8000';
+    process.env.USE_INTERNAL_AI = 'false';
+    process.env.INTERNAL_API_SECRET = '';
+    process.env.GITHUB_APP_WEBHOOK_SECRET = '';
+    process.env.GITLAB_WEBHOOK_SECRET = '';
+    process.env.REPORT_STORAGE_PATH = './tmp/reports';
+    process.env.REPORT_EXPIRY_HOURS = '24';
+
+    const [{ AppModule }, { configureApp }, { PrismaService }, { SessionAuthGuard }, { RepoService }] =
+      await Promise.all([
+        import('../../src/app.module'),
+        import('../../src/bootstrap/configure-app'),
+        import('../../src/prisma/prisma.service'),
+        import('../../src/auth/guards/session-auth.guard'),
+        import('../../src/repo/repo.service')
+      ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .overrideGuard(SessionAuthGuard)
+      .useClass(MockSessionAuthGuard)
+      .overrideProvider(RepoService)
+      .useValue(repoService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await configureApp(app);
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('returns wrapped connected repositories from GET /api/repos', async () => {
+    repoService.listConnectedRepos.mockResolvedValue([
+      {
+        id: 'repo-1',
+        provider: 'github',
+        fullName: 'acme/service',
+        cloneUrl: 'https://github.com/acme/service.git',
+        defaultBranch: 'main',
+        isPrivate: true,
+        lastScanAt: null,
+        lastScanStatus: null
+      }
+    ]);
+
+    await request(app.getHttpServer())
+      .get('/api/repos')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: [
+            {
+              id: 'repo-1',
+              provider: 'github',
+              fullName: 'acme/service'
+            }
+          ],
+          message: null
+        });
+        expect(body.timestamp).toEqual(expect.any(String));
+      });
+
+    expect(repoService.listConnectedRepos).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns wrapped available repositories from GET /api/repos/available', async () => {
+    repoService.listAvailableRepos.mockResolvedValue({
+      items: [
+        {
+          providerRepoId: '101',
+          fullName: 'acme/service',
+          cloneUrl: 'https://github.com/acme/service.git',
+          defaultBranch: 'main',
+          isPrivate: true,
+          alreadyConnected: false
+        }
+      ],
+      page: 2,
+      size: 10,
+      hasNextPage: true,
+      nextPage: 3
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/repos/available')
+      .query({ provider: 'github', page: 2, size: 10 })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            items: [
+              {
+                providerRepoId: '101',
+                fullName: 'acme/service'
+              }
+            ],
+            page: 2,
+            size: 10,
+            hasNextPage: true,
+            nextPage: 3
+          },
+          message: null
+        });
+      });
+
+    expect(repoService.listAvailableRepos).toHaveBeenCalledWith({
+      userId: 'user-1',
+      provider: 'github',
+      page: 2,
+      size: 10
+    });
+  });
+
+  it('returns 201 from POST /api/repos and wraps the connected repo summary', async () => {
+    repoService.connectRepo.mockResolvedValue({
+      id: 'repo-1',
+      fullName: 'acme/service',
+      connectedAt: '2026-03-23T09:00:00.000Z'
+    });
+
+    await request(app.getHttpServer())
+      .post('/api/repos')
+      .send({
+        provider: 'github',
+        providerRepoId: '101'
+      })
+      .expect(201)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            id: 'repo-1',
+            fullName: 'acme/service',
+            connectedAt: '2026-03-23T09:00:00.000Z'
+          },
+          message: null
+        });
+      });
+
+    expect(repoService.connectRepo).toHaveBeenCalledWith({
+      userId: 'user-1',
+      provider: 'github',
+      providerRepoId: '101'
+    });
+  });
+
+  it('returns raw 204 from DELETE /api/repos/:repoId', async () => {
+    repoService.disconnectRepo.mockResolvedValue(undefined);
+
+    await request(app.getHttpServer()).delete('/api/repos/repo-1').expect(204).expect('');
+
+    expect(repoService.disconnectRepo).toHaveBeenCalledWith({
+      userId: 'user-1',
+      repoId: 'repo-1'
+    });
+  });
+
+  it('returns wrapped branch pages from GET /api/repos/:repoId/branches', async () => {
+    repoService.listBranches.mockResolvedValue({
+      items: [{ name: 'main', isDefault: true, lastCommitSha: 'sha-main' }],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/repos/repo-1/branches')
+      .query({ page: 1, size: 30 })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            items: [{ name: 'main', isDefault: true, lastCommitSha: 'sha-main' }],
+            page: 1,
+            size: 30,
+            hasNextPage: false,
+            nextPage: null
+          },
+          message: null
+        });
+      });
+
+    expect(repoService.listBranches).toHaveBeenCalledWith({
+      userId: 'user-1',
+      repoId: 'repo-1',
+      page: 1,
+      size: 30
+    });
+  });
+});

--- a/apps/api/test/repo/repo.service.e2e-spec.ts
+++ b/apps/api/test/repo/repo.service.e2e-spec.ts
@@ -1,0 +1,391 @@
+import type { Provider } from '@aegisai/shared';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import { GitProviderRateLimitError } from '../../src/client/git/git-provider-client.errors';
+import type { IGitProviderClient } from '../../src/client/git/git-provider-client.interface';
+import { RepoService } from '../../src/repo/repo.service';
+
+describe('RepoService', () => {
+  it('lists connected repositories with latest scan metadata', async () => {
+    const lastScanAt = new Date('2026-03-23T01:02:03.000Z');
+    const prisma = {
+      connectedRepo: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'repo-1',
+            provider: 'GITHUB',
+            fullName: 'acme/service',
+            cloneUrl: 'https://github.com/acme/service.git',
+            defaultBranch: 'main',
+            isPrivate: true,
+            scans: [{ createdAt: lastScanAt, status: 'DONE' }]
+          }
+        ])
+      }
+    };
+    const service = new RepoService(prisma as never, {} as never, {} as never);
+
+    await expect(service.listConnectedRepos('user-1')).resolves.toEqual([
+      {
+        id: 'repo-1',
+        provider: 'github',
+        fullName: 'acme/service',
+        cloneUrl: 'https://github.com/acme/service.git',
+        defaultBranch: 'main',
+        isPrivate: true,
+        lastScanAt: lastScanAt.toISOString(),
+        lastScanStatus: 'DONE'
+      }
+    ]);
+
+    expect(prisma.connectedRepo.findMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      include: {
+        scans: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: {
+            createdAt: true,
+            status: true
+          }
+        }
+      },
+      orderBy: {
+        connectedAt: 'desc'
+      }
+    });
+  });
+
+  it('lists available repositories for a connected provider and marks already connected repos', async () => {
+    const prisma = {
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'encrypted-token'
+        })
+      },
+      connectedRepo: {
+        findMany: jest.fn().mockResolvedValue([{ providerRepoId: '101' }])
+      }
+    };
+    const client = createGitProviderClient({
+      getRepositories: jest.fn().mockResolvedValue({
+        items: [
+          {
+            providerRepoId: '101',
+            fullName: 'acme/service',
+            cloneUrl: 'https://github.com/acme/service.git',
+            defaultBranch: 'main',
+            isPrivate: true
+          },
+          {
+            providerRepoId: '102',
+            fullName: 'acme/platform',
+            cloneUrl: 'https://github.com/acme/platform.git',
+            defaultBranch: 'develop',
+            isPrivate: false
+          }
+        ],
+        hasNextPage: true
+      })
+    });
+    const registry = {
+      get: jest.fn().mockReturnValue(client)
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('github-token')
+    };
+    const service = new RepoService(prisma as never, registry as never, tokenCrypto as never);
+
+    await expect(
+      service.listAvailableRepos({
+        userId: 'user-1',
+        provider: 'github',
+        page: 2,
+        size: 10
+      })
+    ).resolves.toEqual({
+      items: [
+        {
+          providerRepoId: '101',
+          fullName: 'acme/service',
+          cloneUrl: 'https://github.com/acme/service.git',
+          defaultBranch: 'main',
+          isPrivate: true,
+          alreadyConnected: true
+        },
+        {
+          providerRepoId: '102',
+          fullName: 'acme/platform',
+          cloneUrl: 'https://github.com/acme/platform.git',
+          defaultBranch: 'develop',
+          isPrivate: false,
+          alreadyConnected: false
+        }
+      ],
+      page: 2,
+      size: 10,
+      hasNextPage: true,
+      nextPage: 3
+    });
+
+    expect(registry.get).toHaveBeenCalledWith('github');
+    expect(client.getRepositories).toHaveBeenCalledWith('github-token', 2, 10);
+  });
+
+  it('connects a repository by provider repo id after loading provider metadata', async () => {
+    const connectedAt = new Date('2026-03-23T09:00:00.000Z');
+    const prisma = {
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'encrypted-token'
+        })
+      },
+      connectedRepo: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({
+          id: 'connected-1',
+          fullName: 'acme/service',
+          connectedAt
+        })
+      }
+    };
+    const client = createGitProviderClient({
+      getRepository: jest.fn().mockResolvedValue({
+        providerRepoId: '101',
+        fullName: 'acme/service',
+        cloneUrl: 'https://github.com/acme/service.git',
+        defaultBranch: 'main',
+        isPrivate: true
+      })
+    });
+    const registry = {
+      get: jest.fn().mockReturnValue(client)
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('github-token')
+    };
+    const service = new RepoService(prisma as never, registry as never, tokenCrypto as never);
+
+    await expect(
+      service.connectRepo({
+        userId: 'user-1',
+        provider: 'github',
+        providerRepoId: '101'
+      })
+    ).resolves.toEqual({
+      id: 'connected-1',
+      fullName: 'acme/service',
+      connectedAt: connectedAt.toISOString()
+    });
+
+    expect(client.getRepository).toHaveBeenCalledWith('101', 'github-token');
+    expect(prisma.connectedRepo.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        provider: 'GITHUB',
+        providerRepoId: '101',
+        fullName: 'acme/service',
+        cloneUrl: 'https://github.com/acme/service.git',
+        defaultBranch: 'main',
+        isPrivate: true
+      }
+    });
+  });
+
+  it('rejects duplicate repository connections for the same user and provider repo id', async () => {
+    const prisma = {
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'encrypted-token'
+        })
+      },
+      connectedRepo: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'connected-1'
+        })
+      }
+    };
+    const service = new RepoService(
+      prisma as never,
+      { get: jest.fn() } as never,
+      { decrypt: jest.fn() } as never
+    );
+
+    await expect(
+      service.connectRepo({
+        userId: 'user-1',
+        provider: 'github',
+        providerRepoId: '101'
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('lists branches for a connected repository owned by the user', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'repo-1',
+          userId: 'user-1',
+          provider: 'GITHUB',
+          fullName: 'acme/service'
+        })
+      },
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'encrypted-token'
+        })
+      }
+    };
+    const client = createGitProviderClient({
+      getBranches: jest.fn().mockResolvedValue({
+        items: [
+          { name: 'main', isDefault: true, lastCommitSha: 'sha-main' },
+          { name: 'feature/repo', isDefault: false, lastCommitSha: 'sha-feature' }
+        ],
+        hasNextPage: false
+      })
+    });
+    const registry = {
+      get: jest.fn().mockReturnValue(client)
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('github-token')
+    };
+    const service = new RepoService(prisma as never, registry as never, tokenCrypto as never);
+
+    await expect(
+      service.listBranches({
+        userId: 'user-1',
+        repoId: 'repo-1',
+        page: 1,
+        size: 30
+      })
+    ).resolves.toEqual({
+      items: [
+        { name: 'main', isDefault: true, lastCommitSha: 'sha-main' },
+        { name: 'feature/repo', isDefault: false, lastCommitSha: 'sha-feature' }
+      ],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null
+    });
+  });
+
+  it('throws when the requested provider is not connected for the user', async () => {
+    const prisma = {
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue(null)
+      }
+    };
+    const service = new RepoService(
+      prisma as never,
+      { get: jest.fn() } as never,
+      { decrypt: jest.fn() } as never
+    );
+
+    await expect(
+      service.listAvailableRepos({
+        userId: 'user-1',
+        provider: 'gitlab',
+        page: 1,
+        size: 30
+      })
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('maps provider rate limits into API throttling errors', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'repo-1',
+          userId: 'user-1',
+          provider: 'GITHUB',
+          fullName: 'acme/service'
+        })
+      },
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'encrypted-token'
+        })
+      }
+    };
+    const client = createGitProviderClient({
+      getBranches: jest.fn().mockRejectedValue(
+        new GitProviderRateLimitError('Rate limited', 'github', 429, 1711111111)
+      )
+    });
+    const service = new RepoService(
+      prisma as never,
+      { get: jest.fn().mockReturnValue(client) } as never,
+      { decrypt: jest.fn().mockReturnValue('github-token') } as never
+    );
+
+    await expect(
+      service
+        .listBranches({
+          userId: 'user-1',
+          repoId: 'repo-1',
+          page: 1,
+          size: 30
+        })
+        .catch((error: { getStatus: () => number }) => error.getStatus())
+    ).resolves.toBe(429);
+  });
+
+  it('deletes a connected repository owned by the user', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'repo-1',
+          userId: 'user-1'
+        }),
+        delete: jest.fn().mockResolvedValue(undefined)
+      }
+    };
+    const service = new RepoService(prisma as never, {} as never, {} as never);
+
+    await expect(
+      service.disconnectRepo({
+        userId: 'user-1',
+        repoId: 'repo-1'
+      })
+    ).resolves.toBeUndefined();
+
+    expect(prisma.connectedRepo.delete).toHaveBeenCalledWith({
+      where: { id: 'repo-1' }
+    });
+  });
+
+  it('throws when disconnecting an unknown connected repository', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue(null)
+      }
+    };
+    const service = new RepoService(prisma as never, {} as never, {} as never);
+
+    await expect(
+      service.disconnectRepo({
+        userId: 'user-1',
+        repoId: 'missing-repo'
+      })
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});
+
+function createGitProviderClient(
+  overrides: Partial<jest.Mocked<IGitProviderClient>> = {}
+): jest.Mocked<IGitProviderClient> {
+  return {
+    provider: 'github' as Provider,
+    getRepositories: jest.fn(),
+    getRepository: jest.fn(),
+    getBranches: jest.fn(),
+    getLatestCommitSha: jest.fn(),
+    getFileTree: jest.fn(),
+    getFileContent: jest.fn(),
+    collectByTarball: jest.fn(),
+    ...overrides
+  };
+}

--- a/docs/superpowers/plans/2026-03-23-repository-service-controller.md
+++ b/docs/superpowers/plans/2026-03-23-repository-service-controller.md
@@ -1,0 +1,56 @@
+# Repository Service and Controller Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the repository backend flows that let a signed-in user browse provider repos, connect one, inspect branches, list connected repos, and disconnect it.
+
+**Architecture:** Keep provider API concerns behind `GitClientRegistry` and extend that abstraction with a direct repository lookup needed for connection. Implement repository behavior in a focused `RepoService` and surface it through a thin `RepoController` that relies on the existing auth/session and global middleware stack.
+
+**Tech Stack:** NestJS 10, Prisma, provider HTTP clients, Jest, Supertest
+
+---
+
+### Task 1: Lock repository behavior with tests
+
+**Files:**
+- Create: `apps/api/test/repo/repo.service.e2e-spec.ts`
+- Create: `apps/api/test/repo/repo.e2e-spec.ts`
+
+- [ ] Write failing service tests for connected repo mapping, available repo lookup, duplicate connect prevention, branch listing, and disconnect behavior.
+- [ ] Write failing controller/e2e tests for `GET /api/repos`, `GET /api/repos/available`, `POST /api/repos`, `DELETE /api/repos/:repoId`, and `GET /api/repos/:repoId/branches`.
+- [ ] Run the targeted repo tests and verify the failures are caused by missing repo module behavior.
+
+### Task 2: Extend provider client capabilities and shared contracts
+
+**Files:**
+- Modify: `apps/api/src/client/git/git-provider-client.interface.ts`
+- Modify: `apps/api/src/client/git/github.client.ts`
+- Modify: `apps/api/src/client/git/gitlab.client.ts`
+- Modify: `apps/api/test/client/git/github.client.e2e-spec.ts`
+- Modify: `apps/api/test/client/git/gitlab.client.e2e-spec.ts`
+- Modify: `packages/shared/src/types/repo.ts`
+
+- [ ] Add a direct repository metadata lookup to the provider client interface.
+- [ ] Implement the lookup in GitHub and GitLab clients with failing tests first.
+- [ ] Add any shared repo request/query contract types needed by the new controller surface.
+
+### Task 3: Implement the repository module
+
+**Files:**
+- Create: `apps/api/src/repo/repo.module.ts`
+- Create: `apps/api/src/repo/repo.service.ts`
+- Create: `apps/api/src/repo/repo.controller.ts`
+- Modify: `apps/api/src/app.module.ts`
+
+- [ ] Implement token resolution, provider client access, connected repo queries, and exception mapping in `RepoService`.
+- [ ] Implement authenticated endpoints and query parsing in `RepoController`.
+- [ ] Register `RepoModule` in `AppModule`.
+
+### Task 4: Verify and finish
+
+**Files:**
+- Verify touched repo/client/shared files above
+
+- [ ] Re-run targeted repo/client tests and confirm green.
+- [ ] Re-run workspace `lint`, `test`, `typecheck`, and `build`.
+- [ ] Commit with `feat: implement repository service and controller` and prepare the PR template after fresh verification.

--- a/docs/superpowers/specs/2026-03-23-repository-service-controller-design.md
+++ b/docs/superpowers/specs/2026-03-23-repository-service-controller-design.md
@@ -1,0 +1,68 @@
+# Repository Service and Controller Design
+
+## Goal
+
+Implement the authenticated repository endpoints needed for the MVP connect-and-scan flow:
+listing connected repositories, listing provider repositories, connecting a repository,
+disconnecting a repository, and listing branches for a connected repository.
+
+## Scope
+
+- Add `RepoModule`, `RepoService`, and `RepoController`.
+- Expose `GET /api/repos`, `GET /api/repos/available`, `POST /api/repos`,
+  `DELETE /api/repos/:repoId`, and `GET /api/repos/:repoId/branches`.
+- Resolve provider access tokens from persisted OAuth tokens and decrypt them before calling
+  provider clients.
+- Extend the git provider client interface with a direct repository metadata lookup used by
+  `POST /api/repos`.
+- Keep scan request/status endpoints out of scope for this issue.
+
+## Design
+
+### API shape
+
+`GET /api/repos` returns connected repositories for the signed-in user, including the latest scan
+timestamp and status when available. `GET /api/repos/available` follows the provider-scoped shape
+from `spec 2.2.md`: `provider` is required and `page`/`size` are cursor-style pagination inputs.
+`POST /api/repos` connects a repository by `provider` + `providerRepoId`, `DELETE /api/repos/:repoId`
+returns `204 No Content`, and `GET /api/repos/:repoId/branches` returns provider branches for a
+connected repository.
+
+### Service responsibilities
+
+`RepoService` owns five flows:
+
+- `listConnectedRepos`
+- `listAvailableRepos`
+- `listBranches`
+- `connectRepo`
+- `disconnectRepo`
+
+The service will fetch the user/provider OAuth token from Prisma, decrypt it with
+`TokenCryptoUtil`, resolve the correct provider client from `GitClientRegistry`, and map provider
+client errors into HTTP/domain exceptions.
+
+### Provider integration
+
+The current provider client abstraction can list repositories, but `POST /api/repos` needs an
+exact repository lookup by `providerRepoId`. This issue extends `IGitProviderClient` with a
+`getRepository` operation and implements it in both GitHub and GitLab clients so connection logic
+does not depend on paginating through list endpoints.
+
+### Validation and errors
+
+- Unsupported or missing `provider` query/body values return `400`.
+- Missing provider connection for the requested provider returns `403`.
+- Unknown connected repositories return `404`.
+- Duplicate repository connections return `409`.
+- Provider 401/404/429/unavailable errors are normalized into structured API errors through the
+  existing global exception filter.
+
+## Testing Strategy
+
+- Add service-level tests for token resolution, provider mapping, branch listing, duplicate
+  prevention, and disconnect behavior.
+- Add e2e coverage for the repository endpoints through the actual controller/runtime path,
+  including wrapped success responses and raw `204` disconnect behavior.
+- Update shared repo contracts only where the runtime endpoints need additional request/query
+  shapes for frontend integration.

--- a/packages/shared/src/types/repo.ts
+++ b/packages/shared/src/types/repo.ts
@@ -32,6 +32,17 @@ export interface ConnectRepoRequest {
   providerRepoId: string;
 }
 
+export interface ListAvailableReposQuery {
+  provider: Provider;
+  page?: number;
+  size?: number;
+}
+
+export interface ListRepoBranchesQuery {
+  page?: number;
+  size?: number;
+}
+
 export interface ConnectRepoResponse {
   id: string;
   fullName: string;


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/60-repository-service-controller`
- 이슈: `#60`

## 🔎 주요 변경 사항

- `apps/api/src/repo/` 아래에 `RepoModule`, `RepoService`, `RepoController`를 추가했습니다.
- `GET /api/repos`, `GET /api/repos/available`, `POST /api/repos`, `DELETE /api/repos/:repoId`, `GET /api/repos/:repoId/branches` 엔드포인트를 구현했습니다.
- OAuth 토큰을 조회하고 복호화한 뒤 `GitClientRegistry`를 통해 provider client를 사용하는 repository service 흐름을 구성했습니다.
- duplicate repository connect를 `409 Conflict`로 막고, provider token 미연결/만료, not found, rate limit, provider unavailable 에러를 구조화된 API 에러로 매핑했습니다.
- `IGitProviderClient`에 direct repository metadata lookup을 추가하고 GitHub/GitLab client 구현과 테스트를 확장했습니다.
- shared repo contract에 available repo/branch query 타입을 추가했습니다.
- AppModule에 `RepoModule`을 연결했습니다.
- repository service/controller와 provider client 회귀 테스트를 추가했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository management API for authenticated users: list connected repositories, discover available repositories from provider accounts, connect and disconnect repositories with duplicate-connection safeguards, and view repository branches with pagination support
  * Extended Git provider client interface enabling direct repository metadata lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->