### PR TITLE
Feat: scan request and status page UI 구현

### DIFF
--- a/apps/web/src/pages/ScanPage.test.tsx
+++ b/apps/web/src/pages/ScanPage.test.tsx
@@ -1,0 +1,256 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listConnectedRepos, listRepoBranches } from "../api/repos";
+import { getScan, listRepoScans, requestScan } from "../api/scans";
+import { createQueryClient } from "../query-client";
+import { ScanPage } from "./ScanPage";
+
+vi.mock("../api/repos", () => ({
+  listConnectedRepos: vi.fn(),
+  listRepoBranches: vi.fn(),
+}));
+
+vi.mock("../api/scans", () => ({
+  requestScan: vi.fn(),
+  getScan: vi.fn(),
+  listRepoScans: vi.fn(),
+}));
+
+const mockedListConnectedRepos = vi.mocked(listConnectedRepos);
+const mockedListRepoBranches = vi.mocked(listRepoBranches);
+const mockedRequestScan = vi.mocked(requestScan);
+const mockedListRepoScans = vi.mocked(listRepoScans);
+const mockedGetScan = vi.mocked(getScan);
+
+function renderScanPage() {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>
+        <ScanPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("ScanPage", () => {
+  beforeEach(() => {
+    mockedListConnectedRepos.mockReset();
+    mockedListRepoBranches.mockReset();
+    mockedRequestScan.mockReset();
+    mockedListRepoScans.mockReset();
+    mockedGetScan.mockReset();
+
+    mockedListConnectedRepos.mockResolvedValue([
+      {
+        id: "repo-1",
+        provider: "github",
+        fullName: "acme/payments-service",
+        cloneUrl: "https://github.com/acme/payments-service.git",
+        defaultBranch: "main",
+        isPrivate: true,
+        lastScanAt: "2026-03-27T08:00:00.000Z",
+        lastScanStatus: "RUNNING",
+      },
+      {
+        id: "repo-2",
+        provider: "gitlab",
+        fullName: "ops/compliance-service",
+        cloneUrl: "https://gitlab.com/ops/compliance-service.git",
+        defaultBranch: "trunk",
+        isPrivate: true,
+        lastScanAt: null,
+        lastScanStatus: null,
+      },
+    ]);
+
+    mockedListRepoBranches.mockImplementation(async (repoId) => {
+      if (repoId === "repo-2") {
+        return {
+          items: [
+            {
+              name: "trunk",
+              isDefault: true,
+              lastCommitSha: "ghi9012",
+            },
+          ],
+          page: 1,
+          size: 30,
+          hasNextPage: false,
+          nextPage: null,
+        };
+      }
+
+      return {
+        items: [
+          {
+            name: "main",
+            isDefault: true,
+            lastCommitSha: "abc1234",
+          },
+          {
+            name: "release/2026",
+            isDefault: false,
+            lastCommitSha: "def5678",
+          },
+        ],
+        page: 1,
+        size: 30,
+        hasNextPage: false,
+        nextPage: null,
+      };
+    });
+
+    mockedListRepoScans.mockImplementation(async (repoId) => {
+      if (repoId === "repo-2") {
+        return {
+          items: [],
+          totalCount: 0,
+          page: 1,
+          totalPages: 1,
+        };
+      }
+
+      return {
+        items: [
+          {
+            id: "scan-1",
+            repoFullName: "acme/payments-service",
+            branch: "main",
+            commitSha: "abc1234",
+            status: "RUNNING",
+            language: "java",
+            totalFiles: 42,
+            totalLines: 8140,
+            summary: {
+              critical: 1,
+              high: 2,
+              medium: 4,
+              low: 1,
+              info: 0,
+            },
+            startedAt: "2026-03-27T08:00:00.000Z",
+            completedAt: null,
+            errorMessage: null,
+            createdAt: "2026-03-27T07:58:00.000Z",
+          },
+          {
+            id: "scan-0",
+            repoFullName: "acme/payments-service",
+            branch: "release/2026",
+            commitSha: "def5678",
+            status: "DONE",
+            language: "java",
+            totalFiles: 40,
+            totalLines: 7990,
+            summary: {
+              critical: 0,
+              high: 1,
+              medium: 3,
+              low: 2,
+              info: 1,
+            },
+            startedAt: "2026-03-26T08:00:00.000Z",
+            completedAt: "2026-03-26T08:06:00.000Z",
+            errorMessage: null,
+            createdAt: "2026-03-26T07:58:00.000Z",
+          },
+        ],
+        totalCount: 2,
+        page: 1,
+        totalPages: 1,
+      };
+    });
+
+    mockedGetScan.mockResolvedValue({
+      id: "scan-1",
+      repoFullName: "acme/payments-service",
+      branch: "main",
+      commitSha: "abc1234",
+      status: "RUNNING",
+      language: "java",
+      totalFiles: 42,
+      totalLines: 8140,
+      summary: {
+        critical: 1,
+        high: 2,
+        medium: 4,
+        low: 1,
+        info: 0,
+      },
+      startedAt: "2026-03-27T08:00:00.000Z",
+      completedAt: null,
+      errorMessage: null,
+      createdAt: "2026-03-27T07:58:00.000Z",
+    });
+
+    mockedRequestScan.mockResolvedValue({
+      scanId: "scan-2",
+      status: "PENDING",
+      message: "Scan queued successfully.",
+    });
+  });
+
+  it("renders the scan workspace with request controls, recent history, and selected scan detail", async () => {
+    renderScanPage();
+
+    expect(
+      screen.getByRole("heading", { name: /orchestrate the next review/i })
+    ).toBeInTheDocument();
+
+    const requestSection = screen.getByRole("region", {
+      name: /scan request form/i,
+    });
+    expect(
+      await within(requestSection).findByRole("button", { name: /acme\/payments-service/i })
+    ).toBeInTheDocument();
+    expect(await within(requestSection).findByRole("option", { name: "release/2026" })).toBeInTheDocument();
+
+    const recentScansSection = screen.getByRole("region", {
+      name: /recent scans/i,
+    });
+    expect(await within(recentScansSection).findByText("scan-1")).toBeInTheDocument();
+
+    const statusSection = screen.getByRole("region", {
+      name: /selected scan status/i,
+    });
+    expect(await within(statusSection).findByText(/running/i)).toBeInTheDocument();
+    expect(within(statusSection).getByText("abc1234")).toBeInTheDocument();
+    expect(within(statusSection).getByText("Critical")).toBeInTheDocument();
+  });
+
+  it("requests a new scan for the selected repository and branch", async () => {
+    const user = userEvent.setup();
+
+    renderScanPage();
+
+    const branchSelect = await screen.findByLabelText(/branch selector/i);
+    await screen.findByRole("option", { name: "release/2026" });
+    await user.selectOptions(branchSelect, "release/2026");
+    await user.click(screen.getByRole("button", { name: /queue java scan/i }));
+
+    await waitFor(() => {
+      expect(mockedRequestScan).toHaveBeenCalledTimes(1);
+      expect(mockedRequestScan.mock.calls[0]?.[0]).toEqual({
+        repoId: "repo-1",
+        branch: "release/2026",
+      });
+    });
+
+    expect(await screen.findByText(/scan queued successfully/i)).toBeInTheDocument();
+  });
+
+  it("renders a connect-first empty state when no repositories are available for scanning", async () => {
+    mockedListConnectedRepos.mockResolvedValueOnce([]);
+
+    renderScanPage();
+
+    expect(
+      await screen.findByText(/connect a repository before requesting a scan/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/recent scans will appear once a repository is linked/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/ScanPage.tsx
+++ b/apps/web/src/pages/ScanPage.tsx
@@ -1,9 +1,460 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+
+import { listConnectedRepos, listRepoBranches } from "../api/repos";
+import { getScan, listRepoScans, requestScan } from "../api/scans";
+
+const BRANCH_PAGE_SIZE = 100;
+const RECENT_SCANS_PAGE_SIZE = 8;
+const ACTIVE_SCAN_STATUSES = new Set(["PENDING", "RUNNING"]);
+
 export function ScanPage() {
+  const queryClient = useQueryClient();
+  const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState("");
+  const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
+  const [submissionMessage, setSubmissionMessage] = useState<string | null>(null);
+
+  const connectedReposQuery = useQuery({
+    queryKey: ["repos", "connected"],
+    queryFn: listConnectedRepos,
+  });
+
+  useEffect(() => {
+    const firstRepoId = connectedReposQuery.data?.[0]?.id ?? null;
+
+    if (!selectedRepoId && firstRepoId) {
+      setSelectedRepoId(firstRepoId);
+      return;
+    }
+
+    if (
+      selectedRepoId &&
+      connectedReposQuery.data &&
+      !connectedReposQuery.data.some((repo) => repo.id === selectedRepoId)
+    ) {
+      setSelectedRepoId(firstRepoId);
+    }
+  }, [connectedReposQuery.data, selectedRepoId]);
+
+  const selectedRepo =
+    connectedReposQuery.data?.find((repo) => repo.id === selectedRepoId) ?? null;
+
+  const branchesQuery = useQuery({
+    queryKey: ["scan", "branches", selectedRepoId],
+    queryFn: () =>
+      listRepoBranches(selectedRepoId!, {
+        page: 1,
+        size: BRANCH_PAGE_SIZE,
+      }),
+    enabled: Boolean(selectedRepoId),
+  });
+
+  useEffect(() => {
+    const branches = branchesQuery.data?.items ?? [];
+    if (!branches.length) {
+      setSelectedBranch("");
+      return;
+    }
+
+    const preferredBranch =
+      branches.find((branch) => branch.name === selectedRepo?.defaultBranch)?.name ??
+      branches.find((branch) => branch.isDefault)?.name ??
+      branches[0]?.name ??
+      "";
+
+    if (!selectedBranch || !branches.some((branch) => branch.name === selectedBranch)) {
+      setSelectedBranch(preferredBranch);
+    }
+  }, [branchesQuery.data, selectedBranch, selectedRepo?.defaultBranch]);
+
+  const recentScansQuery = useQuery({
+    queryKey: ["scan", "recent", selectedRepoId],
+    queryFn: () => listRepoScans(selectedRepoId!, 1, RECENT_SCANS_PAGE_SIZE),
+    enabled: Boolean(selectedRepoId),
+    refetchInterval: (query) => {
+      const scans = query.state.data?.items ?? [];
+      return scans.some((scan) => ACTIVE_SCAN_STATUSES.has(scan.status)) ? 5000 : false;
+    },
+  });
+
+  useEffect(() => {
+    const firstScanId = recentScansQuery.data?.items[0]?.id ?? null;
+
+    if (!selectedScanId && firstScanId) {
+      setSelectedScanId(firstScanId);
+      return;
+    }
+
+    if (
+      selectedScanId &&
+      recentScansQuery.data &&
+      !recentScansQuery.data.items.some((scan) => scan.id === selectedScanId)
+    ) {
+      setSelectedScanId(firstScanId);
+    }
+  }, [recentScansQuery.data, selectedScanId]);
+
+  const selectedScanSummary =
+    recentScansQuery.data?.items.find((scan) => scan.id === selectedScanId) ?? null;
+
+  const selectedScanQuery = useQuery({
+    queryKey: ["scan", "detail", selectedScanId],
+    queryFn: () => getScan(selectedScanId!),
+    enabled: Boolean(selectedScanId),
+    refetchInterval: (query) =>
+      query.state.data && ACTIVE_SCAN_STATUSES.has(query.state.data.status) ? 5000 : false,
+  });
+
+  const requestScanMutation = useMutation({
+    mutationFn: requestScan,
+    onSuccess: async (response) => {
+      setSubmissionMessage(response.message);
+      setSelectedScanId(null);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["scan", "recent"] }),
+        queryClient.invalidateQueries({ queryKey: ["scan", "detail"] }),
+        queryClient.invalidateQueries({ queryKey: ["repos", "connected"] }),
+      ]);
+    },
+  });
+
+  const selectedScan = selectedScanQuery.data ?? selectedScanSummary;
+  const branchOptions = branchesQuery.data?.items ?? [];
+
+  const requestDisabled =
+    !selectedRepoId ||
+    !selectedBranch ||
+    requestScanMutation.isPending ||
+    connectedReposQuery.isLoading ||
+    branchesQuery.isLoading;
+
+  const totals = useMemo(() => {
+    if (!selectedScan) {
+      return null;
+    }
+
+    return {
+      findings:
+        selectedScan.summary.critical +
+        selectedScan.summary.high +
+        selectedScan.summary.medium +
+        selectedScan.summary.low +
+        selectedScan.summary.info,
+      files: selectedScan.totalFiles ?? "—",
+      lines: selectedScan.totalLines ?? "—",
+    };
+  }, [selectedScan]);
+
   return (
-    <section className="placeholder-card">
-      <p className="eyebrow">Foundation ready</p>
-      <h2>Scan</h2>
-      <p>Scan request and polling UX ships in the scan frontend issue.</p>
+    <section className="scan-page">
+      <header className="scan-hero">
+        <div className="scan-hero-copy">
+          <p className="eyebrow">Scan orchestration</p>
+          <h2>Orchestrate the next review</h2>
+          <div className="scan-hero-accent">
+            <p>
+              Queue Java analysis against a controlled branch archive, then monitor the scan
+              as AegisAI moves from repository snapshot to severity summary.
+            </p>
+          </div>
+        </div>
+
+        <div className="scan-hero-panel" aria-hidden="true">
+          <span className="scan-hero-panel-kicker">Read only. Queue first.</span>
+        </div>
+      </header>
+
+      <div className="scan-layout">
+        <div className="scan-main">
+          <section className="scan-section scan-request-card" aria-label="Scan request form">
+            <div className="scan-section-heading">
+              <p className="eyebrow">Request a scan</p>
+              <h3>Select the source before analysis starts</h3>
+            </div>
+
+            {connectedReposQuery.error ? (
+              <div className="scan-inline-alert" role="alert">
+                <strong>Connected repositories unavailable</strong>
+                <p>{getErrorMessage(connectedReposQuery.error)}</p>
+              </div>
+            ) : connectedReposQuery.isLoading ? (
+              <p className="scan-state-copy">Loading connected repositories...</p>
+            ) : connectedReposQuery.data?.length ? (
+              <>
+                <div className="scan-repo-selector" role="list" aria-label="Connected repositories">
+                  {connectedReposQuery.data.map((repo) => (
+                    <button
+                      key={repo.id}
+                      className={`scan-repo-option${
+                        selectedRepoId === repo.id ? " is-selected" : ""
+                      }`}
+                      onClick={() => {
+                        setSelectedRepoId(repo.id);
+                        setSubmissionMessage(null);
+                      }}
+                      type="button"
+                      aria-pressed={selectedRepoId === repo.id}
+                    >
+                      <span className="scan-repo-option-provider">{repo.provider}</span>
+                      <strong>{repo.fullName}</strong>
+                      <span>
+                        {repo.isPrivate ? "Private" : "Public"} · default {repo.defaultBranch}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="scan-form-grid">
+                  <label className="scan-field">
+                    <span>Repository</span>
+                    <select
+                      aria-label="Repository selector"
+                      value={selectedRepoId ?? ""}
+                      onChange={(event) => {
+                        setSelectedRepoId(event.target.value);
+                        setSubmissionMessage(null);
+                      }}
+                    >
+                      {connectedReposQuery.data.map((repo) => (
+                        <option key={repo.id} value={repo.id}>
+                          {repo.fullName}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="scan-field">
+                    <span>Branch selector</span>
+                    <select
+                      aria-label="Branch selector"
+                      disabled={!branchOptions.length || branchesQuery.isLoading}
+                      value={selectedBranch}
+                      onChange={(event) => {
+                        setSelectedBranch(event.target.value);
+                        setSubmissionMessage(null);
+                      }}
+                    >
+                      {branchOptions.map((branch) => (
+                        <option key={branch.name} value={branch.name}>
+                          {branch.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+
+                {branchesQuery.error ? (
+                  <div className="scan-inline-alert" role="alert">
+                    <strong>Branch archive unavailable</strong>
+                    <p>{getErrorMessage(branchesQuery.error)}</p>
+                  </div>
+                ) : null}
+
+                {requestScanMutation.error ? (
+                  <div className="scan-inline-alert" role="alert">
+                    <strong>Scan request failed</strong>
+                    <p>{getErrorMessage(requestScanMutation.error)}</p>
+                  </div>
+                ) : null}
+
+                <div className="scan-form-footer">
+                  <div className="scan-form-hint">
+                    <p>Language</p>
+                    <strong>Java-first analysis</strong>
+                  </div>
+
+                  <button
+                    className="scan-primary-action"
+                    disabled={requestDisabled}
+                    onClick={() => {
+                      if (!selectedRepoId || !selectedBranch) {
+                        return;
+                      }
+
+                      requestScanMutation.mutate({
+                        repoId: selectedRepoId,
+                        branch: selectedBranch,
+                      });
+                    }}
+                    type="button"
+                  >
+                    {requestScanMutation.isPending ? "Queueing..." : "Queue Java scan"}
+                  </button>
+                </div>
+
+                {submissionMessage ? (
+                  <p className="scan-success-note" role="status" aria-live="polite">
+                    {submissionMessage}
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <div className="scan-empty-state">
+                <strong>Connect a repository before requesting a scan.</strong>
+                <p>Recent scans will appear once a repository is linked and queued.</p>
+              </div>
+            )}
+          </section>
+
+          <section className="scan-section" aria-label="Recent scans">
+            <div className="scan-section-heading">
+              <p className="eyebrow">Recent scans</p>
+              <h3>Track the latest branch reviews</h3>
+            </div>
+
+            {!selectedRepoId ? (
+              <p className="scan-state-copy">Select a connected repository to inspect scans.</p>
+            ) : recentScansQuery.error ? (
+              <div className="scan-inline-alert" role="alert">
+                <strong>Scan history unavailable</strong>
+                <p>{getErrorMessage(recentScansQuery.error)}</p>
+              </div>
+            ) : recentScansQuery.isLoading ? (
+              <p className="scan-state-copy">Loading recent scans...</p>
+            ) : recentScansQuery.data?.items.length ? (
+              <div className="scan-history-list">
+                {recentScansQuery.data.items.map((scan) => (
+                  <button
+                    key={scan.id}
+                    className={`scan-history-card${scan.id === selectedScanId ? " is-selected" : ""}`}
+                    onClick={() => setSelectedScanId(scan.id)}
+                    type="button"
+                    aria-pressed={scan.id === selectedScanId}
+                  >
+                    <div className="scan-history-header">
+                      <strong>{scan.id}</strong>
+                      <span className={`scan-status-pill is-${scan.status.toLowerCase()}`}>
+                        {formatStatus(scan.status)}
+                      </span>
+                    </div>
+                    <p>{scan.branch}</p>
+                    <div className="scan-severity-list">
+                      <span>Critical {scan.summary.critical}</span>
+                      <span>High {scan.summary.high}</span>
+                      <span>Medium {scan.summary.medium}</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="scan-state-copy">No scans have been queued for this repository yet.</p>
+            )}
+          </section>
+        </div>
+
+        <aside className="scan-aside">
+          <section className="scan-aside-card" aria-label="Selected scan status">
+            <p className="eyebrow">Selected scan status</p>
+            <h3>Read the current scan without leaving the queue</h3>
+
+            {selectedScanQuery.error ? (
+              <div className="scan-inline-alert" role="alert">
+                <strong>Selected scan unavailable</strong>
+                <p>{getErrorMessage(selectedScanQuery.error)}</p>
+              </div>
+            ) : selectedScan ? (
+              <>
+                <div className="scan-detail-header">
+                  <strong>{selectedScan.repoFullName}</strong>
+                  <span className={`scan-status-pill is-${selectedScan.status.toLowerCase()}`}>
+                    {formatStatus(selectedScan.status)}
+                  </span>
+                </div>
+
+                <dl className="scan-detail-grid">
+                  <div>
+                    <dt>Branch</dt>
+                    <dd>{selectedScan.branch}</dd>
+                  </div>
+                  <div>
+                    <dt>Commit</dt>
+                    <dd>{selectedScan.commitSha ?? "Pending SHA"}</dd>
+                  </div>
+                  <div>
+                    <dt>Files</dt>
+                    <dd>{totals?.files}</dd>
+                  </div>
+                  <div>
+                    <dt>Lines</dt>
+                    <dd>{totals?.lines}</dd>
+                  </div>
+                </dl>
+
+                <div className="scan-summary-band">
+                  <div>
+                    <span>Total findings</span>
+                    <strong>{totals?.findings ?? 0}</strong>
+                  </div>
+                  <div>
+                    <span>Language</span>
+                    <strong>{selectedScan.language}</strong>
+                  </div>
+                </div>
+
+                <div className="scan-severity-matrix">
+                  {Object.entries(selectedScan.summary).map(([severity, count]) => (
+                    <div key={severity}>
+                      <span>{capitalize(severity)}</span>
+                      <strong>{count}</strong>
+                    </div>
+                  ))}
+                </div>
+
+                {selectedScan.errorMessage ? (
+                  <div className="scan-inline-alert" role="alert">
+                    <strong>Scan error</strong>
+                    <p>{selectedScan.errorMessage}</p>
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <p className="scan-state-copy">Choose a repository or queue a scan to inspect status.</p>
+            )}
+          </section>
+
+          <section className="scan-aside-card scan-trust-card">
+            <p className="eyebrow">Privacy protocol</p>
+            <h3>Repository access remains controlled throughout the queue</h3>
+            <ul className="scan-trust-list">
+              <li>Read-only repository access is used for branch collection.</li>
+              <li>Java-first analysis remains scoped to the selected branch snapshot.</li>
+              <li>Queued scans surface status and severity without exposing source content in the UI.</li>
+            </ul>
+          </section>
+        </aside>
+      </div>
     </section>
   );
+}
+
+function formatStatus(status: string) {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function getErrorMessage(error: unknown) {
+  if (
+    error &&
+    typeof error === "object" &&
+    "response" in error &&
+    error.response &&
+    typeof error.response === "object" &&
+    "data" in error.response &&
+    error.response.data &&
+    typeof error.response.data === "object" &&
+    "message" in error.response.data &&
+    typeof error.response.data.message === "string"
+  ) {
+    return error.response.data.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "An unexpected error occurred.";
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1156,6 +1156,381 @@ button {
   place-items: center;
 }
 
+.scan-page {
+  display: grid;
+  gap: 32px;
+}
+
+.scan-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.scan-hero-copy {
+  display: grid;
+  gap: 18px;
+}
+
+.scan-hero-copy h2,
+.scan-section-heading h3,
+.scan-aside-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  color: var(--ink-strong);
+}
+
+.scan-hero-copy h2 {
+  font-size: clamp(2.8rem, 4.8vw, 4.8rem);
+}
+
+.scan-hero-accent {
+  max-width: 44rem;
+  padding-left: 22px;
+  border-left: 4px solid var(--brass-deep);
+}
+
+.scan-hero-accent p,
+.scan-state-copy,
+.scan-inline-alert p,
+.scan-trust-list,
+.scan-history-card p,
+.scan-field span,
+.scan-form-hint p {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.7;
+}
+
+.scan-hero-panel,
+.scan-section,
+.scan-aside-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(122, 89, 8, 0.06);
+  box-shadow: 0 18px 40px rgba(27, 28, 25, 0.06);
+}
+
+.scan-hero-panel {
+  min-height: 220px;
+  padding: 28px;
+  display: flex;
+  align-items: end;
+  justify-content: end;
+  background:
+    linear-gradient(180deg, rgba(251, 249, 244, 0.12), rgba(251, 249, 244, 0.88)),
+    radial-gradient(circle at top left, rgba(181, 141, 61, 0.26), transparent 30%),
+    radial-gradient(circle at bottom right, rgba(64, 94, 146, 0.14), transparent 24%),
+    var(--surface-low);
+}
+
+.scan-hero-panel-kicker {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--brass-deep);
+  font-size: 1.24rem;
+}
+
+.scan-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(320px, 0.7fr);
+  gap: 24px;
+}
+
+.scan-main,
+.scan-aside {
+  display: grid;
+  gap: 24px;
+}
+
+.scan-section,
+.scan-aside-card {
+  padding: 24px;
+}
+
+.scan-section-heading {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.scan-request-card {
+  gap: 22px;
+}
+
+.scan-repo-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.scan-repo-option,
+.scan-history-card {
+  border: 1px solid rgba(210, 197, 178, 0.6);
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.scan-repo-option {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+  text-align: left;
+}
+
+.scan-repo-option:hover,
+.scan-history-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(122, 89, 8, 0.28);
+  box-shadow: 0 18px 36px rgba(27, 28, 25, 0.06);
+}
+
+.scan-repo-option.is-selected,
+.scan-history-card.is-selected {
+  border-color: rgba(122, 89, 8, 0.38);
+  background: linear-gradient(180deg, rgba(245, 243, 238, 0.94), rgba(255, 255, 255, 0.92));
+}
+
+.scan-repo-option-provider {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brass-deep);
+}
+
+.scan-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.scan-field {
+  display: grid;
+  gap: 10px;
+}
+
+.scan-field span {
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.scan-field select {
+  width: 100%;
+  border: 1px solid rgba(210, 197, 178, 0.7);
+  border-radius: 14px;
+  background: rgba(245, 243, 238, 0.84);
+  color: var(--ink-strong);
+  padding: 14px 16px;
+  min-height: 3.25rem;
+}
+
+.scan-field select:focus {
+  outline: 2px solid rgba(122, 89, 8, 0.24);
+  outline-offset: 2px;
+}
+
+.scan-form-footer {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 22px;
+}
+
+.scan-form-hint strong {
+  display: block;
+  margin-top: 4px;
+  color: var(--ink-strong);
+}
+
+.scan-primary-action {
+  border: 0;
+  border-radius: 999px;
+  padding: 14px 22px;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+  box-shadow: 0 18px 36px rgba(122, 89, 8, 0.18);
+}
+
+.scan-primary-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.scan-success-note {
+  margin: 16px 0 0;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(213, 224, 247, 0.36);
+  color: #425067;
+}
+
+.scan-inline-alert {
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(186, 26, 26, 0.12);
+  color: var(--danger-ink);
+}
+
+.scan-inline-alert strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.scan-empty-state {
+  padding: 22px;
+  border-radius: 16px;
+  background: rgba(245, 243, 238, 0.78);
+}
+
+.scan-empty-state strong {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.scan-history-list {
+  display: grid;
+  gap: 14px;
+}
+
+.scan-history-card {
+  padding: 18px;
+  text-align: left;
+  display: grid;
+  gap: 12px;
+}
+
+.scan-history-header,
+.scan-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.scan-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.scan-status-pill.is-pending {
+  background: rgba(181, 141, 61, 0.2);
+  color: var(--brass-deep);
+}
+
+.scan-status-pill.is-running {
+  background: rgba(213, 224, 247, 0.45);
+  color: #425067;
+}
+
+.scan-status-pill.is-done {
+  background: rgba(221, 237, 220, 0.72);
+  color: #34513c;
+}
+
+.scan-status-pill.is-failed {
+  background: rgba(255, 218, 214, 0.9);
+  color: var(--danger-ink);
+}
+
+.scan-severity-list,
+.scan-severity-matrix {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.scan-severity-list span,
+.scan-severity-matrix div {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(245, 243, 238, 0.82);
+  color: var(--ink-muted);
+  font-size: 0.82rem;
+}
+
+.scan-severity-matrix {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.scan-severity-matrix div {
+  display: grid;
+  gap: 4px;
+}
+
+.scan-severity-matrix strong {
+  color: var(--ink-strong);
+  font-size: 1rem;
+}
+
+.scan-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.scan-detail-grid dt,
+.scan-summary-band span {
+  color: var(--ink-faint);
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.scan-detail-grid dd {
+  margin: 6px 0 0;
+  color: var(--ink-strong);
+}
+
+.scan-summary-band {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.scan-summary-band div {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(245, 243, 238, 0.82);
+  display: grid;
+  gap: 6px;
+}
+
+.scan-summary-band strong {
+  color: var(--ink-strong);
+  font-size: 1.1rem;
+}
+
+.scan-trust-list {
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+}
+
 @media (max-width: 900px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -1222,10 +1597,22 @@ button {
 
   .repos-hero,
   .repos-layout,
-  .repos-toolbar {
+  .repos-toolbar,
+  .scan-hero,
+  .scan-layout,
+  .scan-form-grid,
+  .scan-form-footer,
+  .scan-detail-grid,
+  .scan-summary-band {
     grid-template-columns: 1fr;
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .scan-severity-list,
+  .scan-severity-matrix,
+  .scan-repo-selector {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/docs/superpowers/plans/2026-03-27-scan-request-status-page-ui.md
+++ b/docs/superpowers/plans/2026-03-27-scan-request-status-page-ui.md
@@ -1,0 +1,59 @@
+# Scan Request And Status Page UI Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `/scan` placeholder with a real scan orchestration workspace that lets users queue a scan and monitor recent scan status inside the protected shell.
+
+**Architecture:** Reuse the existing protected route and API helpers. Load connected repositories, branch options, recent scans, and selected scan detail with React Query. Use the protected Stitch repository workspace composition as the visual baseline and adapt it into a scan-centric flow.
+
+**Tech Stack:** React, React Router, TanStack Query, Vitest, CSS, existing repo/scan API helpers, Stitch screen references
+
+---
+
+## Chunk 1: Lock The Page Contract In Tests
+
+### Task 1: Add failing scan page tests
+
+**Files:**
+- Add: `apps/web/src/pages/ScanPage.test.tsx`
+
+- [ ] Cover rendering of the scan request form, recent scans, and selected scan detail
+- [ ] Cover queuing a scan for the selected repository and branch
+- [ ] Cover the connect-first empty state when no repositories are available
+- [ ] Run targeted web tests and confirm they fail for the placeholder page
+
+## Chunk 2: Build The Scan Workspace
+
+### Task 2: Replace the placeholder scan page with a request-and-status workspace
+
+**Files:**
+- Modify: `apps/web/src/pages/ScanPage.tsx`
+
+- [ ] Load connected repositories and default the page to the first available source
+- [ ] Load branch options for the selected repository
+- [ ] Load recent scans and selected scan detail for the active repository
+- [ ] Add request-scan mutation and invalidate scan history/detail after success
+- [ ] Add active scan polling for `PENDING` and `RUNNING` states
+- [ ] Preserve accessible selection state and inline error handling
+
+### Task 3: Add Stitch-aligned styling for the scan workspace
+
+**Files:**
+- Modify: `apps/web/src/styles.css`
+
+- [ ] Add scan hero, request card, history list, status panel, and trust-panel styling
+- [ ] Keep the warm editorial protected-workspace tone established by prior issues
+- [ ] Preserve responsive behavior without redesigning the app shell
+
+## Chunk 3: Verify The Frontend Foundation Still Holds
+
+### Task 4: Run targeted and workspace validation
+
+**Files:**
+- Verify only
+
+- [ ] Run `corepack pnpm --filter @aegisai/web test -- ScanPage`
+- [ ] Run `corepack pnpm lint`
+- [ ] Run `corepack pnpm test`
+- [ ] Run `corepack pnpm typecheck`
+- [ ] Run `corepack pnpm build`

--- a/docs/superpowers/specs/2026-03-27-scan-request-status-page-design.md
+++ b/docs/superpowers/specs/2026-03-27-scan-request-status-page-design.md
@@ -1,0 +1,92 @@
+# Scan Request And Status Page Design
+
+## Context
+
+- Issue: `#83`
+- Existing protected shell and route already exist at `/scan`
+- Frontend design work must use Stitch as the primary design source
+- Design context follows the established AegisAI editorial security direction from prior frontend issues
+- Closest Stitch protected-screen reference:
+  - Project: `projects/861350607109533974` (`AegisAI Login Auth UI`)
+  - Source screen: `projects/861350607109533974/screens/3670ddbf00c14519a6b248b60f6e4b83` (`Repositories Workspace`)
+
+## Stitch Usage Notes
+
+- Fresh Stitch generation for a dedicated scan screen was attempted in the existing editorial project and in a new temporary project.
+- Those generation calls returned invalid-argument and timeout failures.
+- To preserve the mandatory Stitch-first workflow, the final page design uses the existing protected `Repositories Workspace` Stitch screen as the visual baseline and adapts its body composition into a scan orchestration workspace.
+
+## Goals
+
+- Replace the placeholder `/scan` page with a real request-and-status workspace
+- Let a signed-in user:
+  - choose a connected repository
+  - choose a branch
+  - queue a Java scan
+  - inspect recent scan history
+  - read the selected scan status without leaving the page
+- Preserve the same calm editorial tone already established for login and repository connection
+
+## Design Direction
+
+- Keep the protected app shell unchanged
+- Reuse the Stitch protected workspace composition language:
+  - strong editorial hero
+  - asymmetric main/aside layout
+  - soft paper surfaces
+  - restrained brass emphasis
+- Shift the page body from repository connection to scan orchestration
+
+## Page Structure
+
+### Hero
+
+- Kicker: `Scan orchestration`
+- Headline centered on deliberate, controlled review flow
+- Supporting copy about branch snapshot analysis and severity summaries
+- Decorative side panel kept as a premium anchor
+
+### Main Column
+
+- Scan request section
+  - connected repository selector
+  - repository selector field
+  - branch selector field
+  - Java-first action hint
+  - primary queue CTA
+  - inline success and request-error states
+- Recent scans section
+  - latest scan history for the selected repository
+  - selectable scan cards
+  - severity chips and status pills
+
+### Aside Column
+
+- Selected scan status panel
+  - branch
+  - commit
+  - files
+  - lines
+  - total findings
+  - severity matrix
+  - failed-scan message if present
+- Privacy protocol panel
+  - read-only repository access
+  - branch-scoped Java analysis
+  - no source-content exposure in the UI
+
+## Runtime Behavior
+
+- Connected repositories load on entry
+- The first connected repository becomes the active repo by default
+- Branches and recent scans follow the active repository
+- The selected scan detail follows the active scan card
+- New scan requests invalidate scan history and refresh detail state
+- Active scans poll until they settle out of `PENDING` / `RUNNING`
+
+## Constraints
+
+- Keep the route at `/scan` to match the current protected app shell
+- Do not introduce backend changes in this issue
+- Keep Stitch as the visual source of truth, using the nearest protected workspace screen when fresh generation is unavailable
+- Preserve accessible labels and programmatic pressed state for repository and scan selection controls


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/83-scan-request-status-page-ui`
- 이슈: `#83`

## 🔎 주요 변경 사항

- Stitch 기준 protected workspace 톤을 유지하면서 `/scan` 페이지를 실제 scan request and status UI로 구현했습니다.
- 연결된 저장소 선택, 브랜치 선택, scan 요청 액션을 frontend API client와 연결했습니다.
- 최근 scan history와 선택된 scan detail status를 한 화면에서 확인할 수 있도록 구성했습니다.
- loading, empty, error, queued, active scan polling 상태를 UI에 반영했습니다.
- `apps/web/src/pages/ScanPage.test.tsx`를 추가해 request/status 흐름 회귀를 검증했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- Stitch 산출물을 기준으로 구현했고, 기능 연결과 반응형 보정에 필요한 최소 수정만 적용했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated scan request and status page enabling users to select connected repositories and branches to queue scans.
  * View recent scans with severity indicators and status labels.
  * Selected scan detail panel displays scan status, severity breakdown, and analysis metrics.
  * Active scans automatically refresh while processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->