### PR TITLE
Feat: scan flow guardrails and UX polish 구현

### DIFF
--- a/apps/web/src/pages/ReposPage.test.tsx
+++ b/apps/web/src/pages/ReposPage.test.tsx
@@ -162,6 +162,11 @@ describe("ReposPage", () => {
     expect(
       await within(branchInsightSection!).findByText("release/2026")
     ).toBeInTheDocument();
+    expect(
+      within(branchInsightSection!).getByRole("link", {
+        name: /open scan workspace/i,
+      })
+    ).toHaveAttribute("href", "/scan?repo=repo-1");
 
     await user.click(
       screen.getByRole("button", { name: /connect acme\/billing-api/i })

--- a/apps/web/src/pages/ReposPage.tsx
+++ b/apps/web/src/pages/ReposPage.tsx
@@ -1,6 +1,7 @@
 import type { Provider } from "@aegisai/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import {
   connectRepo,
@@ -294,19 +295,30 @@ export function ReposPage() {
                 {branchInsightQuery.isLoading ? (
                   <p className="repos-state-copy">Loading branch insight...</p>
                 ) : branchInsightQuery.data?.items.length ? (
-                  <ul className="repos-branch-list">
-                    {branchInsightQuery.data.items.map((branch) => (
-                      <li key={branch.name}>
-                        <div>
-                          <strong>{branch.name}</strong>
-                          <span>
-                            {branch.isDefault ? "Default branch" : "Branch"}
-                          </span>
-                        </div>
-                        <code>{branch.lastCommitSha ?? "No commit SHA"}</code>
-                      </li>
-                    ))}
-                  </ul>
+                  <>
+                    <ul className="repos-branch-list">
+                      {branchInsightQuery.data.items.map((branch) => (
+                        <li key={branch.name}>
+                          <div>
+                            <strong>{branch.name}</strong>
+                            <span>
+                              {branch.isDefault ? "Default branch" : "Branch"}
+                            </span>
+                          </div>
+                          <code>{branch.lastCommitSha ?? "No commit SHA"}</code>
+                        </li>
+                      ))}
+                    </ul>
+
+                    <div className="repos-branch-actions">
+                      <Link
+                        className="repos-primary-action"
+                        to={`/scan?repo=${selectedRepo.id}`}
+                      >
+                        Open scan workspace
+                      </Link>
+                    </div>
+                  </>
                 ) : (
                   <p className="repos-state-copy">No branch metadata available yet.</p>
                 )}

--- a/apps/web/src/pages/ScanPage.test.tsx
+++ b/apps/web/src/pages/ScanPage.test.tsx
@@ -26,10 +26,10 @@ const mockedRequestScan = vi.mocked(requestScan);
 const mockedListRepoScans = vi.mocked(listRepoScans);
 const mockedGetScan = vi.mocked(getScan);
 
-function renderScanPage() {
+function renderScanPage(initialEntries = ["/scan"]) {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <ScanPage />
       </MemoryRouter>
     </QueryClientProvider>
@@ -243,6 +243,73 @@ describe("ScanPage", () => {
     expect(await screen.findByText(/scan queued successfully/i)).toBeInTheDocument();
   });
 
+  it("redirects repeat requests toward the active scan instead of queueing a duplicate", async () => {
+    const user = userEvent.setup();
+
+    renderScanPage();
+
+    const activeScanButton = await screen.findByRole("button", {
+      name: /view active scan/i,
+    });
+    await user.click(activeScanButton);
+
+    expect(mockedRequestScan).not.toHaveBeenCalled();
+    expect(await screen.findByText(/a scan is already active for this branch/i)).toBeInTheDocument();
+  });
+
+  it("uses the repository query parameter as the initial scan context", async () => {
+    renderScanPage(["/scan?repo=repo-2"]);
+
+    const repositorySelect = (await screen.findByLabelText(
+      /repository selector/i
+    )) as HTMLSelectElement;
+    const branchSelect = (await screen.findByLabelText(
+      /branch selector/i
+    )) as HTMLSelectElement;
+
+    expect(repositorySelect.value).toBe("repo-2");
+    expect(branchSelect.value).toBe("trunk");
+    expect(screen.getByText(/no scans have been queued for this repository yet/i)).toBeInTheDocument();
+  });
+
+  it("allows switching away from a repository seeded by the query parameter", async () => {
+    const user = userEvent.setup();
+
+    renderScanPage(["/scan?repo=repo-1"]);
+
+    const repositorySelect = (await screen.findByLabelText(
+      /repository selector/i
+    )) as HTMLSelectElement;
+    const branchSelect = (await screen.findByLabelText(
+      /branch selector/i
+    )) as HTMLSelectElement;
+
+    await user.selectOptions(repositorySelect, "repo-2");
+
+    await waitFor(() => {
+      expect(repositorySelect.value).toBe("repo-2");
+      expect(branchSelect.value).toBe("trunk");
+    });
+  });
+
+  it("ignores stale repository query parameters until a connected repository is validated", async () => {
+    renderScanPage(["/scan?repo=repo-stale"]);
+
+    const repositorySelect = (await screen.findByLabelText(
+      /repository selector/i
+    )) as HTMLSelectElement;
+
+    await waitFor(() => {
+      expect(repositorySelect.value).toBe("repo-1");
+      expect(mockedListRepoBranches.mock.calls.map(([repoId]) => repoId)).not.toContain(
+        "repo-stale"
+      );
+      expect(mockedListRepoScans.mock.calls.map(([repoId]) => repoId)).not.toContain(
+        "repo-stale"
+      );
+    });
+  });
+
   it("renders a connect-first empty state when no repositories are available for scanning", async () => {
     mockedListConnectedRepos.mockResolvedValueOnce([]);
 
@@ -252,5 +319,24 @@ describe("ScanPage", () => {
       await screen.findByText(/connect a repository before requesting a scan/i)
     ).toBeInTheDocument();
     expect(screen.getByText(/recent scans will appear once a repository is linked/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /go to repository connections/i })).toHaveAttribute(
+      "href",
+      "/repos"
+    );
+  });
+
+  it("surfaces a branch guardrail when the selected repository has no branch metadata", async () => {
+    mockedListRepoBranches.mockImplementationOnce(async () => ({
+      items: [],
+      page: 1,
+      size: 30,
+      hasNextPage: false,
+      nextPage: null,
+    }));
+
+    renderScanPage();
+
+    expect(await screen.findByText(/no branch metadata is available for this repository/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /queue java scan/i })).toBeDisabled();
   });
 });

--- a/apps/web/src/pages/ScanPage.tsx
+++ b/apps/web/src/pages/ScanPage.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 
 import { listConnectedRepos, listRepoBranches } from "../api/repos";
 import { getScan, listRepoScans, requestScan } from "../api/scans";
@@ -10,6 +11,8 @@ const ACTIVE_SCAN_STATUSES = new Set(["PENDING", "RUNNING"]);
 
 export function ScanPage() {
   const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedRepoId = searchParams.get("repo");
   const [selectedRepoId, setSelectedRepoId] = useState<string | null>(null);
   const [selectedBranch, setSelectedBranch] = useState("");
   const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
@@ -21,21 +24,36 @@ export function ScanPage() {
   });
 
   useEffect(() => {
+    const connectedRepoIds = new Set(connectedReposQuery.data?.map((repo) => repo.id) ?? []);
     const firstRepoId = connectedReposQuery.data?.[0]?.id ?? null;
+    const requestedConnectedRepoId =
+      requestedRepoId && connectedRepoIds.has(requestedRepoId) ? requestedRepoId : null;
 
-    if (!selectedRepoId && firstRepoId) {
+    if (!selectedRepoId || !connectedRepoIds.has(selectedRepoId)) {
+      if (requestedConnectedRepoId) {
+        setSelectedRepoId(requestedConnectedRepoId);
+        return;
+      }
+
       setSelectedRepoId(firstRepoId);
       return;
     }
+  }, [connectedReposQuery.data, requestedRepoId, selectedRepoId]);
 
-    if (
-      selectedRepoId &&
-      connectedReposQuery.data &&
-      !connectedReposQuery.data.some((repo) => repo.id === selectedRepoId)
-    ) {
-      setSelectedRepoId(firstRepoId);
+  useEffect(() => {
+    if (!connectedReposQuery.data) {
+      return;
     }
-  }, [connectedReposQuery.data, selectedRepoId]);
+
+    if (selectedRepoId && requestedRepoId !== selectedRepoId) {
+      setSearchParams({ repo: selectedRepoId }, { replace: true });
+      return;
+    }
+
+    if (!selectedRepoId && requestedRepoId) {
+      setSearchParams({}, { replace: true });
+    }
+  }, [requestedRepoId, selectedRepoId, setSearchParams]);
 
   const selectedRepo =
     connectedReposQuery.data?.find((repo) => repo.id === selectedRepoId) ?? null;
@@ -121,13 +139,19 @@ export function ScanPage() {
 
   const selectedScan = selectedScanQuery.data ?? selectedScanSummary;
   const branchOptions = branchesQuery.data?.items ?? [];
+  const activeBranchScan =
+    recentScansQuery.data?.items.find(
+      (scan) => scan.branch === selectedBranch && ACTIVE_SCAN_STATUSES.has(scan.status)
+    ) ?? null;
+  const hasBranchMetadata = branchOptions.length > 0;
 
   const requestDisabled =
     !selectedRepoId ||
     !selectedBranch ||
     requestScanMutation.isPending ||
     connectedReposQuery.isLoading ||
-    branchesQuery.isLoading;
+    branchesQuery.isLoading ||
+    !hasBranchMetadata;
 
   const totals = useMemo(() => {
     if (!selectedScan) {
@@ -145,6 +169,31 @@ export function ScanPage() {
       lines: selectedScan.totalLines ?? "—",
     };
   }, [selectedScan]);
+
+  const selectedScanNarrative = useMemo(() => {
+    if (!selectedScan) {
+      return "Choose a recent scan or queue a branch review to see the narrative here.";
+    }
+
+    switch (selectedScan.status) {
+      case "PENDING":
+        return "The branch snapshot is queued. AegisAI will collect the selected repository state before Java analysis begins.";
+      case "RUNNING":
+        return "This branch is already under review. Stay on the active scan instead of queueing a duplicate request.";
+      case "FAILED":
+        return "The review stopped before completion. Re-queue the branch after repository access or provider status is healthy again.";
+      case "DONE":
+        return "The branch review is complete. Use the severity matrix below to decide whether another scan or vulnerability review should follow.";
+      default:
+        return "AegisAI is tracking the current branch review status here.";
+    }
+  }, [selectedScan]);
+
+  const primaryActionLabel = activeBranchScan
+    ? "View active scan"
+    : requestScanMutation.isPending
+      ? "Queueing..."
+      : "Queue Java scan";
 
   return (
     <section className="scan-page">
@@ -249,12 +298,24 @@ export function ScanPage() {
                     <strong>Branch archive unavailable</strong>
                     <p>{getErrorMessage(branchesQuery.error)}</p>
                   </div>
+                ) : selectedRepoId && !branchesQuery.isLoading && !branchOptions.length ? (
+                  <div className="scan-inline-alert scan-inline-alert-neutral" role="status">
+                    <strong>No branch metadata is available for this repository.</strong>
+                    <p>Reconnect the source or return to repository connections before queueing a new review.</p>
+                  </div>
                 ) : null}
 
                 {requestScanMutation.error ? (
                   <div className="scan-inline-alert" role="alert">
                     <strong>Scan request failed</strong>
                     <p>{getErrorMessage(requestScanMutation.error)}</p>
+                  </div>
+                ) : null}
+
+                {activeBranchScan ? (
+                  <div className="scan-inline-alert scan-inline-alert-neutral" role="status">
+                    <strong>An active scan already covers this branch.</strong>
+                    <p>Open the current review instead of creating a duplicate queue entry.</p>
                   </div>
                 ) : null}
 
@@ -268,6 +329,12 @@ export function ScanPage() {
                     className="scan-primary-action"
                     disabled={requestDisabled}
                     onClick={() => {
+                      if (activeBranchScan) {
+                        setSelectedScanId(activeBranchScan.id);
+                        setSubmissionMessage("A scan is already active for this branch.");
+                        return;
+                      }
+
                       if (!selectedRepoId || !selectedBranch) {
                         return;
                       }
@@ -279,7 +346,7 @@ export function ScanPage() {
                     }}
                     type="button"
                   >
-                    {requestScanMutation.isPending ? "Queueing..." : "Queue Java scan"}
+                    {primaryActionLabel}
                   </button>
                 </div>
 
@@ -293,6 +360,11 @@ export function ScanPage() {
               <div className="scan-empty-state">
                 <strong>Connect a repository before requesting a scan.</strong>
                 <p>Recent scans will appear once a repository is linked and queued.</p>
+                <div className="scan-empty-actions">
+                  <Link className="scan-secondary-link" to="/repos">
+                    Go to repository connections
+                  </Link>
+                </div>
               </div>
             )}
           </section>
@@ -400,6 +472,8 @@ export function ScanPage() {
                     </div>
                   ))}
                 </div>
+
+                <p className="scan-detail-narrative">{selectedScanNarrative}</p>
 
                 {selectedScan.errorMessage ? (
                   <div className="scan-inline-alert" role="alert">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -401,6 +401,7 @@ button {
   border-radius: 999px;
   padding: 0 16px;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .repos-primary-action {
@@ -455,6 +456,12 @@ button {
 .repos-branch-list code {
   font-size: 0.82rem;
   color: var(--ink-muted);
+}
+
+.repos-branch-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 18px;
 }
 
 .repos-protocol-list li {
@@ -1391,6 +1398,12 @@ button {
   margin-bottom: 6px;
 }
 
+.scan-inline-alert-neutral {
+  background: rgba(213, 224, 247, 0.28);
+  border: 1px solid rgba(64, 94, 146, 0.14);
+  color: #425067;
+}
+
 .scan-empty-state {
   padding: 22px;
   border-radius: 16px;
@@ -1400,6 +1413,23 @@ button {
 .scan-empty-state strong {
   display: block;
   margin-bottom: 8px;
+}
+
+.scan-empty-actions {
+  display: flex;
+  margin-top: 16px;
+}
+
+.scan-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  color: var(--brass-deep);
+  text-decoration: none;
 }
 
 .scan-history-list {
@@ -1523,6 +1553,12 @@ button {
 .scan-summary-band strong {
   color: var(--ink-strong);
   font-size: 1.1rem;
+}
+
+.scan-detail-narrative {
+  margin: 18px 0 0;
+  color: var(--ink-muted);
+  line-height: 1.7;
 }
 
 .scan-trust-list {

--- a/docs/superpowers/plans/2026-03-27-scan-flow-guardrails-polish.md
+++ b/docs/superpowers/plans/2026-03-27-scan-flow-guardrails-polish.md
@@ -1,0 +1,11 @@
+# #85 Scan Flow Guardrails And UX Polish Plan
+
+1. Add failing frontend regressions for repository-to-scan continuity and scan guardrail states.
+2. Update `/repos` to expose a direct scan-workspace CTA for the selected connected repository.
+3. Update `/scan` to:
+   - respect repository query parameters
+   - surface connect-first and no-branch guardrails
+   - redirect duplicate active branch requests toward the in-flight scan
+   - improve selected scan status messaging
+4. Apply minimal CSS polish required to support the new CTA and state treatments without drifting from the current Stitch baseline.
+5. Run targeted frontend tests, then workspace `lint`, `test`, `typecheck`, and `build`.

--- a/docs/superpowers/specs/2026-03-27-scan-flow-guardrails-polish-design.md
+++ b/docs/superpowers/specs/2026-03-27-scan-flow-guardrails-polish-design.md
@@ -1,0 +1,58 @@
+# #85 Scan Flow Guardrails And UX Polish Design
+
+## Summary
+
+This follow-up closes the usability gap between the repository connection workspace and the scan request/status workspace. The focus is not a new visual language. The focus is preserving the existing Stitch-led protected workspace tone while tightening user guidance around repository selection, branch readiness, active scan duplication, and empty-state recovery.
+
+## Goals
+
+- Preserve the current protected Stitch aesthetic and only apply minimal UX-driven adjustments.
+- Reduce dead-end states between `/repos` and `/scan`.
+- Prevent duplicate scan requests for the same repository branch when an active scan already exists.
+- Make empty, branch-missing, active, failed, and idle scan states easier to understand.
+
+## Non-Goals
+
+- No new dashboard information architecture.
+- No wizard-style scan creation flow.
+- No backend contract changes unless a frontend edge case requires it.
+- No broad redesign of the repository and scan pages beyond guardrail and polish work.
+
+## UX Direction
+
+### Repository To Scan Continuity
+
+The branch insight area on `/repos` should now act as the last checkpoint before analysis. Once a connected repository is selected and its branch metadata is visible, the UI should expose an obvious `Open scan workspace` path into `/scan` using the selected repository as context.
+
+### Scan Request Guardrails
+
+The request area on `/scan` should distinguish four cases:
+
+1. No repositories connected: show a connect-first empty state with a direct link back to `/repos`.
+2. Repository has no branch metadata: disable the scan action and explain that repository metadata must be restored before queueing.
+3. An active scan already exists for the selected branch: do not encourage another queue action. Offer a `View active scan` action instead.
+4. Ready state: allow a normal Java scan request.
+
+### Selected Scan Narrative
+
+The selected scan status card should not only show structured data. It should also explain what the current status means:
+
+- `PENDING`: queued and waiting for snapshot collection
+- `RUNNING`: already in progress, duplication discouraged
+- `DONE`: ready for follow-up review
+- `FAILED`: requeue only after provider access is healthy again
+
+## Testing Strategy
+
+- Add a repository page regression that ensures the selected connected repository links into the scan workspace.
+- Add scan page regressions for:
+  - duplicate active scan handling
+  - repository query-parameter bootstrapping
+  - connect-first empty state recovery
+  - missing branch metadata guardrail
+  - switching away from a seeded repository context
+  - ignoring stale repository query parameters
+
+## Stitch Note
+
+The guardrail pass keeps the existing Stitch-derived protected workspace tone intact. This issue does not request a fresh manual redesign. Changes should remain limited to CTA placement, state messaging, and structural polish necessary for the scan flow to feel coherent in production use.


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/85-scan-flow-guardrails-ux-polish`
- 이슈: `#85`

## 🔎 주요 변경 사항

- `/repos`의 branch insight 영역에 선택된 connected repository를 `/scan`으로 넘기는 `Open scan workspace` CTA를 추가했습니다.
- `/scan`에서 active branch scan이 이미 존재하면 새 요청 대신 `View active scan` 흐름으로 유도하도록 guardrail을 추가했습니다.
- stale 또는 invalid `repo` query parameter가 있어도 connected repository 검증 전에는 branch/scan 요청이 나가지 않도록 정리했습니다.
- connect-first empty state, no-branch metadata state, active scan state, selected scan narrative copy를 보강했습니다.
- repository-to-scan continuity와 scan guardrail 회귀 테스트를 추가 및 확장했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- Stitch 기반 protected workspace 톤을 유지하면서 기능 연결과 상태 polish에 필요한 최소 수정만 적용했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct navigation link from repository branch insights to scan workspace.
  * Enabled repository pre-selection via URL parameters for seamless deep-linking and bookmarking.
  * Implemented safeguards preventing duplicate scans when one is already active for a branch.
  * Enhanced messaging when branch metadata is unavailable.

* **Documentation**
  * Added implementation plan and design specification for scan flow improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->