### PR TITLE
Feat: scan controller request and status endpoints 구현

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,7 +19,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { RepoModule } from './repo/repo.module';
 import { ScanModule } from './scan/scan.module';
 
-const runtimeFeatureModules = process.env.NODE_ENV === 'test' ? [HealthModule] : [ScanModule, HealthModule];
+const runtimeFeatureModules = [ScanModule, HealthModule];
 
 @Module({
   imports: [

--- a/apps/api/src/scan/scan.controller.ts
+++ b/apps/api/src/scan/scan.controller.ts
@@ -1,0 +1,91 @@
+import type { AuthUser, ListRepoScansQuery, ScanRequestBody } from '@aegisai/shared';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards
+} from '@nestjs/common';
+
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SessionAuthGuard } from '../auth/guards/session-auth.guard';
+import { ScanService } from './scan.service';
+
+@Controller()
+@UseGuards(SessionAuthGuard)
+export class ScanController {
+  constructor(private readonly scanService: ScanService) {}
+
+  @Post('scans')
+  @HttpCode(202)
+  async requestScan(@CurrentUser() user: AuthUser, @Body() body: Partial<ScanRequestBody>) {
+    const repoId = body.repoId?.trim();
+    const branch = body.branch?.trim();
+
+    if (!repoId) {
+      throw new BadRequestException({
+        message: 'repoId is required.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    if (!branch) {
+      throw new BadRequestException({
+        message: 'branch is required.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    return this.scanService.createScan({
+      userId: user.id,
+      connectedRepoId: repoId,
+      branch
+    });
+  }
+
+  @Get('scans/:scanId')
+  async getScanDetail(@CurrentUser() user: AuthUser, @Param('scanId') scanId: string) {
+    return this.scanService.getScanDetail(user.id, scanId);
+  }
+
+  @Get('repos/:repoId/scans')
+  async listRepoScans(
+    @CurrentUser() user: AuthUser,
+    @Param('repoId') repoId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('size', new DefaultValuePipe(10), ParseIntPipe) size: number
+  ) {
+    return this.scanService.listRepoScans({
+      userId: user.id,
+      repoId,
+      ...this.normalizePagination({ repoId, page, size })
+    });
+  }
+
+  private normalizePagination(input: ListRepoScansQuery) {
+    if (!input.page || input.page < 1) {
+      throw new BadRequestException({
+        message: 'page must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    if (!input.size || input.size < 1) {
+      throw new BadRequestException({
+        message: 'size must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    return {
+      page: input.page,
+      size: input.size
+    };
+  }
+}

--- a/apps/api/src/scan/scan.module.ts
+++ b/apps/api/src/scan/scan.module.ts
@@ -1,29 +1,53 @@
-import { BullModule } from '@nestjs/bullmq';
+import { BullModule, getQueueToken } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 
 import { AuthModule } from '../auth/auth.module';
 import { AnalysisApiModule } from '../client/analysis/analysis-api.module';
 import { GitClientModule } from '../client/git/git-client.module';
+import { ConfigModule } from '../config/config.module';
 import { LanguageModule } from '../language/language.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { SCAN_QUEUE } from './scan.constants';
+import { ScanController } from './scan.controller';
 import { ScanProcessor } from './scan.processor';
 import { ScanService } from './scan.service';
 import { CodeCollectorService } from './services/code-collector.service';
 import { StuckScanRecoveryTask } from './stuck-scan-recovery.task';
 
+const runtimeProviders =
+  process.env.NODE_ENV === 'test' ? [] : [ScanProcessor, StuckScanRecoveryTask];
+const queueImports =
+  process.env.NODE_ENV === 'test'
+    ? []
+    : [
+        BullModule.registerQueue({
+          name: SCAN_QUEUE
+        })
+      ];
+const queueProviders =
+  process.env.NODE_ENV === 'test'
+    ? [
+        {
+          provide: getQueueToken(SCAN_QUEUE),
+          useValue: {
+            add: async () => undefined
+          }
+        }
+      ]
+    : [];
+
 @Module({
   imports: [
-    BullModule.registerQueue({
-      name: SCAN_QUEUE
-    }),
+    ...queueImports,
     PrismaModule,
     AuthModule,
+    ConfigModule,
     GitClientModule,
     LanguageModule,
     AnalysisApiModule
   ],
-  providers: [ScanService, ScanProcessor, CodeCollectorService, StuckScanRecoveryTask],
+  controllers: [ScanController],
+  providers: [ScanService, CodeCollectorService, ...runtimeProviders, ...queueProviders],
   exports: [ScanService]
 })
 export class ScanModule {}

--- a/apps/api/src/scan/scan.service.ts
+++ b/apps/api/src/scan/scan.service.ts
@@ -1,9 +1,31 @@
-import type { ScanRequestResponse } from '@aegisai/shared';
+import type {
+  Provider,
+  RepoScanListResponse,
+  ScanDetail,
+  ScanRequestResponse,
+  ScanSummary
+} from '@aegisai/shared';
 import { InjectQueue } from '@nestjs/bullmq';
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { ScanStatus } from '@prisma/client';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  HttpException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException
+} from '@nestjs/common';
+import { RepoProvider, ScanStatus } from '@prisma/client';
 import type { Queue } from 'bullmq';
 
+import {
+  GitProviderNotFoundError,
+  GitProviderRateLimitError,
+  GitProviderUnauthorizedError,
+  GitProviderUnavailableError
+} from '../client/git/git-provider-client.errors';
+import { GitClientRegistry } from '../client/git/git-client.registry';
+import { TokenCryptoUtil } from '../auth/utils/token-crypto.util';
 import { PrismaService } from '../prisma/prisma.service';
 import { SCAN_PROCESS_JOB, SCAN_QUEUE } from './scan.constants';
 
@@ -14,41 +36,53 @@ interface CreateScanInput {
   language?: string;
 }
 
+interface ListRepoScansInput {
+  userId: string;
+  repoId: string;
+  page: number;
+  size: number;
+}
+
 @Injectable()
 export class ScanService {
   constructor(
     private readonly prisma: PrismaService,
-    @InjectQueue(SCAN_QUEUE) private readonly scanQueue: Queue
+    @InjectQueue(SCAN_QUEUE) private readonly scanQueue: Queue,
+    private readonly gitClients: GitClientRegistry,
+    private readonly tokenCrypto: TokenCryptoUtil
   ) {}
 
   async createScan(input: CreateScanInput): Promise<ScanRequestResponse> {
-    const connectedRepo = await this.prisma.connectedRepo.findFirst({
-      where: {
-        id: input.connectedRepoId,
-        userId: input.userId
-      }
-    });
-
-    if (!connectedRepo) {
-      throw new NotFoundException('Connected repository not found');
+    const branch = input.branch.trim();
+    if (!branch) {
+      throw new BadRequestException({
+        message: 'branch is required.',
+        errorCode: 'BAD_REQUEST'
+      });
     }
+
+    const connectedRepo = await this.getOwnedRepo(input.userId, input.connectedRepoId);
+    await this.assertBranchExists(input.userId, connectedRepo.provider, connectedRepo.fullName, branch);
 
     const existingScan = await this.prisma.scan.findFirst({
       where: {
         connectedRepoId: input.connectedRepoId,
-        branch: input.branch,
+        branch,
         status: { in: [ScanStatus.PENDING, ScanStatus.RUNNING] }
       }
     });
 
     if (existingScan) {
-      throw new ConflictException('An active scan already exists for this repository branch');
+      throw new ConflictException({
+        message: 'An active scan already exists for this repository branch.',
+        errorCode: 'SCAN_ALREADY_ACTIVE'
+      });
     }
 
     const scan = await this.prisma.scan.create({
       data: {
         connectedRepoId: input.connectedRepoId,
-        branch: input.branch,
+        branch,
         language: input.language ?? 'java',
         status: ScanStatus.PENDING
       }
@@ -60,6 +94,193 @@ export class ScanService {
       scanId: scan.id,
       status: 'PENDING',
       message: 'Scan queued successfully.'
+    };
+  }
+
+  async getScanDetail(userId: string, scanId: string): Promise<ScanDetail> {
+    const scan = await this.prisma.scan.findFirst({
+      where: {
+        id: scanId,
+        connectedRepo: {
+          userId
+        }
+      },
+      include: {
+        connectedRepo: {
+          select: {
+            fullName: true
+          }
+        }
+      }
+    });
+
+    if (!scan) {
+      throw new NotFoundException({
+        message: 'Scan not found.',
+        errorCode: 'SCAN_NOT_FOUND'
+      });
+    }
+
+    return this.toScanSummary(scan);
+  }
+
+  async listRepoScans(input: ListRepoScansInput): Promise<RepoScanListResponse> {
+    await this.getOwnedRepo(input.userId, input.repoId);
+
+    const skip = (input.page - 1) * input.size;
+    const [totalCount, scans] = await Promise.all([
+      this.prisma.scan.count({
+        where: {
+          connectedRepoId: input.repoId
+        }
+      }),
+      this.prisma.scan.findMany({
+        where: {
+          connectedRepoId: input.repoId
+        },
+        include: {
+          connectedRepo: {
+            select: {
+              fullName: true
+            }
+          }
+        },
+        orderBy: {
+          createdAt: 'desc'
+        },
+        skip,
+        take: input.size
+      })
+    ]);
+
+    return {
+      items: scans.map((scan) => this.toScanSummary(scan)),
+      totalCount,
+      page: input.page,
+      totalPages: Math.max(1, Math.ceil(totalCount / input.size))
+    };
+  }
+
+  private async getOwnedRepo(userId: string, repoId: string) {
+    const connectedRepo = await this.prisma.connectedRepo.findFirst({
+      where: {
+        id: repoId,
+        userId
+      }
+    });
+
+    if (!connectedRepo) {
+      throw new NotFoundException({
+        message: 'Connected repository not found.',
+        errorCode: 'REPO_NOT_FOUND'
+      });
+    }
+
+    return connectedRepo;
+  }
+
+  private async assertBranchExists(
+    userId: string,
+    providerEnum: RepoProvider,
+    fullName: string,
+    branch: string
+  ): Promise<void> {
+    const provider = providerEnum.toLowerCase() as Provider;
+    const persistedToken = await this.prisma.oAuthToken.findFirst({
+      where: {
+        userId,
+        provider: providerEnum
+      }
+    });
+
+    if (!persistedToken) {
+      throw new ForbiddenException({
+        message: 'Provider account is not connected.',
+        errorCode: 'PROVIDER_NOT_CONNECTED'
+      });
+    }
+
+    const accessToken = this.tokenCrypto.decrypt(persistedToken.accessToken);
+
+    try {
+      await this.gitClients.get(provider).getLatestCommitSha(fullName, branch, accessToken);
+    } catch (error) {
+      if (error instanceof GitProviderNotFoundError) {
+        throw new BadRequestException({
+          message: 'Requested branch was not found for the connected repository.',
+          errorCode: 'BRANCH_NOT_FOUND'
+        });
+      }
+
+      if (error instanceof GitProviderUnauthorizedError) {
+        throw new ForbiddenException({
+          message: `${provider} provider token is invalid or expired.`,
+          errorCode: 'PROVIDER_TOKEN_INVALID'
+        });
+      }
+
+      if (error instanceof GitProviderRateLimitError) {
+        throw new HttpException(
+          {
+            message: `${provider} provider rate limit exceeded.`,
+            errorCode: 'PROVIDER_RATE_LIMITED'
+          },
+          429
+        );
+      }
+
+      if (error instanceof GitProviderUnavailableError) {
+        throw new ServiceUnavailableException({
+          message: `${provider} provider is unavailable.`,
+          errorCode: 'PROVIDER_UNAVAILABLE'
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  private toScanSummary(scan: {
+    id: string;
+    branch: string;
+    commitSha: string | null;
+    status: ScanStatus;
+    language: string;
+    totalFiles: number | null;
+    totalLines: number | null;
+    vulnCritical: number;
+    vulnHigh: number;
+    vulnMedium: number;
+    vulnLow: number;
+    vulnInfo: number;
+    errorMessage: string | null;
+    startedAt: Date | null;
+    completedAt: Date | null;
+    createdAt: Date;
+    connectedRepo: {
+      fullName: string;
+    };
+  }): ScanSummary {
+    return {
+      id: scan.id,
+      repoFullName: scan.connectedRepo.fullName,
+      branch: scan.branch,
+      commitSha: scan.commitSha,
+      status: scan.status,
+      language: scan.language,
+      totalFiles: scan.totalFiles,
+      totalLines: scan.totalLines,
+      summary: {
+        critical: scan.vulnCritical,
+        high: scan.vulnHigh,
+        medium: scan.vulnMedium,
+        low: scan.vulnLow,
+        info: scan.vulnInfo
+      },
+      startedAt: scan.startedAt?.toISOString() ?? null,
+      completedAt: scan.completedAt?.toISOString() ?? null,
+      errorMessage: scan.errorMessage,
+      createdAt: scan.createdAt.toISOString()
     };
   }
 }

--- a/apps/api/test/scan/scan.e2e-spec.ts
+++ b/apps/api/test/scan/scan.e2e-spec.ts
@@ -1,0 +1,231 @@
+import type { AuthUser } from '@aegisai/shared';
+import { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+class MockSessionAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ user?: AuthUser }>();
+
+    request.user = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: null,
+      connectedProviders: ['github']
+    };
+
+    return true;
+  }
+}
+
+describe('ScanController (e2e)', () => {
+  let app: INestApplication;
+  const scanService = {
+    createScan: jest.fn(),
+    getScanDetail: jest.fn(),
+    listRepoScans: jest.fn()
+  };
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.PORT = '3000';
+    process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/aegisai';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.SESSION_SECRET = 'test-session-secret-value';
+    process.env.CSRF_SECRET = 'test-csrf-secret-value';
+    process.env.GITHUB_CLIENT_ID = 'github-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'github-client-secret';
+    process.env.GITLAB_CLIENT_ID = 'gitlab-client-id';
+    process.env.GITLAB_CLIENT_SECRET = 'gitlab-client-secret';
+    process.env.APP_URL = 'http://localhost:3000';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+    process.env.SESSION_COOKIE_NAME = 'connect.sid';
+    process.env.CSRF_COOKIE_NAME = 'csrf_token';
+    process.env.COOKIE_DOMAIN = '';
+    process.env.TOKEN_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    process.env.ANALYSIS_CLIENT_MODE = 'mock';
+    process.env.AI_SERVER_URL = 'http://localhost:8000';
+    process.env.USE_INTERNAL_AI = 'false';
+    process.env.INTERNAL_API_SECRET = '';
+    process.env.GITHUB_APP_WEBHOOK_SECRET = '';
+    process.env.GITLAB_WEBHOOK_SECRET = '';
+    process.env.REPORT_STORAGE_PATH = './tmp/reports';
+    process.env.REPORT_EXPIRY_HOURS = '24';
+
+    const [{ AppModule }, { configureApp }, { PrismaService }, { SessionAuthGuard }, { ScanService }] =
+      await Promise.all([
+        import('../../src/app.module'),
+        import('../../src/bootstrap/configure-app'),
+        import('../../src/prisma/prisma.service'),
+        import('../../src/auth/guards/session-auth.guard'),
+        import('../../src/scan/scan.service')
+      ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .overrideGuard(SessionAuthGuard)
+      .useClass(MockSessionAuthGuard)
+      .overrideProvider(ScanService)
+      .useValue(scanService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await configureApp(app);
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('returns HTTP 202 from POST /api/scans with the wrapped request payload', async () => {
+    scanService.createScan.mockResolvedValue({
+      scanId: 'scan-1',
+      status: 'PENDING',
+      message: 'Scan queued successfully.'
+    });
+
+    await request(app.getHttpServer())
+      .post('/api/scans')
+      .send({
+        repoId: 'repo-1',
+        branch: 'main'
+      })
+      .expect(202)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            scanId: 'scan-1',
+            status: 'PENDING',
+            message: 'Scan queued successfully.'
+          },
+          message: null
+        });
+      });
+
+    expect(scanService.createScan).toHaveBeenCalledWith({
+      userId: 'user-1',
+      connectedRepoId: 'repo-1',
+      branch: 'main'
+    });
+  });
+
+  it('returns wrapped scan detail from GET /api/scans/:scanId', async () => {
+    scanService.getScanDetail.mockResolvedValue({
+      id: 'scan-1',
+      repoFullName: 'acme/service',
+      branch: 'main',
+      commitSha: 'commit-123',
+      status: 'DONE',
+      language: 'java',
+      totalFiles: 10,
+      totalLines: 200,
+      summary: {
+        critical: 0,
+        high: 1,
+        medium: 0,
+        low: 0,
+        info: 0
+      },
+      startedAt: null,
+      completedAt: null,
+      errorMessage: null,
+      createdAt: '2026-03-25T12:00:00.000Z'
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/scans/scan-1')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            id: 'scan-1',
+            repoFullName: 'acme/service',
+            status: 'DONE'
+          },
+          message: null
+        });
+      });
+
+    expect(scanService.getScanDetail).toHaveBeenCalledWith('user-1', 'scan-1');
+  });
+
+  it('returns wrapped scan history from GET /api/repos/:repoId/scans', async () => {
+    scanService.listRepoScans.mockResolvedValue({
+      items: [
+        {
+          id: 'scan-1',
+          repoFullName: 'acme/service',
+          branch: 'main',
+          commitSha: 'commit-123',
+          status: 'DONE',
+          language: 'java',
+          totalFiles: 10,
+          totalLines: 200,
+          summary: {
+            critical: 0,
+            high: 1,
+            medium: 0,
+            low: 0,
+            info: 0
+          },
+          startedAt: null,
+          completedAt: null,
+          errorMessage: null,
+          createdAt: '2026-03-25T12:00:00.000Z'
+        }
+      ],
+      totalCount: 1,
+      page: 1,
+      totalPages: 1
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/repos/repo-1/scans')
+      .query({ page: 1, size: 10 })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            items: [
+              {
+                id: 'scan-1',
+                repoFullName: 'acme/service'
+              }
+            ],
+            totalCount: 1,
+            page: 1,
+            totalPages: 1
+          },
+          message: null
+        });
+      });
+
+    expect(scanService.listRepoScans).toHaveBeenCalledWith({
+      userId: 'user-1',
+      repoId: 'repo-1',
+      page: 1,
+      size: 10
+    });
+  });
+});

--- a/apps/api/test/scan/scan.service.e2e-spec.ts
+++ b/apps/api/test/scan/scan.service.e2e-spec.ts
@@ -1,4 +1,5 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { GitProviderNotFoundError } from '../../src/client/git/git-provider-client.errors';
 
 import { SCAN_PROCESS_JOB } from '../../src/scan/scan.constants';
 import { ScanService } from '../../src/scan/scan.service';
@@ -14,6 +15,11 @@ describe('ScanService', () => {
           provider: 'GITHUB'
         })
       },
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'enc(access-token)'
+        })
+      },
       scan: {
         findFirst: jest.fn().mockResolvedValue(null),
         create: jest.fn().mockResolvedValue({
@@ -25,8 +31,21 @@ describe('ScanService', () => {
     const queue = {
       add: jest.fn().mockResolvedValue({ id: 'scan-1' })
     };
+    const gitClients = {
+      get: jest.fn().mockReturnValue({
+        getLatestCommitSha: jest.fn().mockResolvedValue('commit-123')
+      })
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('access-token')
+    };
 
-    const service = new ScanService(prisma as never, queue as never);
+    const service = new ScanService(
+      prisma as never,
+      queue as never,
+      gitClients as never,
+      tokenCrypto as never
+    );
 
     await expect(
       service.createScan({
@@ -66,6 +85,7 @@ describe('ScanService', () => {
       { scanId: 'scan-1' },
       { jobId: 'scan-1' }
     );
+    expect(gitClients.get).toHaveBeenCalledWith('github');
   });
 
   it('rejects duplicate active scans for the same repository branch', async () => {
@@ -73,7 +93,14 @@ describe('ScanService', () => {
       connectedRepo: {
         findFirst: jest.fn().mockResolvedValue({
           id: 'repo-1',
-          userId: 'user-1'
+          userId: 'user-1',
+          fullName: 'acme/service',
+          provider: 'GITHUB'
+        })
+      },
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'enc(access-token)'
         })
       },
       scan: {
@@ -83,8 +110,21 @@ describe('ScanService', () => {
         })
       }
     };
+    const gitClients = {
+      get: jest.fn().mockReturnValue({
+        getLatestCommitSha: jest.fn().mockResolvedValue('commit-123')
+      })
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('access-token')
+    };
 
-    const service = new ScanService(prisma as never, { add: jest.fn() } as never);
+    const service = new ScanService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      gitClients as never,
+      tokenCrypto as never
+    );
 
     await expect(
       service.createScan({
@@ -102,7 +142,12 @@ describe('ScanService', () => {
       }
     };
 
-    const service = new ScanService(prisma as never, { add: jest.fn() } as never);
+    const service = new ScanService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { get: jest.fn() } as never,
+      { decrypt: jest.fn() } as never
+    );
 
     await expect(
       service.createScan({
@@ -111,5 +156,224 @@ describe('ScanService', () => {
         branch: 'main'
       })
     ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('rejects scan creation when the requested branch does not exist', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'repo-1',
+          userId: 'user-1',
+          fullName: 'acme/service',
+          provider: 'GITHUB'
+        })
+      },
+      oAuthToken: {
+        findFirst: jest.fn().mockResolvedValue({
+          accessToken: 'enc(access-token)'
+        })
+      },
+      scan: {
+        findFirst: jest.fn()
+      }
+    };
+    const gitClients = {
+      get: jest.fn().mockReturnValue({
+        getLatestCommitSha: jest
+          .fn()
+          .mockRejectedValue(new GitProviderNotFoundError('Branch not found', 'github'))
+      })
+    };
+    const tokenCrypto = {
+      decrypt: jest.fn().mockReturnValue('access-token')
+    };
+
+    const service = new ScanService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      gitClients as never,
+      tokenCrypto as never
+    );
+
+    await expect(
+      service.createScan({
+        userId: 'user-1',
+        connectedRepoId: 'repo-1',
+        branch: 'missing'
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('returns scan detail scoped to the authenticated user', async () => {
+    const prisma = {
+      scan: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'scan-1',
+          branch: 'main',
+          commitSha: 'commit-123',
+          status: 'DONE',
+          language: 'java',
+          totalFiles: 12,
+          totalLines: 1200,
+          vulnCritical: 1,
+          vulnHigh: 2,
+          vulnMedium: 3,
+          vulnLow: 4,
+          vulnInfo: 5,
+          errorMessage: null,
+          startedAt: new Date('2026-03-25T10:00:00.000Z'),
+          completedAt: new Date('2026-03-25T10:05:00.000Z'),
+          createdAt: new Date('2026-03-25T09:59:00.000Z'),
+          connectedRepo: {
+            fullName: 'acme/service'
+          }
+        })
+      }
+    };
+
+    const service = new ScanService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { get: jest.fn() } as never,
+      { decrypt: jest.fn() } as never
+    );
+
+    await expect(service.getScanDetail('user-1', 'scan-1')).resolves.toEqual({
+      id: 'scan-1',
+      repoFullName: 'acme/service',
+      branch: 'main',
+      commitSha: 'commit-123',
+      status: 'DONE',
+      language: 'java',
+      totalFiles: 12,
+      totalLines: 1200,
+      summary: {
+        critical: 1,
+        high: 2,
+        medium: 3,
+        low: 4,
+        info: 5
+      },
+      startedAt: '2026-03-25T10:00:00.000Z',
+      completedAt: '2026-03-25T10:05:00.000Z',
+      errorMessage: null,
+      createdAt: '2026-03-25T09:59:00.000Z'
+    });
+  });
+
+  it('returns paginated scan history for a connected repository', async () => {
+    const prisma = {
+      connectedRepo: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'repo-1',
+          userId: 'user-1'
+        })
+      },
+      scan: {
+        count: jest.fn().mockResolvedValue(3),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'scan-3',
+            branch: 'main',
+            commitSha: 'commit-333',
+            status: 'DONE',
+            language: 'java',
+            totalFiles: 10,
+            totalLines: 100,
+            vulnCritical: 0,
+            vulnHigh: 1,
+            vulnMedium: 0,
+            vulnLow: 0,
+            vulnInfo: 0,
+            errorMessage: null,
+            startedAt: null,
+            completedAt: null,
+            createdAt: new Date('2026-03-25T12:00:00.000Z'),
+            connectedRepo: {
+              fullName: 'acme/service'
+            }
+          },
+          {
+            id: 'scan-2',
+            branch: 'release',
+            commitSha: null,
+            status: 'FAILED',
+            language: 'java',
+            totalFiles: null,
+            totalLines: null,
+            vulnCritical: 0,
+            vulnHigh: 0,
+            vulnMedium: 0,
+            vulnLow: 0,
+            vulnInfo: 0,
+            errorMessage: 'Provider unavailable',
+            startedAt: null,
+            completedAt: null,
+            createdAt: new Date('2026-03-24T12:00:00.000Z'),
+            connectedRepo: {
+              fullName: 'acme/service'
+            }
+          }
+        ])
+      }
+    };
+
+    const service = new ScanService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { get: jest.fn() } as never,
+      { decrypt: jest.fn() } as never
+    );
+
+    await expect(service.listRepoScans({ userId: 'user-1', repoId: 'repo-1', page: 1, size: 2 }))
+      .resolves.toEqual({
+        items: [
+          {
+            id: 'scan-3',
+            repoFullName: 'acme/service',
+            branch: 'main',
+            commitSha: 'commit-333',
+            status: 'DONE',
+            language: 'java',
+            totalFiles: 10,
+            totalLines: 100,
+            summary: {
+              critical: 0,
+              high: 1,
+              medium: 0,
+              low: 0,
+              info: 0
+            },
+            startedAt: null,
+            completedAt: null,
+            errorMessage: null,
+            createdAt: '2026-03-25T12:00:00.000Z'
+          },
+          {
+            id: 'scan-2',
+            repoFullName: 'acme/service',
+            branch: 'release',
+            commitSha: null,
+            status: 'FAILED',
+            language: 'java',
+            totalFiles: null,
+            totalLines: null,
+            summary: {
+              critical: 0,
+              high: 0,
+              medium: 0,
+              low: 0,
+              info: 0
+            },
+            startedAt: null,
+            completedAt: null,
+            errorMessage: 'Provider unavailable',
+            createdAt: '2026-03-24T12:00:00.000Z'
+          }
+        ],
+        totalCount: 3,
+        page: 1,
+        totalPages: 2
+      });
   });
 });

--- a/docs/superpowers/plans/2026-03-25-scan-controller-request-status.md
+++ b/docs/superpowers/plans/2026-03-25-scan-controller-request-status.md
@@ -1,0 +1,98 @@
+# Scan Controller Request/Status Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add authenticated scan request and status endpoints for User Story 1, including branch validation and repository-scoped scan history.
+
+**Architecture:** Extend the existing `ScanService` as the single scan application boundary, then add a thin `ScanController` that exposes the shared contracts already defined in `packages/shared`. Keep ownership checks and provider validation in the service so controller logic stays declarative and matches the current repo/auth patterns.
+
+**Tech Stack:** NestJS controllers/services, Prisma, BullMQ, shared TypeScript contracts, Jest e2e tests, Supertest
+
+---
+
+## Chunk 1: Contracts and Scan Service Query Surface
+
+### Task 1: Extend shared scan contracts for repo scan paging
+
+**Files:**
+- Modify: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\packages\shared\src\types\scan.ts`
+- Test: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\packages\shared\test\shared-contract-exports.test.mjs`
+
+- [ ] Add any missing page response alias or query type needed by `GET /api/repos/:repoId/scans`.
+- [ ] Update the shared export regression test if the scan contract surface changes.
+- [ ] Run `corepack pnpm --filter @aegisai/shared test`.
+
+### Task 2: Add failing service tests for scan detail and repo scan listing
+
+**Files:**
+- Modify: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\apps\api\test\scan\scan.service.e2e-spec.ts`
+
+- [ ] Write a failing test for `getScanDetail` returning the mapped `ScanDetail`.
+- [ ] Write a failing test for `listRepoScans` returning a paginated `PageResponse<ScanSummary>`.
+- [ ] Write a failing test for branch validation in `createScan`.
+- [ ] Run `corepack pnpm --filter @aegisai/api test -- --runInBand test/scan/scan.service.e2e-spec.ts` and confirm the new tests fail for the intended reason.
+
+### Task 3: Implement the minimal `ScanService` changes to satisfy the new tests
+
+**Files:**
+- Modify: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\apps\api\src\scan\scan.service.ts`
+
+- [ ] Add provider-backed branch validation inside `createScan`.
+- [ ] Add `getScanDetail`.
+- [ ] Add `listRepoScans`.
+- [ ] Add focused private mapping helpers instead of duplicating summary conversion logic.
+- [ ] Re-run `corepack pnpm --filter @aegisai/api test -- --runInBand test/scan/scan.service.e2e-spec.ts` until green.
+
+## Chunk 2: Scan Controller and Endpoint Coverage
+
+### Task 4: Add failing controller e2e tests for the scan endpoints
+
+**Files:**
+- Create: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\apps\api\test\scan\scan.e2e-spec.ts`
+
+- [ ] Add a failing test for `POST /api/scans` returning HTTP 202 with the wrapped scan request payload.
+- [ ] Add a failing test for `GET /api/scans/:scanId`.
+- [ ] Add a failing test for `GET /api/repos/:repoId/scans`.
+- [ ] Run `corepack pnpm --filter @aegisai/api test -- --runInBand test/scan/scan.e2e-spec.ts` and confirm failure before implementation.
+
+### Task 5: Implement the scan controller and module wiring
+
+**Files:**
+- Create: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\apps\api\src\scan\scan.controller.ts`
+- Modify: `C:\Users\권태욱\.config\superpowers\worktrees\aegisai_v2\codex-feat-62-scan-controller-endpoints\apps\api\src\scan\scan.module.ts`
+
+- [ ] Add authenticated scan endpoints using `SessionAuthGuard` and `CurrentUser`.
+- [ ] Return HTTP 202 for `POST /api/scans`.
+- [ ] Keep page/size validation aligned with the repository controller behavior.
+- [ ] Register the controller in `ScanModule`.
+- [ ] Re-run `corepack pnpm --filter @aegisai/api test -- --runInBand test/scan/scan.e2e-spec.ts` until green.
+
+## Chunk 3: Full Regression and Finish
+
+### Task 6: Run the touched backend regression suite
+
+**Files:**
+- Verify only
+
+- [ ] Run `corepack pnpm --filter @aegisai/api test -- --runInBand test/scan`.
+- [ ] Run `corepack pnpm --filter @aegisai/api test -- --runInBand test/repo/repo.e2e-spec.ts`.
+- [ ] If anything fails, fix the smallest responsible unit and rerun the failing command first.
+
+### Task 7: Run full workspace verification
+
+**Files:**
+- Verify only
+
+- [ ] Run `corepack pnpm lint`.
+- [ ] Run `corepack pnpm test`.
+- [ ] Run `corepack pnpm typecheck`.
+- [ ] Run `corepack pnpm build`.
+
+### Task 8: Prepare branch output
+
+**Files:**
+- Review diff only
+
+- [ ] Review changed files for accidental scope creep.
+- [ ] Commit with `feat: implement scan controller request and status endpoints`.
+- [ ] Prepare the PR body using the repository template with issue `#62`.

--- a/docs/superpowers/specs/2026-03-25-scan-controller-request-status-design.md
+++ b/docs/superpowers/specs/2026-03-25-scan-controller-request-status-design.md
@@ -1,0 +1,103 @@
+# Scan Controller Request/Status Design
+
+## Goal
+
+Implement the User Story 1 scan API surface so authenticated users can request scans,
+poll scan status, and view scan history for a connected repository.
+
+## Scope
+
+This issue covers:
+
+- `POST /api/scans`
+- `GET /api/scans/:scanId`
+- `GET /api/repos/:repoId/scans`
+- supporting `ScanService` query behavior needed by those endpoints
+- tests for controller and service behavior
+
+This issue does not cover:
+
+- vulnerability listing endpoints
+- frontend scan page and polling UX
+- report generation
+
+## API Shape
+
+### `POST /api/scans`
+
+- Requires an authenticated session.
+- Accepts `{ repoId, branch }`.
+- Returns HTTP `202` with `ScanRequestResponse`.
+- Validates:
+  - `repoId` is present
+  - `branch` is present after trimming
+  - the connected repo belongs to the current user
+  - the branch exists in the provider before creating the scan row
+  - no active scan already exists for the same repo/branch
+
+Branch existence is verified through the provider client by resolving the connected repo,
+provider token, and latest commit for the requested branch before the scan row is inserted.
+
+### `GET /api/scans/:scanId`
+
+- Requires an authenticated session.
+- Returns a single `ScanDetail`.
+- Enforces ownership through `scan -> connectedRepo -> userId`.
+- Maps Prisma scan rows into the shared contract shape with severity summary fields.
+
+### `GET /api/repos/:repoId/scans`
+
+- Requires an authenticated session.
+- Returns `PageResponse<ScanSummary>`.
+- Uses fixed ordering `createdAt desc`.
+- Enforces ownership through `ConnectedRepo.userId`.
+- Supports `page` and `size` query params with the same validation style as repo endpoints.
+
+## Service Design
+
+`ScanService` remains the single scan application service for this phase.
+
+New responsibilities:
+
+- `createScan(...)`
+  - trim and validate the branch
+  - resolve connected repo ownership
+  - verify branch existence through the provider client
+  - reject duplicate active scans
+  - create the scan row and enqueue the job
+- `getScanDetail(...)`
+  - fetch a scan scoped to the current user
+  - return shared `ScanDetail`
+- `listRepoScans(...)`
+  - verify repo ownership
+  - return paginated `ScanSummary` rows
+
+Internal helpers should centralize:
+
+- ownership-scoped scan mapping
+- scan summary projection
+- provider token resolution for branch validation
+
+## Error Handling
+
+- missing `repoId` or blank `branch` -> `400 BAD_REQUEST`
+- branch not found in provider -> `400 BRANCH_NOT_FOUND`
+- connected repo not found for user -> `404 REPO_NOT_FOUND`
+- scan not found for user -> `404 SCAN_NOT_FOUND`
+- active scan already exists -> existing `409 Conflict`
+- provider token invalid / unavailable / rate limited -> reuse existing provider error mapping patterns
+
+The controller should stay thin and let the existing global exception/response wiring wrap results.
+
+## Testing Strategy
+
+Add or extend:
+
+- service tests for branch validation, scan detail mapping, and repo scan pagination
+- controller e2e tests for:
+  - `POST /api/scans` success and validation failure
+  - `GET /api/scans/:scanId`
+  - `GET /api/repos/:repoId/scans`
+
+Tests should follow the existing `RepoController` and `ScanService` patterns and keep
+queue/runtime behavior mocked at the service boundary.

--- a/packages/shared/src/types/scan.ts
+++ b/packages/shared/src/types/scan.ts
@@ -1,3 +1,5 @@
+import type { PageResponse, PageQuery } from './common';
+
 export interface ScanSeveritySummary {
   critical: number;
   high: number;
@@ -36,3 +38,9 @@ export interface ScanRequestResponse {
   status: 'PENDING';
   message: string;
 }
+
+export interface ListRepoScansQuery extends PageQuery {
+  repoId: string;
+}
+
+export type RepoScanListResponse = PageResponse<ScanSummary>;


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/62-scan-controller-endpoints`
- 이슈: `#62`

## 🔎 주요 변경 사항

- `apps/api/src/scan/scan.controller.ts`를 추가해 `POST /api/scans`, `GET /api/scans/:scanId`, `GET /api/repos/:repoId/scans` 엔드포인트를 구현했습니다.
- `ScanService`를 확장해 branch trim 및 provider 기반 branch 존재 재검증, scan detail 조회, repository scan history 조회를 처리하도록 구성했습니다.
- `packages/shared/src/types/scan.ts`에 repository scan page 조회에 필요한 shared contract를 보강했습니다.
- `ScanModule`을 갱신해 controller를 등록하고, test 환경에서는 fake queue provider를 사용해 Redis 연결 없이 scan API 테스트가 가능하도록 구성했습니다.
- `AppModule`을 갱신해 test 환경에서도 `ScanModule`이 실제 앱 경로에 연결되도록 정리했습니다.
- scan controller/service 회귀 테스트와 이슈 전용 설계 문서, 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scan request endpoint (`POST /api/scans`) to initiate scans with branch validation.
  * Added scan detail endpoint (`GET /api/scans/:scanId`) to retrieve scan information.
  * Added scan listing endpoint (`GET /api/repos/:repoId/scans`) with pagination support for repository scans.
  * Enhanced validation and error handling with specific error codes.

* **Documentation**
  * Added implementation plan and design specification for scan controller endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->