### PR TITLE
Fix: API Docker runtime entrypoint 경로 수정

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/apps/api ./apps/api
 EXPOSE 3000
-CMD ["node", "apps/api/dist/main.js"]
+CMD ["node", "apps/api/dist/apps/api/src/main.js"]

--- a/apps/api/test/contracts/mvp-openapi.e2e-spec.ts
+++ b/apps/api/test/contracts/mvp-openapi.e2e-spec.ts
@@ -5,7 +5,7 @@ describe('MVP OpenAPI contract', () => {
   const contract = readFileSync(
     join(__dirname, '../../../../specs/001-aegisai-mvp-foundation/contracts/mvp-openapi.yaml'),
     'utf8'
-  );
+  ).replace(/\r\n/g, '\n');
 
   it('documents the currently implemented auth, repo, and scan endpoints', () => {
     expect(contract).toContain('/auth/github:');

--- a/test/github-actions/api-dockerfile.test.mjs
+++ b/test/github-actions/api-dockerfile.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const dockerfile = readFileSync(new URL('../../apps/api/Dockerfile', import.meta.url), 'utf8');
+
+test('api docker runtime entrypoint matches the built Nest output path', () => {
+  assert.match(dockerfile, /CMD \["node", "apps\/api\/dist\/apps\/api\/src\/main\.js"\]/);
+  assert.doesNotMatch(dockerfile, /CMD \["node", "apps\/api\/dist\/main\.js"\]/);
+});

--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -60,7 +60,7 @@ test('cd workflow and oracle deployment files enforce the split infra/app deploy
 
   assert.match(apiDockerfile, /FROM node:20-alpine/);
   assert.match(apiDockerfile, /corepack pnpm --filter @aegisai\/api build/);
-  assert.match(apiDockerfile, /CMD \["node", "apps\/api\/dist\/main\.js"\]/);
+  assert.match(apiDockerfile, /CMD \["node", "apps\/api\/dist\/apps\/api\/src\/main\.js"\]/);
 
   assert.match(webDockerfile, /FROM nginx:1\.27-alpine/);
   assert.match(webDockerfile, /COPY --from=builder \/app\/apps\/web\/dist/);


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `codex/fix-70-api-docker-entrypoint`
- 이슈: `#70`

## 🔎 주요 변경 사항

- API Docker runtime entrypoint를 실제 Nest 빌드 산출물 경로에 맞게 수정했습니다.
- API Dockerfile entrypoint 경로가 다시 어긋나지 않도록 GitHub Actions 회귀 테스트를 추가했습니다.
- Windows CRLF 환경에서도 OpenAPI/CD 회귀 테스트가 안정적으로 동작하도록 줄바꿈 정규화를 보강했습니다.
- production 배포 실패의 직접 원인이던 API 컨테이너 부팅 경로 문제를 제거했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for container deployment configuration.
  * Updated test expectations to match configuration changes.
  * Enhanced test robustness for cross-platform line-ending compatibility.

* **Chores**
  * Updated container build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->