### PR TITLE
Feat: repository connection page UI 구현

### DIFF
--- a/apps/web/src/api/repos.test.ts
+++ b/apps/web/src/api/repos.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { unwrapApiResponse } from "./client";
+import { connectRepo, disconnectRepo } from "./repos";
+
+const { mockedPost, mockedDelete } = vi.hoisted(() => ({
+  mockedPost: vi.fn(),
+  mockedDelete: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  apiClient: {
+    post: mockedPost,
+    delete: mockedDelete,
+  },
+  unwrapApiResponse: vi.fn(),
+}));
+
+const mockedUnwrapApiResponse = vi.mocked(unwrapApiResponse);
+
+describe("repo api helpers", () => {
+  beforeEach(() => {
+    mockedPost.mockReset();
+    mockedDelete.mockReset();
+    mockedUnwrapApiResponse.mockReset();
+  });
+
+  it("submits connect repository requests through the repo api", async () => {
+    mockedPost.mockResolvedValue({
+      data: { success: true },
+    });
+    mockedUnwrapApiResponse.mockReturnValue({
+      id: "repo-2",
+      fullName: "acme/billing-api",
+      connectedAt: "2026-03-26T11:00:00.000Z",
+    });
+
+    const result = await connectRepo({
+      provider: "github",
+      providerRepoId: "gh-2",
+    });
+
+    expect(mockedPost).toHaveBeenCalledWith("/repos", {
+      provider: "github",
+      providerRepoId: "gh-2",
+    });
+    expect(result).toEqual({
+      id: "repo-2",
+      fullName: "acme/billing-api",
+      connectedAt: "2026-03-26T11:00:00.000Z",
+    });
+  });
+
+  it("sends disconnect requests to the repo api", async () => {
+    await disconnectRepo("repo-1");
+
+    expect(mockedDelete).toHaveBeenCalledWith("/repos/repo-1");
+  });
+});

--- a/apps/web/src/api/repos.ts
+++ b/apps/web/src/api/repos.ts
@@ -1,6 +1,8 @@
 import type {
   ApiResponse,
   AvailableRepoListResponse,
+  ConnectRepoRequest,
+  ConnectRepoResponse,
   ConnectedRepoListResponse,
   ListAvailableReposQuery,
   ListRepoBranchesQuery,
@@ -39,4 +41,19 @@ export async function listRepoBranches(
   );
 
   return unwrapApiResponse(response.data);
+}
+
+export async function connectRepo(
+  input: ConnectRepoRequest
+): Promise<ConnectRepoResponse> {
+  const response = await apiClient.post<ApiResponse<ConnectRepoResponse>>(
+    "/repos",
+    input
+  );
+
+  return unwrapApiResponse(response.data);
+}
+
+export async function disconnectRepo(repoId: string): Promise<void> {
+  await apiClient.delete(`/repos/${repoId}`);
 }

--- a/apps/web/src/pages/ReposPage.test.tsx
+++ b/apps/web/src/pages/ReposPage.test.tsx
@@ -1,0 +1,233 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createQueryClient } from "../query-client";
+import { ReposPage } from "./ReposPage";
+import {
+  connectRepo,
+  disconnectRepo,
+  listAvailableRepos,
+  listConnectedRepos,
+  listRepoBranches,
+} from "../api/repos";
+
+vi.mock("../api/repos", () => ({
+  listConnectedRepos: vi.fn(),
+  listAvailableRepos: vi.fn(),
+  listRepoBranches: vi.fn(),
+  connectRepo: vi.fn(),
+  disconnectRepo: vi.fn(),
+}));
+
+const mockedListConnectedRepos = vi.mocked(listConnectedRepos);
+const mockedListAvailableRepos = vi.mocked(listAvailableRepos);
+const mockedListRepoBranches = vi.mocked(listRepoBranches);
+const mockedConnectRepo = vi.mocked(connectRepo);
+const mockedDisconnectRepo = vi.mocked(disconnectRepo);
+
+function renderReposPage() {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>
+        <ReposPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("ReposPage", () => {
+  beforeEach(() => {
+    mockedListConnectedRepos.mockReset();
+    mockedListAvailableRepos.mockReset();
+    mockedListRepoBranches.mockReset();
+    mockedConnectRepo.mockReset();
+    mockedDisconnectRepo.mockReset();
+
+    mockedListConnectedRepos.mockResolvedValue([
+      {
+        id: "repo-1",
+        provider: "github",
+        fullName: "acme/payments-service",
+        cloneUrl: "https://github.com/acme/payments-service.git",
+        defaultBranch: "main",
+        isPrivate: true,
+        lastScanAt: "2026-03-26T10:00:00.000Z",
+        lastScanStatus: "DONE",
+      },
+    ]);
+
+    mockedListAvailableRepos.mockImplementation(async (query) => {
+      if (query.provider === "gitlab") {
+        return {
+          items: [
+            {
+              providerRepoId: "gl-1",
+              fullName: "ops/compliance-service",
+              cloneUrl: "https://gitlab.com/ops/compliance-service.git",
+              defaultBranch: "trunk",
+              isPrivate: true,
+              alreadyConnected: false,
+            },
+          ],
+          page: 1,
+          size: 30,
+          hasNextPage: false,
+          nextPage: null,
+        };
+      }
+
+      return {
+        items: [
+          {
+            providerRepoId: "gh-1",
+            fullName: "acme/payments-service",
+            cloneUrl: "https://github.com/acme/payments-service.git",
+            defaultBranch: "main",
+            isPrivate: true,
+            alreadyConnected: true,
+          },
+          {
+            providerRepoId: "gh-2",
+            fullName: "acme/billing-api",
+            cloneUrl: "https://github.com/acme/billing-api.git",
+            defaultBranch: "develop",
+            isPrivate: false,
+            alreadyConnected: false,
+          },
+        ],
+        page: 1,
+        size: 30,
+        hasNextPage: false,
+        nextPage: null,
+      };
+    });
+
+    mockedListRepoBranches.mockResolvedValue({
+      items: [
+        {
+          name: "main",
+          isDefault: true,
+          lastCommitSha: "abc1234",
+        },
+        {
+          name: "release/2026",
+          isDefault: false,
+          lastCommitSha: "def5678",
+        },
+      ],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null,
+    });
+
+    mockedConnectRepo.mockResolvedValue({
+      id: "repo-2",
+      fullName: "acme/billing-api",
+      connectedAt: "2026-03-26T11:00:00.000Z",
+    });
+
+    mockedDisconnectRepo.mockResolvedValue(undefined);
+  });
+
+  it("renders connected and available repositories with branch insight actions", async () => {
+    const user = userEvent.setup();
+
+    renderReposPage();
+
+    expect(
+      screen.getByRole("heading", { name: /begin the archive/i })
+    ).toBeInTheDocument();
+
+    const connectedSection = screen.getByRole("region", {
+      name: /connected repositories/i,
+    });
+    const availableSection = screen.getByRole("region", {
+      name: /available repositories/i,
+    });
+
+    expect(
+      await within(connectedSection).findByText("acme/payments-service")
+    ).toBeInTheDocument();
+    expect(
+      within(availableSection).getByText("acme/billing-api")
+    ).toBeInTheDocument();
+
+    const branchInsightSection = screen.getByText(/inspect the branch surface before scanning/i)
+      .closest("section");
+    expect(branchInsightSection).not.toBeNull();
+    expect(
+      await within(branchInsightSection!).findByText("release/2026")
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /connect acme\/billing-api/i })
+    );
+
+    expect(mockedConnectRepo).toHaveBeenCalledTimes(1);
+    expect(mockedConnectRepo.mock.calls[0]?.[0]).toEqual({
+      provider: "github",
+      providerRepoId: "gh-2",
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /disconnect acme\/payments-service/i })
+    );
+
+    expect(mockedDisconnectRepo).toHaveBeenCalledTimes(1);
+    expect(mockedDisconnectRepo.mock.calls[0]?.[0]).toBe("repo-1");
+  });
+
+  it("switches the provider filter and refetches available repositories", async () => {
+    const user = userEvent.setup();
+
+    renderReposPage();
+
+    await screen.findByText("acme/billing-api");
+
+    await user.click(screen.getByRole("button", { name: /gitlab/i }));
+
+    await waitFor(() => {
+      expect(mockedListAvailableRepos).toHaveBeenCalledWith({
+        provider: "gitlab",
+        page: 1,
+        size: 30,
+      });
+    });
+
+    expect(await screen.findByText("ops/compliance-service")).toBeInTheDocument();
+  });
+
+  it("renders empty states when there are no connected or available repositories", async () => {
+    mockedListConnectedRepos.mockResolvedValueOnce([]);
+    mockedListAvailableRepos.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null,
+    });
+    mockedListRepoBranches.mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null,
+    });
+
+    renderReposPage();
+
+    expect(await screen.findByText(/no repositories connected yet/i)).toBeInTheDocument();
+
+    const availableSection = screen.getByRole("region", {
+      name: /available repositories/i,
+    });
+    expect(
+      within(availableSection).getByText(/no repositories ready for connection/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/connect a repository to inspect branches/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/ReposPage.tsx
+++ b/apps/web/src/pages/ReposPage.tsx
@@ -1,9 +1,367 @@
+import type { Provider } from "@aegisai/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import {
+  connectRepo,
+  disconnectRepo,
+  listAvailableRepos,
+  listConnectedRepos,
+  listRepoBranches,
+} from "../api/repos";
+
+const AVAILABLE_PAGE_SIZE = 30;
+const BRANCH_PAGE_SIZE = 30;
+
+const providerOptions: Array<{ value: Provider; label: string }> = [
+  { value: "github", label: "GitHub" },
+  { value: "gitlab", label: "GitLab" },
+] as const;
+
 export function ReposPage() {
+  const queryClient = useQueryClient();
+  const [activeProvider, setActiveProvider] = useState<Provider>("github");
+  const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
+
+  const connectedReposQuery = useQuery({
+    queryKey: ["repos", "connected"],
+    queryFn: listConnectedRepos,
+  });
+
+  const availableReposQuery = useQuery({
+    queryKey: ["repos", "available", activeProvider],
+    queryFn: () =>
+      listAvailableRepos({
+        provider: activeProvider,
+        page: 1,
+        size: AVAILABLE_PAGE_SIZE,
+      }),
+  });
+
+  useEffect(() => {
+    const firstRepoId = connectedReposQuery.data?.[0]?.id ?? null;
+
+    if (!selectedRepoId && firstRepoId) {
+      setSelectedRepoId(firstRepoId);
+      return;
+    }
+
+    if (
+      selectedRepoId &&
+      connectedReposQuery.data &&
+      !connectedReposQuery.data.some((repo) => repo.id === selectedRepoId)
+    ) {
+      setSelectedRepoId(firstRepoId);
+    }
+  }, [connectedReposQuery.data, selectedRepoId]);
+
+  const selectedRepo =
+    connectedReposQuery.data?.find((repo) => repo.id === selectedRepoId) ?? null;
+
+  const branchInsightQuery = useQuery({
+    queryKey: ["repos", "branches", selectedRepoId],
+    queryFn: () =>
+      listRepoBranches(selectedRepoId!, {
+        page: 1,
+        size: BRANCH_PAGE_SIZE,
+      }),
+    enabled: Boolean(selectedRepoId),
+  });
+
+  const connectMutation = useMutation({
+    mutationFn: connectRepo,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["repos", "connected"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["repos", "available"],
+        }),
+      ]);
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: disconnectRepo,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["repos", "connected"],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["repos", "available"],
+        }),
+      ]);
+    },
+  });
+
+  const queryErrorMessage =
+    getErrorMessage(connectedReposQuery.error) ??
+    getErrorMessage(availableReposQuery.error) ??
+    getErrorMessage(branchInsightQuery.error);
+  const mutationErrorMessage =
+    getErrorMessage(connectMutation.error) ??
+    getErrorMessage(disconnectMutation.error);
+  const pageErrorMessage = queryErrorMessage ?? mutationErrorMessage;
+
   return (
-    <section className="placeholder-card">
-      <p className="eyebrow">Foundation ready</p>
-      <h2>Repositories</h2>
-      <p>Repository connection UX ships in the repository frontend issue.</p>
+    <section className="repos-page">
+      <header className="repos-hero">
+        <div className="repos-hero-copy">
+          <p className="eyebrow">Connection hub</p>
+          <h2>Begin the Archive</h2>
+          <div className="repos-hero-accent">
+            <p>
+              AegisAI uses read-only repository access for high-fidelity Java scans. Your code
+              stays in your perimeter while we orchestrate security context around it.
+            </p>
+          </div>
+        </div>
+
+        <div className="repos-hero-panel" aria-hidden="true">
+          <span className="repos-hero-panel-kicker">Protocol secured</span>
+        </div>
+      </header>
+
+      <div className="repos-toolbar">
+        <div className="repos-provider-filter" role="toolbar" aria-label="Repository provider">
+          {providerOptions.map((option) => (
+            <button
+              key={option.value}
+              className={`repos-filter-button${
+                activeProvider === option.value ? " is-active" : ""
+              }`}
+              onClick={() => setActiveProvider(option.value)}
+              type="button"
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        <p className="repos-toolbar-copy">
+          Filter available sources without leaving the connected repository registry.
+        </p>
+      </div>
+
+      {pageErrorMessage ? (
+        <div className="repos-alert" role="alert">
+          <strong>Repository access unavailable</strong>
+          <p>{pageErrorMessage}</p>
+        </div>
+      ) : null}
+
+      <div className="repos-layout">
+        <div className="repos-main">
+          <section
+            className="repos-section"
+            aria-label="Connected repositories"
+          >
+            <div className="repos-section-heading">
+              <p className="eyebrow">Connected repositories</p>
+              <h3>Protected sources already in scope</h3>
+            </div>
+
+            {connectedReposQuery.isLoading ? (
+              <p className="repos-state-copy">Loading connected repositories...</p>
+            ) : connectedReposQuery.data?.length ? (
+              <div className="repos-list">
+                {connectedReposQuery.data.map((repo) => (
+                  <article
+                    key={repo.id}
+                    className={`repos-record${
+                      selectedRepoId === repo.id ? " is-selected" : ""
+                    }`}
+                  >
+                    <button
+                      className="repos-record-body"
+                      onClick={() => setSelectedRepoId(repo.id)}
+                      type="button"
+                    >
+                      <div className="repos-record-header">
+                        <span className="repos-provider-badge">
+                          {repo.provider}
+                        </span>
+                        <span className="repos-privacy-badge">
+                          {repo.isPrivate ? "Private" : "Public"}
+                        </span>
+                      </div>
+
+                      <div className="repos-record-copy">
+                        <h4>{repo.fullName}</h4>
+                        <p>Default branch: {repo.defaultBranch}</p>
+                      </div>
+
+                      <dl className="repos-record-meta">
+                        <div>
+                          <dt>Last scan</dt>
+                          <dd>{formatScanStatus(repo.lastScanStatus)}</dd>
+                        </div>
+                        <div>
+                          <dt>Last activity</dt>
+                          <dd>{formatTimestamp(repo.lastScanAt)}</dd>
+                        </div>
+                      </dl>
+                    </button>
+
+                    <button
+                      className="repos-secondary-action"
+                      disabled={disconnectMutation.isPending}
+                      onClick={() => disconnectMutation.mutate(repo.id)}
+                      type="button"
+                      aria-label={`Disconnect ${repo.fullName}`}
+                    >
+                      Disconnect
+                    </button>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p className="repos-state-copy">No repositories connected yet.</p>
+            )}
+          </section>
+
+          <section
+            className="repos-section"
+            aria-label="Available repositories"
+          >
+            <div className="repos-section-heading">
+              <p className="eyebrow">Available repositories</p>
+              <h3>Bring new sources into the scanning archive</h3>
+            </div>
+
+            {availableReposQuery.isLoading ? (
+              <p className="repos-state-copy">Loading available repositories...</p>
+            ) : availableReposQuery.data?.items.length ? (
+              <div className="repos-list">
+                {availableReposQuery.data.items.map((repo) => (
+                  <article key={repo.providerRepoId} className="repos-record">
+                    <div className="repos-record-header">
+                      <span className="repos-provider-badge">{activeProvider}</span>
+                      <span className="repos-privacy-badge">
+                        {repo.isPrivate ? "Private" : "Public"}
+                      </span>
+                    </div>
+
+                    <div className="repos-record-copy">
+                      <h4>{repo.fullName}</h4>
+                      <p>Default branch: {repo.defaultBranch}</p>
+                    </div>
+
+                    <div className="repos-available-actions">
+                      {repo.alreadyConnected ? (
+                        <span className="repos-connected-chip">
+                          Already connected
+                        </span>
+                      ) : (
+                        <button
+                          className="repos-primary-action"
+                          disabled={connectMutation.isPending}
+                          onClick={() =>
+                            connectMutation.mutate({
+                              provider: activeProvider,
+                              providerRepoId: repo.providerRepoId,
+                            })
+                          }
+                          type="button"
+                          aria-label={`Connect ${repo.fullName}`}
+                        >
+                          Connect
+                        </button>
+                      )}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p className="repos-state-copy">No repositories ready for connection.</p>
+            )}
+          </section>
+        </div>
+
+        <aside className="repos-aside">
+          <section className="repos-aside-card">
+            <p className="eyebrow">Branch insight</p>
+            <h3>Inspect the branch surface before scanning</h3>
+
+            {selectedRepo ? (
+              <>
+                <p className="repos-aside-copy">
+                  {selectedRepo.fullName} exposes the following branch archive for scan routing.
+                </p>
+
+                {branchInsightQuery.isLoading ? (
+                  <p className="repos-state-copy">Loading branch insight...</p>
+                ) : branchInsightQuery.data?.items.length ? (
+                  <ul className="repos-branch-list">
+                    {branchInsightQuery.data.items.map((branch) => (
+                      <li key={branch.name}>
+                        <div>
+                          <strong>{branch.name}</strong>
+                          <span>
+                            {branch.isDefault ? "Default branch" : "Branch"}
+                          </span>
+                        </div>
+                        <code>{branch.lastCommitSha ?? "No commit SHA"}</code>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="repos-state-copy">No branch metadata available yet.</p>
+                )}
+              </>
+            ) : (
+              <p className="repos-aside-copy">
+                Connect a repository to inspect branches.
+              </p>
+            )}
+          </section>
+
+          <section className="repos-aside-card">
+            <p className="eyebrow">Privacy protocol</p>
+            <h3>Read-only access, zero archive drift</h3>
+            <ul className="repos-protocol-list">
+              <li>Read-only provider access</li>
+              <li>SOC2 Type II aligned scan environment</li>
+              <li>No permanent source retention</li>
+            </ul>
+          </section>
+        </aside>
+      </div>
     </section>
   );
+}
+
+function formatScanStatus(status: string | null): string {
+  if (!status) {
+    return "No scan recorded";
+  }
+
+  return status.toLowerCase().replace(/_/g, " ");
+}
+
+function formatTimestamp(timestamp: string | null): string {
+  if (!timestamp) {
+    return "Awaiting first scan";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+function getErrorMessage(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "We could not synchronize repository access right now.";
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -130,6 +130,338 @@ button {
   padding: 28px;
 }
 
+.repos-page {
+  display: grid;
+  gap: 32px;
+}
+
+.repos-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(260px, 0.7fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.repos-hero-copy {
+  display: grid;
+  gap: 18px;
+}
+
+.repos-hero-copy h2,
+.repos-section-heading h3,
+.repos-aside-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  color: var(--ink-strong);
+}
+
+.repos-hero-copy h2 {
+  font-size: clamp(2.9rem, 5vw, 5rem);
+}
+
+.repos-hero-accent {
+  max-width: 42rem;
+  padding-left: 22px;
+  border-left: 4px solid var(--brass-deep);
+}
+
+.repos-hero-accent p,
+.repos-toolbar-copy,
+.repos-record-copy p,
+.repos-state-copy,
+.repos-alert p,
+.repos-aside-copy {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.7;
+}
+
+.repos-hero-panel,
+.repos-section,
+.repos-aside-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(122, 89, 8, 0.06);
+  box-shadow: 0 18px 40px rgba(27, 28, 25, 0.06);
+}
+
+.repos-hero-panel {
+  min-height: 220px;
+  padding: 28px;
+  display: flex;
+  align-items: end;
+  justify-content: end;
+  background:
+    linear-gradient(180deg, rgba(251, 249, 244, 0.16), rgba(251, 249, 244, 0.88)),
+    radial-gradient(circle at top left, rgba(181, 141, 61, 0.28), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(64, 94, 146, 0.14), transparent 26%),
+    var(--surface-low);
+}
+
+.repos-hero-panel-kicker {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--brass-deep);
+  font-size: 1.3rem;
+}
+
+.repos-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 0 4px;
+}
+
+.repos-provider-filter {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.repos-filter-button,
+.repos-primary-action,
+.repos-secondary-action,
+.repos-record-body {
+  font: inherit;
+}
+
+.repos-filter-button {
+  border: 1px solid rgba(210, 197, 178, 0.7);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--ink-muted);
+  border-radius: 999px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.repos-filter-button.is-active {
+  color: #fff;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+}
+
+.repos-alert {
+  padding: 18px 20px;
+  border-radius: 16px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(186, 26, 26, 0.12);
+  color: var(--danger-ink);
+}
+
+.repos-alert strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.repos-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.8fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.repos-main,
+.repos-aside {
+  display: grid;
+  gap: 24px;
+}
+
+.repos-section,
+.repos-aside-card {
+  padding: 26px;
+}
+
+.repos-section-heading {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.repos-section-heading h3,
+.repos-aside-card h3 {
+  font-size: clamp(1.7rem, 2vw, 2.35rem);
+}
+
+.repos-list {
+  display: grid;
+  gap: 16px;
+}
+
+.repos-record {
+  display: grid;
+  gap: 14px;
+  padding: 20px;
+  border-radius: 18px;
+  background: var(--surface-low);
+}
+
+.repos-record.is-selected {
+  background: linear-gradient(180deg, rgba(213, 224, 247, 0.32), rgba(245, 243, 238, 0.92));
+}
+
+.repos-record-body {
+  display: grid;
+  gap: 14px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.repos-record-header,
+.repos-available-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.repos-provider-badge,
+.repos-privacy-badge,
+.repos-connected-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.repos-provider-badge {
+  background: rgba(213, 224, 247, 0.72);
+  color: #425067;
+}
+
+.repos-privacy-badge {
+  background: rgba(228, 226, 221, 0.85);
+  color: var(--ink-muted);
+}
+
+.repos-connected-chip {
+  background: rgba(122, 89, 8, 0.12);
+  color: var(--brass-deep);
+}
+
+.repos-record-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.repos-record-copy h4 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.55rem;
+  letter-spacing: -0.03em;
+}
+
+.repos-record-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+
+.repos-record-meta dt {
+  margin: 0 0 4px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.repos-record-meta dd {
+  margin: 0;
+  color: var(--ink-strong);
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.repos-primary-action,
+.repos-secondary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0 16px;
+  cursor: pointer;
+}
+
+.repos-primary-action {
+  border: 0;
+  color: #fff;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+}
+
+.repos-secondary-action {
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  background: transparent;
+  color: var(--brass-deep);
+}
+
+.repos-primary-action:disabled,
+.repos-secondary-action:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+.repos-branch-list,
+.repos-protocol-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.repos-branch-list li,
+.repos-protocol-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--surface-low);
+}
+
+.repos-branch-list strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.repos-branch-list span {
+  display: block;
+  color: var(--ink-faint);
+  font-size: 0.82rem;
+}
+
+.repos-branch-list code {
+  font-size: 0.82rem;
+  color: var(--ink-muted);
+}
+
+.repos-protocol-list li {
+  justify-content: flex-start;
+  color: var(--ink-muted);
+}
+
 .standalone-page {
   min-height: 100vh;
   display: grid;
@@ -873,7 +1205,8 @@ button {
   }
 
   .landing-step-grid-v2,
-  .login-trust-grid-v2 {
+  .login-trust-grid-v2,
+  .repos-record-meta {
     grid-template-columns: 1fr;
   }
 
@@ -885,6 +1218,14 @@ button {
 
   .login-card-v2 {
     padding: 32px 24px;
+  }
+
+  .repos-hero,
+  .repos-layout,
+  .repos-toolbar {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 

--- a/docs/superpowers/plans/2026-03-26-repository-connection-page-ui.md
+++ b/docs/superpowers/plans/2026-03-26-repository-connection-page-ui.md
@@ -1,0 +1,71 @@
+# Repository Connection Page Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the protected repository connection page UI at `/repositories`, using the Stitch desktop repository connection design as the baseline while wiring it to the existing repo APIs.
+
+**Architecture:** Keep the existing protected app shell intact and replace the page body with a Stitch-aligned repository connection workspace. Use React Query for connected, available, and branch queries, and keep connect/disconnect actions inside the same page state loop.
+
+**Tech Stack:** React, React Router, TanStack Query, Axios API helpers, Vitest, CSS, Stitch screen references
+
+---
+
+## Chunk 1: Lock The Repository UX In Tests
+
+### Task 1: Add failing tests for connection workflows
+
+**Files:**
+- Add: `apps/web/src/pages/ReposPage.test.tsx`
+- Add: `apps/web/src/api/repos.test.ts`
+
+- [ ] Cover connected and available repository rendering
+- [ ] Cover provider filter switching
+- [ ] Cover connect and disconnect action wiring
+- [ ] Cover empty-state rendering
+- [ ] Run the targeted web tests and confirm they fail for the expected reasons
+
+## Chunk 2: Wire Missing Repo Client Actions
+
+### Task 2: Extend the repo API helper surface
+
+**Files:**
+- Modify: `apps/web/src/api/repos.ts`
+
+- [ ] Add `connectRepo()` using the existing shared request/response contract
+- [ ] Add `disconnectRepo()` using the existing repo delete endpoint
+- [ ] Keep response unwrapping aligned with the shared API envelope
+
+## Chunk 3: Build The Stitch-Aligned Page Body
+
+### Task 3: Replace the repository placeholder with the connection workspace
+
+**Files:**
+- Modify: `apps/web/src/pages/ReposPage.tsx`
+
+- [ ] Add the editorial hero and provider filter
+- [ ] Load connected repositories and available repositories with React Query
+- [ ] Add connect and disconnect mutations with query invalidation
+- [ ] Add branch insight tied to the currently selected connected repository
+- [ ] Preserve loading, empty, and error states inside the page body
+
+### Task 4: Add repository page styling based on the Stitch composition
+
+**Files:**
+- Modify: `apps/web/src/styles.css`
+
+- [ ] Add repository page layout, card, aside, and state styling
+- [ ] Keep the page visually aligned with the warm editorial protected-shell tone
+- [ ] Preserve responsive behavior without redesigning the app shell
+
+## Chunk 4: Verify The Page In Isolation And In Workspace Context
+
+### Task 5: Run targeted and workspace validation
+
+**Files:**
+- Verify only
+
+- [ ] Run `corepack pnpm --filter @aegisai/web test -- ReposPage repos.test`
+- [ ] Run `corepack pnpm lint`
+- [ ] Run `corepack pnpm test`
+- [ ] Run `corepack pnpm typecheck`
+- [ ] Run `corepack pnpm build`

--- a/docs/superpowers/specs/2026-03-26-repository-connection-page-design.md
+++ b/docs/superpowers/specs/2026-03-26-repository-connection-page-design.md
@@ -1,0 +1,74 @@
+# Repository Connection Page Design
+
+## Context
+
+- Issue: `#81`
+- Frontend design work must use Stitch as the primary design source
+- Existing protected shell from `#64` and `#79` remains the outer frame
+- Stitch project: `projects/11276866576122067718` (`AegisAI Public Entry V2`)
+- Source screens explored for this issue:
+  - Mobile repository connection: `projects/11276866576122067718/screens/d6451bb934ca4788be72465093268bef`
+  - Desktop repository connection: `projects/11276866576122067718/screens/6b8143ea99f843e098d9b0ef4c91ad94`
+  - Connected-state exploration: `projects/11276866576122067718/screens/91016a2a38184a379dba7be1ff715662`
+
+## Goals
+
+- Turn `/repositories` into a real connection workspace instead of a placeholder
+- Preserve the Stitch editorial tone and composition as much as possible
+- Connect the screen to the existing repo APIs without redesigning the protected shell
+- Make provider filtering, connect, disconnect, and branch insight legible in one surface
+
+## Design Direction
+
+- Keep the existing app shell chrome and transplant the Stitch repository experience into the page body
+- Preserve the strongest Stitch motifs:
+  - editorial hero copy
+  - provider-driven connection surface
+  - privacy and trust messaging
+  - asymmetrical side content
+- Remove only the parts that would duplicate the existing app shell, such as the extra left registry navigation
+
+## Page Structure
+
+### Hero
+
+- Kicker: `Connection hub`
+- Headline: `Begin the Archive`
+- Supporting copy focused on read-only scanning and controlled access
+- Decorative secured panel kept as a visual anchor
+
+### Toolbar
+
+- Provider filter buttons for GitHub and GitLab
+- Secondary copy that explains the filtering behavior
+
+### Main Column
+
+- Connected repositories section
+  - existing connections
+  - selection state for branch insight
+  - disconnect action
+- Available repositories section
+  - filtered by active provider
+  - connected chip for already-linked sources
+  - connect action for ready sources
+
+### Aside Column
+
+- Branch insight panel for the selected connected repository
+- Privacy protocol panel that reinforces the trust model and non-persistence rules
+
+## Runtime Behavior
+
+- Connected repositories are loaded on page entry
+- Available repositories are re-fetched when the provider filter changes
+- Branch insight follows the selected connected repository
+- Connect and disconnect actions invalidate the connected and available queries
+- Empty, loading, and error states stay visible inside their relevant sections rather than through modals
+
+## Constraints
+
+- Do not redesign the app shell itself in this issue
+- Do not introduce new backend endpoints
+- Keep Stitch output as the visual source of truth and only make implementation-driven adjustments
+- Preserve accessible button labels, section landmarks, and responsive behavior


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/81-repository-connection-page-ui`
- 이슈: `#81`

## 🔎 주요 변경 사항

- Stitch 기준으로 `/repositories` 페이지를 실제 repository connection workspace UI로 구현했습니다.
- connected repositories, available repositories, branch insight, privacy protocol 구성을 한 화면에 연결했습니다.
- provider filter와 connect, disconnect 액션을 frontend API client와 연결했습니다.
- `apps/web/src/api/repos.ts`에 repository connect/disconnect helper를 추가했습니다.
- repository connection page와 repo API helper에 대한 회귀 테스트를 추가했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- Stitch 산출물을 기준으로 구현했고, 기능 연결과 반응형 보정에 필요한 최소 수정만 적용했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated repository connection page enabling users to connect and disconnect repositories across different providers.
  * Added provider filtering to view available repositories by source.
  * Implemented branch inspection for selected repositories.
  * Enhanced UI with connected and available repository lists, including empty-state messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->