### PR TITLE
Fix: Prisma OpenSSL runtime dependency in production API container

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:20-alpine AS builder
+FROM node:20-bookworm-slim AS builder
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
 WORKDIR /app
 COPY . .
@@ -6,7 +9,10 @@ RUN corepack pnpm install --frozen-lockfile
 RUN corepack pnpm --filter @aegisai/shared build
 RUN corepack pnpm --filter @aegisai/api build
 
-FROM node:20-alpine AS runner
+FROM node:20-bookworm-slim AS runner
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
 WORKDIR /app
 ENV NODE_ENV=production

--- a/docs/superpowers/plans/2026-03-26-prisma-openssl-runtime.md
+++ b/docs/superpowers/plans/2026-03-26-prisma-openssl-runtime.md
@@ -1,0 +1,46 @@
+# Prisma OpenSSL Runtime Dependency Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the production API container from crashing by switching its Docker runtime to a Prisma-compatible OpenSSL environment.
+
+**Architecture:** Keep the fix constrained to the API Docker image. Replace Alpine with Debian slim in both build and runtime stages, install OpenSSL explicitly, and update the existing GitHub Actions Dockerfile regressions to lock the new runtime contract.
+
+**Tech Stack:** Docker, Prisma, GitHub Actions regression tests
+
+---
+
+## Chunk 1: Lock The Failure With Tests
+
+### Task 1: Update Dockerfile regression expectations
+
+**Files:**
+- Modify: `test/github-actions/api-dockerfile.test.mjs`
+- Modify: `test/github-actions/cd-workflow.test.mjs`
+
+- [ ] Add failing expectations for Debian slim stages and explicit OpenSSL installation.
+- [ ] Run the focused Dockerfile regression and verify it fails against the Alpine image.
+
+## Chunk 2: Apply The Runtime Fix
+
+### Task 2: Update the API Docker image base
+
+**Files:**
+- Modify: `apps/api/Dockerfile`
+
+- [ ] Replace Alpine builder and runner stages with Debian slim.
+- [ ] Install `openssl` and `ca-certificates` in both stages.
+- [ ] Re-run the focused Dockerfile regression and confirm it passes.
+
+## Chunk 3: Full Verification
+
+### Task 3: Run repository validation
+
+**Files:**
+- Review only
+
+- [ ] Run `corepack pnpm lint`.
+- [ ] Run `corepack pnpm test`.
+- [ ] Run `corepack pnpm typecheck`.
+- [ ] Run `corepack pnpm build`.
+- [ ] Commit with `fix: switch api docker runtime to debian slim`.

--- a/docs/superpowers/specs/2026-03-26-prisma-openssl-runtime-design.md
+++ b/docs/superpowers/specs/2026-03-26-prisma-openssl-runtime-design.md
@@ -1,0 +1,54 @@
+# Prisma OpenSSL Runtime Dependency Fix Design
+
+## Goal
+
+Prevent the production API container from crashing on Oracle ARM64 because Prisma resolves a
+musl/OpenSSL 1.1 runtime that is unavailable in the current Alpine-based image.
+
+## Root Cause
+
+The API Docker image currently uses `node:20-alpine` for both builder and runner stages.
+That causes Prisma to generate and load the `linux-musl-arm64-openssl-1.1.x` engine in
+production. On the deployed Oracle VPS, that engine fails to start because
+`libssl.so.1.1` is not present.
+
+Observed production error:
+- `PrismaClientInitializationError`
+- `Error loading shared library libssl.so.1.1: No such file or directory`
+
+## Recommended Fix
+
+Move the API build and runtime images from Alpine to Debian slim and install OpenSSL
+explicitly in both stages.
+
+Why:
+- Debian slim gives Prisma a glibc/OpenSSL 3 compatible runtime path on ARM64.
+- Installing `openssl` and `ca-certificates` makes the runtime dependency explicit instead of
+  relying on image defaults.
+- The change is isolated to the API Docker image and does not affect application code or the
+  web container.
+
+## Scope
+
+In scope:
+- `apps/api/Dockerfile`
+- Dockerfile regression tests under `test/github-actions`
+
+Out of scope:
+- Prisma package upgrades
+- Compose topology changes
+- Oracle network or firewall configuration
+
+## Verification
+
+Lock the fix with tests that assert:
+- API Dockerfile no longer uses Alpine
+- API Dockerfile uses `node:20-bookworm-slim`
+- OpenSSL runtime packages are installed
+- Existing API entrypoint regression still holds
+
+Repository verification remains:
+- `corepack pnpm lint`
+- `corepack pnpm test`
+- `corepack pnpm typecheck`
+- `corepack pnpm build`

--- a/test/github-actions/api-dockerfile.test.mjs
+++ b/test/github-actions/api-dockerfile.test.mjs
@@ -7,4 +7,9 @@ const dockerfile = readFileSync(new URL('../../apps/api/Dockerfile', import.meta
 test('api docker runtime entrypoint matches the built Nest output path', () => {
   assert.match(dockerfile, /CMD \["node", "apps\/api\/dist\/apps\/api\/src\/main\.js"\]/);
   assert.doesNotMatch(dockerfile, /CMD \["node", "apps\/api\/dist\/main\.js"\]/);
+  assert.match(dockerfile, /FROM node:20-bookworm-slim AS builder/);
+  assert.match(dockerfile, /FROM node:20-bookworm-slim AS runner/);
+  assert.match(dockerfile, /apt-get install -y --no-install-recommends openssl ca-certificates/);
+  assert.doesNotMatch(dockerfile, /FROM node:20-alpine AS builder/);
+  assert.doesNotMatch(dockerfile, /FROM node:20-alpine AS runner/);
 });

--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -78,7 +78,9 @@ test('cd workflow and oracle deployment files enforce the split infra/app deploy
   assert.match(workflow, /docker-compose\.infra\.yml/);
   assert.match(workflow, /docker-compose\.app\.yml/);
 
-  assert.match(apiDockerfile, /FROM node:20-alpine/);
+  assert.match(apiDockerfile, /FROM node:20-bookworm-slim AS builder/);
+  assert.match(apiDockerfile, /FROM node:20-bookworm-slim AS runner/);
+  assert.match(apiDockerfile, /apt-get install -y --no-install-recommends openssl ca-certificates/);
   assert.match(apiDockerfile, /corepack pnpm --filter @aegisai\/api build/);
   assert.match(apiDockerfile, /CMD \["node", "apps\/api\/dist\/apps\/api\/src\/main\.js"\]/);
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `codex/fix-74-prisma-openssl-runtime`
- 이슈: `#74`

## 🔎 주요 변경 사항

- API Docker 이미지를 Alpine에서 Debian slim 기반으로 전환했습니다.
- builder, runner stage 모두에 `openssl`과 `ca-certificates`를 명시적으로 설치하도록 수정했습니다.
- Prisma가 production ARM64 환경에서 musl/OpenSSL 1.1 런타임에 의존하지 않도록 API Docker runtime 기반을 정리했습니다.
- API Dockerfile 회귀 테스트와 CD workflow 회귀 테스트를 현재 runtime 계약에 맞게 갱신했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated API container base image to a Debian-based runtime with enhanced SSL/certificate support.

* **Tests**
  * Updated API container regression tests to validate the new base image and SSL package installation.

* **Documentation**
  * Added implementation plan and design specifications for the container runtime update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->