### PR TITLE
Feat: public landing page and login entry flow 구현

### DIFF
--- a/apps/web/src/pages/LandingPage.test.tsx
+++ b/apps/web/src/pages/LandingPage.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { LandingPage } from "./LandingPage";
+
+function renderLandingPage() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/login" element={<div>login route</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("LandingPage", () => {
+  it("renders the public product narrative and primary access CTAs", () => {
+    renderLandingPage();
+
+    expect(
+      screen.getByRole("heading", {
+        name: /precision security for java ecosystems/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /start with github/i })
+    ).toHaveAttribute("href", "http://localhost:3000/api/auth/github");
+    expect(
+      screen.getByRole("link", { name: /start with gitlab/i })
+    ).toHaveAttribute("href", "http://localhost:3000/api/auth/gitlab");
+    expect(screen.getByRole("link", { name: /log in/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+  });
+
+  it("renders the product trust story and scan workflow", () => {
+    renderLandingPage();
+
+    expect(screen.getByText(/provider-scoped access/i)).toBeInTheDocument();
+    expect(screen.getByText(/session-first orchestration/i)).toBeInTheDocument();
+    expect(screen.getByText(/java-first analysis/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /connect provider/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /choose repository and branch/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /run scan/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,0 +1,201 @@
+import { Link } from "react-router-dom";
+
+import { getProviderLoginUrl } from "../api/auth";
+
+const trustSignals = [
+  "Provider-scoped access",
+  "Session-first orchestration",
+  "Java-first analysis",
+] as const;
+
+const workflowSteps = [
+  {
+    step: "01",
+    title: "Connect provider",
+    description:
+      "Authenticate through GitHub or GitLab and keep repository access explicit from the start.",
+  },
+  {
+    step: "02",
+    title: "Choose repository and branch",
+    description:
+      "Move into repository context, validate branch scope, and keep the scan handoff controlled.",
+  },
+  {
+    step: "03",
+    title: "Run scan",
+    description:
+      "Queue repository analysis and review structured findings without breaking provider trust boundaries.",
+  },
+] as const;
+
+const assurancePoints = [
+  "Sessions stay controlled from first entry to scan execution.",
+  "Provider OAuth keeps repository authorization explicit and revocable.",
+  "Branch-aware handoff reduces noise before scan orchestration begins.",
+] as const;
+
+const footerColumns = [
+  {
+    title: "Product",
+    links: ["Methodology", "Security posture", "Support"],
+  },
+  {
+    title: "Access",
+    links: ["GitHub start", "GitLab start", "Login"],
+  },
+  {
+    title: "Company",
+    links: ["Privacy", "Terms", "Contact"],
+  },
+] as const;
+
+export function LandingPage() {
+  return (
+    <main className="landing-page">
+      <div className="landing-shell">
+        <header className="landing-nav" aria-label="AegisAI public navigation">
+          <div className="landing-brand-lockup">
+            <p className="eyebrow">AegisAI</p>
+            <p className="landing-brand-copy">Repository security scanning for engineering teams</p>
+          </div>
+
+          <nav className="landing-nav-links" aria-label="Public">
+            <a href="#workflow">Workflow</a>
+            <a href="#trust">Trust</a>
+            <a href="#start">Get started</a>
+            <Link to="/login">Log in</Link>
+          </nav>
+        </header>
+
+        <section className="landing-hero">
+          <div className="landing-hero-copy">
+            <p className="eyebrow">Java-first repository security</p>
+            <h1>Precision Security for Java Ecosystems.</h1>
+            <p className="landing-lead">
+              AegisAI helps engineering teams move from provider-authenticated repository access to
+              branch-aware Java scanning with a controlled, trust-first workflow.
+            </p>
+
+            <div className="landing-cta-row">
+              <a className="landing-primary-cta" href={getProviderLoginUrl("github")}>
+                Start with GitHub
+              </a>
+              <a className="landing-secondary-cta" href={getProviderLoginUrl("gitlab")}>
+                Start with GitLab
+              </a>
+              <Link className="landing-text-cta" to="/login">
+                View access portal
+              </Link>
+            </div>
+
+            <div className="landing-trust-strip" aria-label="Trust signals">
+              {trustSignals.map((signal) => (
+                <span key={signal}>{signal}</span>
+              ))}
+            </div>
+          </div>
+
+          <aside className="landing-hero-panel" aria-label="AegisAI trust summary">
+            <div className="landing-panel-card">
+              <p className="eyebrow">Operational clarity</p>
+              <h2>Repository trust, branch intent, and scan initiation stay inside one calm flow.</h2>
+              <p>
+                Designed for teams who want secure access control without dropping into a noisy
+                security dashboard on first contact.
+              </p>
+            </div>
+
+            <div className="landing-panel-metrics">
+              <div>
+                <strong>01</strong>
+                <span>Controlled provider entry</span>
+              </div>
+              <div>
+                <strong>02</strong>
+                <span>Branch-aware setup</span>
+              </div>
+              <div>
+                <strong>03</strong>
+                <span>Scan-ready workspace</span>
+              </div>
+            </div>
+          </aside>
+        </section>
+
+        <section className="landing-logo-strip" aria-label="Trusted by security-first teams">
+          <span>Vantage</span>
+          <span>Oracle</span>
+          <span>Lumina</span>
+          <span>Kinetic</span>
+          <span>Zenith</span>
+        </section>
+
+        <section className="landing-workflow" id="workflow">
+          <div className="landing-section-heading">
+            <p className="eyebrow">How it works</p>
+            <h2>Designed for the secure path from access to scan.</h2>
+          </div>
+
+          <div className="landing-step-grid">
+            {workflowSteps.map((step) => (
+              <article key={step.step} className="landing-step-card">
+                <p className="landing-step-index">{step.step}</p>
+                <h3>{step.title}</h3>
+                <p>{step.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="landing-assurance" id="trust">
+          <div className="landing-section-heading">
+            <p className="eyebrow">Why teams trust this flow</p>
+            <h2>Low-friction entry, explicit authorization, and a cleaner handoff into real work.</h2>
+          </div>
+
+          <div className="landing-assurance-grid">
+            {assurancePoints.map((point) => (
+              <article key={point} className="landing-assurance-card">
+                <p>{point}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="landing-final-cta" id="start">
+          <div>
+            <p className="eyebrow">Start your secure workflow</p>
+            <h2>Open a repository-scoped path into AegisAI.</h2>
+            <p>
+              Pick the provider that owns your repositories and move straight into the controlled
+              access flow.
+            </p>
+          </div>
+
+          <div className="landing-final-actions">
+            <a className="landing-primary-cta" href={getProviderLoginUrl("github")}>
+              Begin with GitHub access
+            </a>
+            <Link className="landing-text-cta" to="/login">
+              Open secure portal
+            </Link>
+          </div>
+        </section>
+
+        <footer className="landing-footer">
+          {footerColumns.map((column) => (
+            <div key={column.title} className="landing-footer-column">
+              <p className="eyebrow">{column.title}</p>
+              <ul>
+                {column.links.map((link) => (
+                  <li key={link}>{link}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -39,9 +39,16 @@ describe("LoginPage", () => {
     renderLoginPage();
 
     expect(
-      screen.getByRole("heading", { name: /secure java scanning that stays in your provider flow/i })
+      screen.getByRole("heading", {
+        name: /secure access for repository scanning/i,
+      })
     ).toBeInTheDocument();
-    expect(screen.getByText(/session-based auth/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to overview/i })
+    ).toHaveAttribute("href", "/");
+    expect(screen.getByText(/session-based access/i)).toBeInTheDocument();
+    expect(screen.getByText(/provider oauth only/i)).toBeInTheDocument();
+    expect(screen.getByText(/java-first analysis/i)).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /continue with github/i })
     ).toHaveAttribute("href", "http://localhost:3000/api/auth/github");
@@ -72,7 +79,7 @@ describe("LoginPage", () => {
     renderLoginPage("/login?error=oauth_failed");
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      /login did not complete successfully/i
+      /authentication could not be completed/i
     );
   });
 
@@ -110,7 +117,7 @@ describe("LoginPage", () => {
     renderLoginPage();
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      /we could not verify your existing session/i
+      /existing session unavailable/i
     );
   });
 });

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useSearchParams } from "react-router-dom";
+import { Link, Navigate, useSearchParams } from "react-router-dom";
 
 import { getProviderLoginUrl } from "../api/auth";
 import { useAuth } from "../hooks/useAuth";
@@ -8,16 +8,22 @@ const providerActions = [
     provider: "github",
     label: "Continue with GitHub",
     eyebrow: "Repository provider",
-    description: "Connect GitHub repositories and move directly into branch-aware Java scanning.",
+    description: "Authorize GitHub access and move directly into secure repository orchestration.",
     glyph: "GH",
   },
   {
     provider: "gitlab",
     label: "Continue with GitLab",
     eyebrow: "Self-managed friendly",
-    description: "Use the same session flow for GitLab-hosted repositories and queued scans.",
+    description: "Use the same controlled access flow for GitLab-hosted repositories and scans.",
     glyph: "GL",
   },
+] as const;
+
+const trustSignals = [
+  "Session-based access",
+  "Provider OAuth only",
+  "Java-first analysis",
 ] as const;
 
 function getAuthErrorMessage(errorCode: string | null): string | null {
@@ -26,10 +32,10 @@ function getAuthErrorMessage(errorCode: string | null): string | null {
   }
 
   if (errorCode === "oauth_failed") {
-    return "Login did not complete successfully. Please choose a provider and try again.";
+    return "Authentication could not be completed. Please choose a provider and try again.";
   }
 
-  return "We could not complete sign-in. Please try again.";
+  return "We could not complete secure sign-in. Please try again.";
 }
 
 export function LoginPage() {
@@ -48,101 +54,89 @@ export function LoginPage() {
 
   return (
     <main className="login-page">
-      <header className="login-header" aria-label="AegisAI sign-in header">
-        <div>
-          <p className="eyebrow">AegisAI</p>
-          <p className="login-header-title">Security workspace for repository trust decisions</p>
-        </div>
-        <p className="login-header-meta">Session-first access for Java repository scanning</p>
-      </header>
-
-      <section className="login-hero">
-        <div className="login-copy">
-          <p className="eyebrow">Editorial security login</p>
-          <h1>Secure Java scanning that stays in your provider flow.</h1>
-          <p className="login-lead">
-            Authenticate with GitHub or GitLab, keep session-based control, and move straight
-            into repository connection and queued branch scans once sign-in completes.
-          </p>
-          <p className="login-support-copy">
-            AegisAI only uses provider-authorized repository, branch, and scan context. Your
-            access stays explicit from the first screen.
-          </p>
-
-          <div className="login-trust-strip" aria-label="Session and repository access notes">
-            <span>Session-based auth</span>
-            <span>Provider OAuth only</span>
-            <span>Java-first MVP</span>
+      <div className="login-shell">
+        <header className="login-topbar" aria-label="AegisAI sign-in header">
+          <div>
+            <p className="eyebrow">AegisAI</p>
+            <p className="login-header-title">Secure login for repository-scoped analysis</p>
           </div>
+          <Link className="login-back-link" to="/">
+            Back to overview
+          </Link>
+        </header>
 
-          <dl className="login-facts" aria-label="Security-first access highlights">
-            <div>
-              <dt>01</dt>
-              <dd>Authenticate once, then continue into repository selection without a detached auth silo.</dd>
-            </div>
-            <div>
-              <dt>02</dt>
-              <dd>OAuth tokens are scoped to repository discovery, branch context, and scan execution.</dd>
-            </div>
-          </dl>
-        </div>
-
-        <div className="login-card">
-          <div className="login-card-header">
-            <p className="eyebrow">Access portal</p>
-            <h2>Choose a provider and enter the workspace.</h2>
-            <p className="login-card-copy">
-              Use the same session flow for repository discovery, branch validation, and scan
-              kickoff. Nothing starts until you authorize the provider you trust.
+        <section className="login-access-layout">
+          <div className="login-access-copy">
+            <p className="eyebrow">Step two</p>
+            <h1>Secure access for repository scanning.</h1>
+            <p className="login-lead">
+              Continue with the provider that owns your repositories and keep access explicit from
+              session bootstrap through scan initiation.
             </p>
-          </div>
 
-          {errorMessage ? (
-            <div className="login-alert" role="alert">
-              <strong>Authentication did not complete.</strong>
-              <p>{errorMessage}</p>
-            </div>
-          ) : null}
-
-          {!errorMessage && bootstrapErrorMessage ? (
-            <div className="login-alert" role="alert">
-              <strong>Existing session unavailable.</strong>
-              <p>{bootstrapErrorMessage}</p>
-            </div>
-          ) : null}
-
-          {isLoading ? (
-            <div className="login-loading" role="status">
-              <strong>Checking your session...</strong>
-              <p>If you already signed in, we will route you back to the protected workspace.</p>
-            </div>
-          ) : (
-            <div className="provider-actions">
-              {providerActions.map((action) => (
-                <a
-                  key={action.provider}
-                  className="provider-button"
-                  href={getProviderLoginUrl(action.provider)}
-                >
-                  <span className="provider-button-topline">
-                    <span className="provider-glyph" aria-hidden="true">
-                      {action.glyph}
-                    </span>
-                    <span className="provider-button-eyebrow">{action.eyebrow}</span>
-                  </span>
-                  <strong>{action.label}</strong>
-                  <span className="provider-button-copy">{action.description}</span>
-                </a>
+            <div className="login-trust-strip" aria-label="Session and repository access notes">
+              {trustSignals.map((signal) => (
+                <span key={signal}>{signal}</span>
               ))}
             </div>
-          )}
-
-          <div className="login-footer-note">
-            <p>Security architecture remains session-aware and provider-scoped from first login.</p>
-            <p>Continue with the provider that owns the repositories you want to scan.</p>
           </div>
-        </div>
-      </section>
+
+          <section className="login-access-card" aria-label="AegisAI provider access">
+            <div className="login-card-header">
+              <p className="eyebrow">Access portal</p>
+              <h2>Continue with your provider</h2>
+              <p className="login-card-copy">
+                Authorize once, then move directly into protected repository management and scan
+                orchestration.
+              </p>
+            </div>
+
+            {errorMessage ? (
+              <div className="login-alert" role="alert">
+                <strong>Authentication could not be completed.</strong>
+                <p>{errorMessage}</p>
+              </div>
+            ) : null}
+
+            {!errorMessage && bootstrapErrorMessage ? (
+              <div className="login-alert" role="alert">
+                <strong>Existing session unavailable.</strong>
+                <p>{bootstrapErrorMessage}</p>
+              </div>
+            ) : null}
+
+            {isLoading ? (
+              <div className="login-loading" role="status">
+                <strong>Checking your session...</strong>
+                <p>If an active session exists, we will route you back into the protected workspace.</p>
+              </div>
+            ) : (
+              <div className="provider-actions">
+                {providerActions.map((action) => (
+                  <a
+                    key={action.provider}
+                    className="provider-button"
+                    href={getProviderLoginUrl(action.provider)}
+                  >
+                    <span className="provider-button-topline">
+                      <span className="provider-glyph" aria-hidden="true">
+                        {action.glyph}
+                      </span>
+                      <span className="provider-button-eyebrow">{action.eyebrow}</span>
+                    </span>
+                    <strong>{action.label}</strong>
+                    <span className="provider-button-copy">{action.description}</span>
+                  </a>
+                ))}
+              </div>
+            )}
+
+            <div className="login-footer-note">
+              <p>Session-controlled entry stays aligned with provider authorization from the first action.</p>
+            </div>
+          </section>
+        </section>
+      </div>
     </main>
   );
 }

--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { routes } from "./router";
+
+describe("router", () => {
+  it("exposes the public landing page at the root path", () => {
+    expect(routes[0]?.path).toBe("/");
+  });
+
+  it("keeps /login separate from the protected workspace routes", () => {
+    expect(routes[1]?.path).toBe("/login");
+    expect(routes[2]?.path).toBeUndefined();
+  });
+});

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,19 +1,23 @@
-import { createBrowserRouter, Navigate } from "react-router-dom";
+import { createBrowserRouter, type RouteObject } from "react-router-dom";
 
 import { AppShell } from "./components/layout/AppShell";
 import { ProtectedRoute } from "./components/layout/ProtectedRoute";
 import { DashboardPage } from "./pages/DashboardPage";
+import { LandingPage } from "./pages/LandingPage";
 import { LoginPage } from "./pages/LoginPage";
 import { ReposPage } from "./pages/ReposPage";
 import { ScanPage } from "./pages/ScanPage";
 
-export const router = createBrowserRouter([
+export const routes: RouteObject[] = [
+  {
+    path: "/",
+    element: <LandingPage />,
+  },
   {
     path: "/login",
     element: <LoginPage />,
   },
   {
-    path: "/",
     element: (
       <ProtectedRoute>
         <AppShell />
@@ -21,21 +25,19 @@ export const router = createBrowserRouter([
     ),
     children: [
       {
-        index: true,
-        element: <Navigate replace to="/dashboard" />,
-      },
-      {
-        path: "dashboard",
+        path: "/dashboard",
         element: <DashboardPage />,
       },
       {
-        path: "repos",
+        path: "/repos",
         element: <ReposPage />,
       },
       {
-        path: "scan",
+        path: "/scan",
         element: <ScanPage />,
       },
     ],
   },
-]);
+];
+
+export const router = createBrowserRouter(routes);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -137,92 +137,143 @@ button {
   padding: 24px;
 }
 
+.landing-page,
 .login-page {
   min-height: 100vh;
-  padding: 24px;
-  position: relative;
-  overflow: hidden;
+  padding: 28px;
 }
 
+.landing-page {
+  background:
+    radial-gradient(circle at top right, rgba(181, 141, 61, 0.1), transparent 24%),
+    radial-gradient(circle at bottom left, rgba(64, 94, 146, 0.08), transparent 16%),
+    linear-gradient(180deg, #fbf9f4 0%, #f3f0e8 100%);
+}
+
+.login-page {
+  background:
+    radial-gradient(circle at top right, rgba(181, 141, 61, 0.08), transparent 22%),
+    linear-gradient(180deg, #fcfbf7 0%, #f4f1ea 100%);
+}
+
+.landing-page::before,
 .login-page::before {
   content: "";
-  position: absolute;
+  position: fixed;
   inset: 0;
   background:
     linear-gradient(90deg, rgba(122, 89, 8, 0.04) 1px, transparent 1px),
     linear-gradient(rgba(122, 89, 8, 0.03) 1px, transparent 1px);
-  background-size: 72px 72px;
-  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent 70%);
+  background-size: 78px 78px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.35), transparent 70%);
+  opacity: 0.5;
   pointer-events: none;
 }
 
-.login-header {
+.landing-shell,
+.login-shell {
   width: min(1220px, 100%);
   margin: 0 auto;
-  padding: 6px 0 24px;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 20px;
   position: relative;
   z-index: 1;
 }
 
-.login-header-title,
-.login-header-meta {
-  margin: 6px 0 0;
+.landing-nav,
+.login-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.landing-nav {
+  padding: 8px 0 36px;
+}
+
+.login-topbar {
+  padding: 8px 0 28px;
+}
+
+.landing-brand-copy,
+.login-header-title {
+  margin: 8px 0 0;
   color: var(--ink-faint);
   font-size: 0.95rem;
 }
 
-.login-header-meta {
-  text-align: right;
-  max-width: 18rem;
+.landing-nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 18px;
+  color: var(--ink-muted);
+  font-size: 0.95rem;
 }
 
-.login-hero {
-  width: min(1220px, 100%);
-  margin: 0 auto;
+.landing-nav-links a,
+.login-back-link,
+.landing-text-cta {
+  position: relative;
+  color: var(--ink-muted);
+}
+
+.landing-nav-links a::after,
+.login-back-link::after,
+.landing-text-cta::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -4px;
+  width: 100%;
+  height: 1px;
+  transform: scaleX(0);
+  transform-origin: left;
+  background: rgba(122, 89, 8, 0.5);
+  transition: transform 180ms ease;
+}
+
+.landing-nav-links a:hover::after,
+.login-back-link:hover::after,
+.landing-text-cta:hover::after {
+  transform: scaleX(1);
+}
+
+.landing-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(380px, 0.85fr);
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
   gap: 40px;
   align-items: stretch;
-  position: relative;
-  z-index: 1;
 }
 
-.login-copy,
-.login-card {
-  border: 1px solid rgba(122, 89, 8, 0.05);
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 24px 48px -12px rgba(27, 28, 25, 0.06);
-  border-radius: 24px;
-}
-
-.login-copy {
-  padding: 56px;
+.landing-hero-copy {
   display: grid;
-  gap: 20px;
+  gap: 24px;
   align-content: center;
-  background:
-    radial-gradient(circle at top right, rgba(181, 141, 61, 0.12), transparent 30%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(245, 243, 238, 0.92));
+  padding: 36px 0 12px;
 }
 
-.login-copy h1,
-.login-card h2 {
+.landing-hero-copy h1,
+.landing-section-heading h2,
+.landing-final-cta h2,
+.login-access-copy h1,
+.login-card-header h2 {
   margin: 0;
-  line-height: 1.04;
   font-family: var(--font-display);
-  letter-spacing: -0.02em;
+  line-height: 0.98;
+  letter-spacing: -0.03em;
   color: var(--ink-strong);
 }
 
-.login-copy h1 {
-  font-size: clamp(3rem, 6vw, 5.2rem);
-  max-width: 12.5ch;
+.landing-hero-copy h1 {
+  font-size: clamp(3.2rem, 7vw, 6rem);
+  max-width: 10ch;
 }
 
+.landing-lead,
+.landing-panel-card p,
+.landing-step-card p,
+.landing-assurance-card p,
+.landing-final-cta p,
 .login-lead,
 .login-card-copy,
 .provider-button-copy,
@@ -231,70 +282,228 @@ button {
   color: var(--ink-muted);
 }
 
-.login-support-copy {
-  margin: 0;
-  max-width: 42rem;
-  color: var(--ink-faint);
-  font-size: 0.97rem;
+.landing-lead {
+  max-width: 38rem;
+  font-size: 1.05rem;
 }
 
+.landing-cta-row,
+.landing-final-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+}
+
+.landing-primary-cta,
+.landing-secondary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.25rem;
+  padding: 0 22px;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.landing-primary-cta {
+  color: #fff;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+  box-shadow: 0 18px 36px rgba(122, 89, 8, 0.18);
+}
+
+.landing-secondary-cta {
+  color: var(--ink-strong);
+  border: 1px solid rgba(122, 89, 8, 0.14);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.landing-trust-strip,
 .login-trust-strip {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  padding-top: 16px;
 }
 
+.landing-trust-strip span,
 .login-trust-strip span {
-  padding: 10px 16px;
+  padding: 10px 14px;
   border-radius: 999px;
-  background: rgba(245, 243, 238, 0.94);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(122, 89, 8, 0.08);
   color: var(--ink-muted);
-  border: 1px solid rgba(122, 89, 8, 0.06);
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
   font-weight: 700;
 }
 
-.login-facts {
-  margin: 16px 0 0;
+.landing-hero-panel {
+  display: grid;
+  gap: 18px;
+  align-content: center;
+}
+
+.landing-panel-card,
+.landing-panel-metrics,
+.landing-step-card,
+.landing-assurance-card,
+.landing-final-cta,
+.login-access-card {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(122, 89, 8, 0.06);
+  box-shadow: 0 24px 48px -12px rgba(27, 28, 25, 0.06);
+}
+
+.landing-panel-card,
+.landing-panel-metrics {
+  border-radius: 28px;
+}
+
+.landing-panel-card {
+  padding: 28px;
+  display: grid;
+  gap: 14px;
+}
+
+.landing-panel-card h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  line-height: 1.04;
+  font-family: var(--font-display);
+  color: var(--ink-strong);
+}
+
+.landing-panel-metrics {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.landing-panel-metrics div {
+  display: grid;
+  gap: 4px;
+}
+
+.landing-panel-metrics strong,
+.landing-step-index {
+  color: var(--brass-deep);
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+}
+
+.landing-logo-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 44px;
+  padding: 18px 0;
+  color: var(--ink-faint);
+  letter-spacing: 0.12em;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+}
+
+.landing-workflow,
+.landing-assurance {
+  display: grid;
+  gap: 28px;
+  margin-top: 72px;
+}
+
+.landing-section-heading {
+  display: grid;
+  gap: 10px;
+}
+
+.landing-section-heading h2,
+.landing-final-cta h2 {
+  max-width: 14ch;
+  font-size: clamp(2.1rem, 4vw, 3.4rem);
+}
+
+.landing-step-grid,
+.landing-assurance-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.landing-step-card,
+.landing-assurance-card {
+  border-radius: 24px;
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.landing-step-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--ink-strong);
+}
+
+.landing-final-cta {
+  margin-top: 72px;
+  border-radius: 28px;
+  padding: 32px;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: center;
+}
+
+.landing-footer {
+  margin-top: 36px;
+  padding: 24px 0 12px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.landing-footer-column ul {
+  margin: 14px 0 0;
   padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+  color: var(--ink-faint);
+}
+
+.login-access-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(360px, 0.8fr);
+  gap: 40px;
+  align-items: center;
+  padding: 44px 0 12px;
+}
+
+.login-access-copy {
   display: grid;
   gap: 22px;
+  padding-right: 12px;
 }
 
-.login-facts div {
+.login-access-copy h1 {
+  max-width: 12ch;
+  font-size: clamp(3rem, 5vw, 5rem);
+}
+
+.login-access-card {
+  border-radius: 28px;
+  padding: 32px;
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 14px;
-  align-items: start;
-}
-
-.login-facts dt {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: 1.5rem;
-  color: var(--brass-deep);
-}
-
-.login-facts dd {
-  margin: 0;
-  color: var(--ink-muted);
-}
-
-.login-card {
-  padding: 40px;
-  display: grid;
-  gap: 24px;
-  align-content: start;
-  background:
-    linear-gradient(180deg, rgba(245, 243, 238, 0.94), rgba(255, 255, 255, 0.98));
+  gap: 22px;
 }
 
 .login-card-header {
   display: grid;
   gap: 10px;
+}
+
+.login-card-header h2 {
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
 }
 
 .provider-actions {
@@ -306,7 +515,7 @@ button {
   display: grid;
   gap: 10px;
   padding: 20px;
-  border-radius: 18px;
+  border-radius: 20px;
   border: 1px solid rgba(122, 89, 8, 0.08);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 240, 233, 0.96));
   transition:
@@ -322,7 +531,7 @@ button {
 }
 
 .provider-button strong {
-  font-size: 1.12rem;
+  font-size: 1.08rem;
   color: var(--ink-strong);
 }
 

--- a/docs/superpowers/plans/2026-03-26-public-landing-login-entry.md
+++ b/docs/superpowers/plans/2026-03-26-public-landing-login-entry.md
@@ -1,0 +1,12 @@
+# Public Landing Page And Login Entry Flow Plan
+
+## Issue
+
+- `#77` `Feat: public landing page and login entry flow 구현`
+
+## Plan
+
+1. Add landing page and router tests that describe the new public entry structure before changing implementation.
+2. Implement a dedicated `LandingPage` and expose public `/` and `/login` routes while keeping protected routes behind the existing shell.
+3. Refactor `LoginPage.tsx` and shared styles to match the approved landing-plus-access split.
+4. Re-run targeted web tests, then run workspace validation (`lint`, `test`, `typecheck`, `build`).

--- a/docs/superpowers/specs/2026-03-26-public-landing-login-entry-design.md
+++ b/docs/superpowers/specs/2026-03-26-public-landing-login-entry-design.md
@@ -1,0 +1,31 @@
+# Public Landing Page And Login Entry Flow Design
+
+## Context
+
+- Issue: `#77`
+- Scope: introduce a public SaaS landing page at `/` and reposition `/login` as a focused secure access page
+- Constraint: keep the existing OAuth flow, auth bootstrap behavior, and protected workspace routes intact
+
+## Goals
+
+- Make AegisAI feel like a real commercial SaaS product before authentication
+- Separate product introduction from the secure access step so each screen has one clear job
+- Align the public entry flow with the approved light, premium Stitch direction
+
+## Screen Direction
+
+- `/` becomes a public editorial landing page with product narrative, trust framing, workflow explanation, and provider entry CTA
+- `/login` becomes a short, high-confidence secure access page with provider actions and session status handling
+- Protected workspace routes remain dedicated to authenticated product use and keep their existing paths
+
+## Information Architecture
+
+- Landing page sections: public nav, hero, trust strip, workflow, assurance, final CTA, footer
+- Login page sections: compact top bar, narrative copy, trust strip, provider access card, session/error states
+- Routing order: public landing, public login, then protected shell routes
+
+## Non-Goals
+
+- No changes to OAuth endpoints or backend auth contracts
+- No redesign of repositories, scans, or dashboard in this issue
+- No protected app shell redesign in this issue


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `codex/feat-77-public-landing-login-entry`
- 이슈: `#77`

## 🔎 주요 변경 사항

- 공개 소개 페이지(`/`)를 추가해 AegisAI의 제품 소개, 신뢰 요소, 기본 워크플로우, provider 진입 CTA를 구성했습니다.
- 로그인 페이지(`/login`)를 전용 secure access page로 재구성해 OAuth 진입과 세션 상태 확인에 집중하도록 정리했습니다.
- 라우팅 구조를 갱신해 public landing/login과 보호된 workspace 경계를 명확히 분리했습니다.
- landing/login 화면 테스트와 router 테스트를 추가 및 갱신했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [ ] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched public landing page at `/` showcasing product features, workflow steps, and authentication entry points
  * Added "Back to overview" navigation link on login page

* **Improvements**
  * Redesigned login page layout with improved visual structure and navigation
  * Updated error messages for clearer user guidance
  * Enhanced visual design across authentication pages with refined typography and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->