### PR TITLE
Feat: vulnerability review page UI 구현

### DIFF
--- a/apps/web/src/api/vulnerabilities.ts
+++ b/apps/web/src/api/vulnerabilities.ts
@@ -1,0 +1,44 @@
+import type {
+  ApiResponse,
+  VulnerabilityDetail,
+  VulnerabilityFeedbackRequest,
+  VulnerabilityFeedbackResponse,
+  VulnerabilityPageResponse,
+} from "@aegisai/shared";
+
+import { apiClient, unwrapApiResponse } from "./client";
+
+export async function listScanVulnerabilities(
+  scanId: string,
+  page = 1,
+  size = 50
+): Promise<VulnerabilityPageResponse> {
+  const response = await apiClient.get<ApiResponse<VulnerabilityPageResponse>>(
+    `/scans/${scanId}/vulnerabilities`,
+    {
+      params: { page, size },
+    }
+  );
+
+  return unwrapApiResponse(response.data);
+}
+
+export async function getVulnerability(vulnId: string): Promise<VulnerabilityDetail> {
+  const response = await apiClient.get<ApiResponse<VulnerabilityDetail>>(
+    `/vulnerabilities/${vulnId}`
+  );
+
+  return unwrapApiResponse(response.data);
+}
+
+export async function submitVulnerabilityFeedback(
+  vulnId: string,
+  body: VulnerabilityFeedbackRequest
+): Promise<VulnerabilityFeedbackResponse> {
+  const response = await apiClient.post<ApiResponse<VulnerabilityFeedbackResponse>>(
+    `/vulnerabilities/${vulnId}/feedback`,
+    body
+  );
+
+  return unwrapApiResponse(response.data);
+}

--- a/apps/web/src/pages/ScanPage.test.tsx
+++ b/apps/web/src/pages/ScanPage.test.tsx
@@ -165,26 +165,52 @@ describe("ScanPage", () => {
       };
     });
 
-    mockedGetScan.mockResolvedValue({
-      id: "scan-1",
-      repoFullName: "acme/payments-service",
-      branch: "main",
-      commitSha: "abc1234",
-      status: "RUNNING",
-      language: "java",
-      totalFiles: 42,
-      totalLines: 8140,
-      summary: {
-        critical: 1,
-        high: 2,
-        medium: 4,
-        low: 1,
-        info: 0,
-      },
-      startedAt: "2026-03-27T08:00:00.000Z",
-      completedAt: null,
-      errorMessage: null,
-      createdAt: "2026-03-27T07:58:00.000Z",
+    mockedGetScan.mockImplementation(async (scanId) => {
+      if (scanId === "scan-0") {
+        return {
+          id: "scan-0",
+          repoFullName: "acme/payments-service",
+          branch: "release/2026",
+          commitSha: "def5678",
+          status: "DONE",
+          language: "java",
+          totalFiles: 40,
+          totalLines: 7990,
+          summary: {
+            critical: 0,
+            high: 1,
+            medium: 3,
+            low: 2,
+            info: 1,
+          },
+          startedAt: "2026-03-26T08:00:00.000Z",
+          completedAt: "2026-03-26T08:06:00.000Z",
+          errorMessage: null,
+          createdAt: "2026-03-26T07:58:00.000Z",
+        };
+      }
+
+      return {
+        id: "scan-1",
+        repoFullName: "acme/payments-service",
+        branch: "main",
+        commitSha: "abc1234",
+        status: "RUNNING",
+        language: "java",
+        totalFiles: 42,
+        totalLines: 8140,
+        summary: {
+          critical: 1,
+          high: 2,
+          medium: 4,
+          low: 1,
+          info: 0,
+        },
+        startedAt: "2026-03-27T08:00:00.000Z",
+        completedAt: null,
+        errorMessage: null,
+        createdAt: "2026-03-27T07:58:00.000Z",
+      };
     });
 
     mockedRequestScan.mockResolvedValue({
@@ -267,8 +293,10 @@ describe("ScanPage", () => {
       /branch selector/i
     )) as HTMLSelectElement;
 
-    expect(repositorySelect.value).toBe("repo-2");
-    expect(branchSelect.value).toBe("trunk");
+    await waitFor(() => {
+      expect(repositorySelect.value).toBe("repo-2");
+      expect(branchSelect.value).toBe("trunk");
+    });
     expect(screen.getByText(/no scans have been queued for this repository yet/i)).toBeInTheDocument();
   });
 
@@ -338,5 +366,18 @@ describe("ScanPage", () => {
 
     expect(await screen.findByText(/no branch metadata is available for this repository/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /queue java scan/i })).toBeDisabled();
+  });
+
+  it("links completed scans into the vulnerability review workspace", async () => {
+    const user = userEvent.setup();
+
+    renderScanPage();
+
+    await user.click(await screen.findByRole("button", { name: /scan-0/i }));
+
+    expect(await screen.findByRole("link", { name: /open vulnerability review/i })).toHaveAttribute(
+      "href",
+      "/scan/scan-0/review"
+    );
   });
 });

--- a/apps/web/src/pages/ScanPage.tsx
+++ b/apps/web/src/pages/ScanPage.tsx
@@ -475,6 +475,17 @@ export function ScanPage() {
 
                 <p className="scan-detail-narrative">{selectedScanNarrative}</p>
 
+                {selectedScan.status === "DONE" ? (
+                  <div className="scan-detail-actions">
+                    <Link
+                      className="scan-secondary-link scan-secondary-link-strong"
+                      to={`/scan/${selectedScan.id}/review`}
+                    >
+                      Open vulnerability review
+                    </Link>
+                  </div>
+                ) : null}
+
                 {selectedScan.errorMessage ? (
                   <div className="scan-inline-alert" role="alert">
                     <strong>Scan error</strong>

--- a/apps/web/src/pages/VulnerabilityReviewPage.test.tsx
+++ b/apps/web/src/pages/VulnerabilityReviewPage.test.tsx
@@ -1,0 +1,353 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  VulnerabilityDetail,
+  VulnerabilityFeedbackResponse,
+  VulnerabilityListItem,
+} from "@aegisai/shared";
+
+import { getScan } from "../api/scans";
+import {
+  getVulnerability,
+  listScanVulnerabilities,
+  submitVulnerabilityFeedback,
+} from "../api/vulnerabilities";
+import { createQueryClient } from "../query-client";
+import { VulnerabilityReviewPage } from "./VulnerabilityReviewPage";
+
+vi.mock("../api/scans", () => ({
+  getScan: vi.fn(),
+}));
+
+vi.mock("../api/vulnerabilities", () => ({
+  listScanVulnerabilities: vi.fn(),
+  getVulnerability: vi.fn(),
+  submitVulnerabilityFeedback: vi.fn(),
+}));
+
+const mockedGetScan = vi.mocked(getScan);
+const mockedListScanVulnerabilities = vi.mocked(listScanVulnerabilities);
+const mockedGetVulnerability = vi.mocked(getVulnerability);
+const mockedSubmitVulnerabilityFeedback = vi.mocked(submitVulnerabilityFeedback);
+
+function renderVulnerabilityReviewPage(initialEntry = "/scan/scan-0/review") {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Routes>
+          <Route path="/scan/:scanId/review" element={<VulnerabilityReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("VulnerabilityReviewPage", () => {
+  beforeEach(() => {
+    mockedGetScan.mockReset();
+    mockedListScanVulnerabilities.mockReset();
+    mockedGetVulnerability.mockReset();
+    mockedSubmitVulnerabilityFeedback.mockReset();
+
+    mockedGetScan.mockResolvedValue({
+      id: "scan-0",
+      repoFullName: "acme/payments-service",
+      branch: "release/2026",
+      commitSha: "def5678",
+      status: "DONE",
+      language: "java",
+      totalFiles: 40,
+      totalLines: 7990,
+      summary: {
+        critical: 1,
+        high: 1,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      startedAt: "2026-03-26T08:00:00.000Z",
+      completedAt: "2026-03-26T08:06:00.000Z",
+      errorMessage: null,
+      createdAt: "2026-03-26T07:58:00.000Z",
+    });
+
+    const findings: VulnerabilityListItem[] = [
+      {
+        id: "vuln-1",
+        title: "Unsafe deserialization path",
+        severity: "CRITICAL",
+        filePath: "src/main/java/com/acme/security/Deserializer.java",
+        lineStart: 118,
+        lineEnd: 143,
+        cweId: "CWE-502",
+        owaspCategory: "A08:2021",
+        status: "OPEN",
+      },
+      {
+        id: "vuln-2",
+        title: "Path traversal in export handler",
+        severity: "HIGH",
+        filePath: "src/main/java/com/acme/export/ExportController.java",
+        lineStart: 74,
+        lineEnd: 89,
+        cweId: "CWE-22",
+        owaspCategory: "A01:2021",
+        status: "OPEN",
+      },
+    ];
+
+    const details = new Map<string, VulnerabilityDetail>([
+      [
+        "vuln-1",
+        {
+          id: "vuln-1",
+          title: "Unsafe deserialization path",
+          description:
+            "A user-controlled payload reaches a Java deserializer without type constraints.",
+          severity: "CRITICAL",
+          filePath: "src/main/java/com/acme/security/Deserializer.java",
+          lineStart: 118,
+          lineEnd: 143,
+          codeSnippet: "ObjectInputStream stream = new ObjectInputStream(input);",
+          fixSuggestion: "Replace native deserialization with a safe allowlist mapper.",
+          fixExplanation:
+            "Java native deserialization accepts arbitrary object graphs when type validation is missing.",
+          cweId: "CWE-502",
+          cveId: null,
+          owaspCategory: "A08:2021",
+          referenceLinks: [
+            {
+              title: "OWASP Insecure Deserialization",
+              url: "https://owasp.org/www-community/vulnerabilities/Insecure_Deserialization",
+            },
+          ],
+          consensusScore: 0.92,
+          modelResults: [
+            {
+              model: "gpt-5.4",
+              detected: true,
+              severity: "CRITICAL",
+              reasoning: "User input flows directly into native deserialization.",
+            },
+          ],
+          status: "OPEN",
+          userFeedback: null,
+        },
+      ],
+      [
+        "vuln-2",
+        {
+          id: "vuln-2",
+          title: "Path traversal in export handler",
+          description: "Export handler concatenates an untrusted path segment into file access.",
+          severity: "HIGH",
+          filePath: "src/main/java/com/acme/export/ExportController.java",
+          lineStart: 74,
+          lineEnd: 89,
+          codeSnippet: "Path exportPath = base.resolve(request.getPath());",
+          fixSuggestion: "Normalize the path and enforce an allowlisted export root.",
+          fixExplanation:
+            "File system access should never rely on raw request path segments without canonical validation.",
+          cweId: "CWE-22",
+          cveId: null,
+          owaspCategory: "A01:2021",
+          referenceLinks: null,
+          consensusScore: 0.74,
+          modelResults: [
+            {
+              model: "gpt-5.4",
+              detected: true,
+              severity: "HIGH",
+              reasoning: "User input reaches file path resolution without canonical checks.",
+            },
+          ],
+          status: "OPEN",
+          userFeedback: null,
+        },
+      ],
+    ]);
+
+    mockedListScanVulnerabilities.mockResolvedValue({
+      items: findings,
+      totalCount: findings.length,
+      page: 1,
+      totalPages: 1,
+    });
+    mockedGetVulnerability.mockImplementation(async (id) => details.get(id)!);
+    mockedSubmitVulnerabilityFeedback.mockImplementation(
+      async (id, feedback): Promise<VulnerabilityFeedbackResponse> => ({
+        id,
+        status: feedback.feedback,
+        userFeedback: feedback.feedback,
+      })
+    );
+  });
+
+  it("renders a vulnerability review workspace with list, detail, and feedback flow", async () => {
+    const user = userEvent.setup();
+
+    renderVulnerabilityReviewPage();
+
+    expect(
+      screen.getByRole("heading", { name: /review confirmed findings/i })
+    ).toBeInTheDocument();
+    expect(await screen.findByText("acme/payments-service")).toBeInTheDocument();
+
+    const findingsRegion = screen.getByRole("region", {
+      name: /vulnerability findings/i,
+    });
+    expect(
+      await within(findingsRegion).findByRole("button", {
+        name: /unsafe deserialization path/i,
+      })
+    ).toBeInTheDocument();
+
+    const detailRegion = screen.getByRole("region", {
+      name: /selected vulnerability detail/i,
+    });
+    expect(await within(detailRegion).findByText(/replace native deserialization/i)).toBeInTheDocument();
+    expect(within(detailRegion).getByText(/consensus score/i)).toBeInTheDocument();
+
+    await user.click(
+      within(findingsRegion).getByRole("button", {
+        name: /path traversal in export handler/i,
+      })
+    );
+
+    expect(await within(detailRegion).findByText(/normalize the path/i)).toBeInTheDocument();
+
+    await user.click(
+      within(detailRegion).getByRole("button", {
+        name: /accept finding/i,
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockedSubmitVulnerabilityFeedback).toHaveBeenCalledWith("vuln-2", {
+        feedback: "ACCEPTED",
+      });
+    });
+
+    expect(await within(detailRegion).findByText(/accepted/i)).toBeInTheDocument();
+  });
+
+  it("renders a no-findings state when the scan completes without stored vulnerabilities", async () => {
+    mockedListScanVulnerabilities.mockResolvedValueOnce({
+      items: [],
+      totalCount: 0,
+      page: 1,
+      totalPages: 1,
+    });
+
+    renderVulnerabilityReviewPage();
+
+    expect(await screen.findByText(/no findings were stored for this scan/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /return to scan workspace/i })).toHaveAttribute(
+      "href",
+      "/scan"
+    );
+  });
+
+  it("renders an error state when vulnerability data cannot be loaded", async () => {
+    mockedListScanVulnerabilities.mockRejectedValueOnce(
+      new Error("Vulnerability review is temporarily unavailable.")
+    );
+
+    renderVulnerabilityReviewPage();
+
+    expect(await screen.findByText(/vulnerability review unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+  });
+
+  it("supports paginated vulnerability pages without hiding later findings", async () => {
+    const user = userEvent.setup();
+
+    mockedListScanVulnerabilities
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "vuln-1",
+            title: "Unsafe deserialization path",
+            severity: "CRITICAL",
+            filePath: "src/main/java/com/acme/security/Deserializer.java",
+            lineStart: 118,
+            lineEnd: 143,
+            cweId: "CWE-502",
+            owaspCategory: "A08:2021",
+            status: "OPEN",
+          },
+        ],
+        totalCount: 2,
+        page: 1,
+        totalPages: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: "vuln-2",
+            title: "Path traversal in export handler",
+            severity: "HIGH",
+            filePath: "src/main/java/com/acme/export/ExportController.java",
+            lineStart: 74,
+            lineEnd: 89,
+            cweId: "CWE-22",
+            owaspCategory: "A01:2021",
+            status: "OPEN",
+          },
+        ],
+        totalCount: 2,
+        page: 2,
+        totalPages: 2,
+      });
+
+    renderVulnerabilityReviewPage();
+
+    expect(await screen.findByText(/page 1 of 2/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next findings page/i }));
+
+    await waitFor(() => {
+      expect(mockedListScanVulnerabilities).toHaveBeenLastCalledWith("scan-0", 2, 50);
+    });
+
+    expect(await screen.findByText(/page 2 of 2/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /path traversal in export handler/i })).toBeInTheDocument();
+  });
+
+  it("blocks direct entry when the scan has not finished yet", async () => {
+    mockedGetScan.mockResolvedValueOnce({
+      id: "scan-0",
+      repoFullName: "acme/payments-service",
+      branch: "release/2026",
+      commitSha: "def5678",
+      status: "RUNNING",
+      language: "java",
+      totalFiles: 40,
+      totalLines: 7990,
+      summary: {
+        critical: 1,
+        high: 1,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      startedAt: "2026-03-26T08:00:00.000Z",
+      completedAt: null,
+      errorMessage: null,
+      createdAt: "2026-03-26T07:58:00.000Z",
+    });
+
+    renderVulnerabilityReviewPage();
+
+    expect(await screen.findByText(/vulnerability review opens after a completed scan/i)).toBeInTheDocument();
+    expect(mockedListScanVulnerabilities).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: /return to scan workspace/i })).toHaveAttribute(
+      "href",
+      "/scan"
+    );
+  });
+});

--- a/apps/web/src/pages/VulnerabilityReviewPage.tsx
+++ b/apps/web/src/pages/VulnerabilityReviewPage.tsx
@@ -1,0 +1,480 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import type {
+  UserFeedback,
+  VulnerabilityDetail,
+  VulnerabilityPageResponse,
+} from "@aegisai/shared";
+
+import { getScan } from "../api/scans";
+import {
+  getVulnerability,
+  listScanVulnerabilities,
+  submitVulnerabilityFeedback,
+} from "../api/vulnerabilities";
+
+const FINDINGS_PAGE_SIZE = 50;
+
+export function VulnerabilityReviewPage() {
+  const { scanId = "" } = useParams();
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [selectedVulnerabilityId, setSelectedVulnerabilityId] = useState<string | null>(null);
+
+  const scanQuery = useQuery({
+    queryKey: ["scan", "detail", scanId],
+    queryFn: () => getScan(scanId),
+    enabled: Boolean(scanId),
+  });
+
+  const vulnerabilitiesQuery = useQuery({
+    queryKey: ["vulnerabilities", scanId, page],
+    queryFn: () => listScanVulnerabilities(scanId, page, FINDINGS_PAGE_SIZE),
+    enabled: scanQuery.data?.status === "DONE",
+  });
+
+  const findings = vulnerabilitiesQuery.data?.items ?? [];
+
+  useEffect(() => {
+    if (!findings.length) {
+      setSelectedVulnerabilityId(null);
+      return;
+    }
+
+    if (!selectedVulnerabilityId || !findings.some((item) => item.id === selectedVulnerabilityId)) {
+      setSelectedVulnerabilityId(findings[0]?.id ?? null);
+    }
+  }, [findings, selectedVulnerabilityId]);
+
+  const selectedFinding =
+    findings.find((finding) => finding.id === selectedVulnerabilityId) ?? findings[0] ?? null;
+
+  const detailQuery = useQuery({
+    queryKey: ["vulnerability", selectedFinding?.id],
+    queryFn: () => getVulnerability(selectedFinding!.id),
+    enabled: Boolean(selectedFinding?.id),
+  });
+
+  const feedbackMutation = useMutation({
+    mutationFn: ({ vulnId, feedback }: { vulnId: string; feedback: UserFeedback }) =>
+      submitVulnerabilityFeedback(vulnId, { feedback }),
+    onSuccess: (response) => {
+      queryClient.setQueryData<VulnerabilityDetail | undefined>(
+        ["vulnerability", response.id],
+        (current) =>
+          current
+            ? {
+                ...current,
+                status: response.status,
+                userFeedback: response.userFeedback,
+              }
+            : current
+      );
+
+      queryClient.setQueryData<VulnerabilityPageResponse | undefined>(
+        ["vulnerabilities", scanId, page],
+        (current) =>
+          current
+            ? {
+                ...current,
+                items: current.items.map((item) =>
+                  item.id === response.id ? { ...item, status: response.status } : item
+                ),
+              }
+            : current
+      );
+    },
+  });
+
+  const selectedDetail = detailQuery.data ?? null;
+  const totalPages = vulnerabilitiesQuery.data?.totalPages ?? 1;
+  const totalCount = vulnerabilitiesQuery.data?.totalCount ?? findings.length;
+
+  const severityBreakdown = useMemo(() => {
+    const summary = scanQuery.data?.summary;
+    if (!summary) {
+      return [];
+    }
+
+    return [
+      { label: "Critical", value: summary.critical, tone: "critical" },
+      { label: "High", value: summary.high, tone: "high" },
+      { label: "Medium", value: summary.medium, tone: "medium" },
+      { label: "Low", value: summary.low, tone: "low" },
+      { label: "Info", value: summary.info, tone: "info" },
+    ];
+  }, [scanQuery.data]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [scanId]);
+
+  const pageError =
+    scanQuery.error ?? (scanQuery.data?.status === "DONE" ? vulnerabilitiesQuery.error : null);
+
+  return (
+    <section className="review-page">
+      <header className="review-hero">
+        <div className="review-hero-copy">
+          <p className="eyebrow">Vulnerability review</p>
+          <h2>Review confirmed findings</h2>
+          <div className="review-hero-accent">
+            <p>
+              Stay inside the protected scan workspace while triaging the stored findings,
+              comparing model consensus, and recording the decision your team wants preserved.
+            </p>
+          </div>
+        </div>
+
+        <div className="review-hero-panel" aria-hidden="true">
+          <span className="review-hero-panel-kicker">Triaged. Traceable. Calm.</span>
+        </div>
+      </header>
+
+      {pageError ? (
+        <section className="review-section" aria-label="Vulnerability review error">
+          <div className="review-inline-alert" role="alert">
+            <strong>Vulnerability review unavailable</strong>
+            <p>{getErrorMessage(pageError)}</p>
+          </div>
+        </section>
+      ) : scanQuery.isLoading || vulnerabilitiesQuery.isLoading ? (
+        <section className="review-section" aria-label="Vulnerability review loading">
+          <p className="review-state-copy">Loading the protected findings workspace...</p>
+        </section>
+      ) : scanQuery.data?.status !== "DONE" ? (
+        <section className="review-section" aria-label="Vulnerability review not ready">
+          <div className="review-inline-alert review-inline-alert-neutral" role="status">
+            <strong>Vulnerability review opens after a completed scan.</strong>
+            <p>
+              This scan is still {formatStatus(scanQuery.data?.status ?? "PENDING").toLowerCase()}.
+              Return to the scan workspace and reopen review after the branch analysis completes.
+            </p>
+          </div>
+          <div className="review-empty-actions">
+            <Link className="review-secondary-link" to="/scan">
+              Return to scan workspace
+            </Link>
+          </div>
+        </section>
+      ) : scanQuery.data ? (
+        <div className="review-layout">
+          <div className="review-main">
+            <section className="review-section" aria-label="Scan review summary">
+              <div className="review-section-heading">
+                <p className="eyebrow">Stored scan context</p>
+                <h3>{scanQuery.data.repoFullName}</h3>
+              </div>
+
+              <dl className="review-summary-grid">
+                <div>
+                  <dt>Branch</dt>
+                  <dd>{scanQuery.data.branch}</dd>
+                </div>
+                <div>
+                  <dt>Commit</dt>
+                  <dd>{scanQuery.data.commitSha ?? "Pending SHA"}</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>{formatStatus(scanQuery.data.status)}</dd>
+                </div>
+                <div>
+                  <dt>Language</dt>
+                  <dd>{scanQuery.data.language}</dd>
+                </div>
+              </dl>
+
+              <div className="review-severity-band">
+                {severityBreakdown.map((item) => (
+                  <div key={item.label} className={`review-severity-tile is-${item.tone}`}>
+                    <span>{item.label}</span>
+                    <strong>{item.value}</strong>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="review-section" aria-label="Vulnerability findings">
+              <div className="review-section-heading">
+                <p className="eyebrow">Stored findings</p>
+                <h3>Trace the file, line, and severity before deciding what to keep</h3>
+              </div>
+
+              {totalPages > 1 ? (
+                <div className="review-pagination">
+                  <p className="review-pagination-copy">
+                    Page {page} of {totalPages} · {totalCount} findings
+                  </p>
+                  <div className="review-pagination-actions">
+                    <button
+                      type="button"
+                      className="review-pagination-button"
+                      disabled={page === 1}
+                      onClick={() => setPage((current) => Math.max(1, current - 1))}
+                    >
+                      Previous findings page
+                    </button>
+                    <button
+                      type="button"
+                      className="review-pagination-button"
+                      disabled={page >= totalPages}
+                      onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+                    >
+                      Next findings page
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+
+              {!findings.length ? (
+                <div className="review-empty-state">
+                  <strong>No findings were stored for this scan.</strong>
+                  <p>
+                    The selected review completed without persisted vulnerabilities. Return to the
+                    scan workspace if you want to queue another branch or inspect the scan status.
+                  </p>
+                  <div className="review-empty-actions">
+                    <Link className="review-secondary-link" to="/scan">
+                      Return to scan workspace
+                    </Link>
+                  </div>
+                </div>
+              ) : (
+                <div className="review-finding-list">
+                  {findings.map((finding) => (
+                    <button
+                      key={finding.id}
+                      type="button"
+                      className={`review-finding-card${
+                        selectedFinding?.id === finding.id ? " is-selected" : ""
+                      }`}
+                      onClick={() => setSelectedVulnerabilityId(finding.id)}
+                      aria-pressed={selectedFinding?.id === finding.id}
+                    >
+                      <div className="review-finding-header">
+                        <span className={`review-severity-pill is-${finding.severity.toLowerCase()}`}>
+                          {finding.severity}
+                        </span>
+                        <span className={`review-status-chip is-${finding.status.toLowerCase()}`}>
+                          {formatStatus(finding.status)}
+                        </span>
+                      </div>
+                      <strong>{finding.title}</strong>
+                      <p>{finding.filePath}</p>
+                      <div className="review-finding-meta">
+                        <span>Line {formatLineRange(finding.lineStart, finding.lineEnd)}</span>
+                        <span>{finding.cweId ?? "CWE pending"}</span>
+                        <span>{finding.owaspCategory ?? "OWASP mapping pending"}</span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+
+          <aside className="review-aside">
+            <section className="review-aside-card" aria-label="Selected vulnerability detail">
+              <p className="eyebrow">Selected vulnerability detail</p>
+              <h3>Inspect the rationale before recording feedback</h3>
+
+              {!selectedFinding ? (
+                <p className="review-state-copy">
+                  Select a stored finding to inspect description, evidence, and analyst guidance.
+                </p>
+              ) : detailQuery.error ? (
+                <div className="review-inline-alert" role="alert">
+                  <strong>Vulnerability detail unavailable</strong>
+                  <p>{getErrorMessage(detailQuery.error)}</p>
+                </div>
+              ) : detailQuery.isLoading || !selectedDetail ? (
+                <p className="review-state-copy">Loading the selected finding detail...</p>
+              ) : (
+                <>
+                  <div className="review-detail-header">
+                    <strong>{selectedDetail.title}</strong>
+                    <span className={`review-status-chip is-${selectedDetail.status.toLowerCase()}`}>
+                      {formatStatus(selectedDetail.status)}
+                    </span>
+                  </div>
+
+                  <dl className="review-detail-grid">
+                    <div>
+                      <dt>File</dt>
+                      <dd>{selectedDetail.filePath}</dd>
+                    </div>
+                    <div>
+                      <dt>Line range</dt>
+                      <dd>{formatLineRange(selectedDetail.lineStart, selectedDetail.lineEnd)}</dd>
+                    </div>
+                    <div>
+                      <dt>CWE</dt>
+                      <dd>{selectedDetail.cweId ?? "Pending mapping"}</dd>
+                    </div>
+                    <div>
+                      <dt>Consensus score</dt>
+                      <dd>
+                        {selectedDetail.consensusScore == null
+                          ? "Pending score"
+                          : formatPercentage(selectedDetail.consensusScore)}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div className="review-detail-block">
+                    <span className="review-block-label">Description</span>
+                    <p>{selectedDetail.description}</p>
+                  </div>
+
+                  {selectedDetail.codeSnippet ? (
+                    <div className="review-code-block">
+                      <span className="review-block-label">Evidence snippet</span>
+                      <pre>{selectedDetail.codeSnippet}</pre>
+                    </div>
+                  ) : null}
+
+                  {selectedDetail.fixSuggestion ? (
+                    <div className="review-detail-block">
+                      <span className="review-block-label">Fix suggestion</span>
+                      <p>{selectedDetail.fixSuggestion}</p>
+                    </div>
+                  ) : null}
+
+                  {selectedDetail.fixExplanation ? (
+                    <div className="review-detail-block">
+                      <span className="review-block-label">Why it matters</span>
+                      <p>{selectedDetail.fixExplanation}</p>
+                    </div>
+                  ) : null}
+
+                  {selectedDetail.modelResults?.length ? (
+                    <div className="review-model-list">
+                      <span className="review-block-label">Model consensus</span>
+                      {selectedDetail.modelResults.map((result) => (
+                        <div key={result.model} className="review-model-card">
+                          <div className="review-model-header">
+                            <strong>{result.model}</strong>
+                            <span>{result.detected ? "Detected" : "No signal"}</span>
+                          </div>
+                          <p>{result.reasoning}</p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {selectedDetail.referenceLinks?.length ? (
+                    <div className="review-reference-list">
+                      <span className="review-block-label">Reference links</span>
+                      {selectedDetail.referenceLinks.map((reference) => (
+                        <a
+                          key={reference.url}
+                          href={reference.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="review-reference-link"
+                        >
+                          {reference.title}
+                        </a>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {feedbackMutation.error ? (
+                    <div className="review-inline-alert" role="alert">
+                      <strong>Feedback could not be saved</strong>
+                      <p>{getErrorMessage(feedbackMutation.error)}</p>
+                    </div>
+                  ) : null}
+
+                  <div className="review-feedback-actions">
+                    <button
+                      type="button"
+                      className="review-primary-action"
+                      disabled={feedbackMutation.isPending}
+                      onClick={() =>
+                        feedbackMutation.mutate({
+                          vulnId: selectedDetail.id,
+                          feedback: "ACCEPTED",
+                        })
+                      }
+                    >
+                      Accept finding
+                    </button>
+                    <button
+                      type="button"
+                      className="review-secondary-action"
+                      disabled={feedbackMutation.isPending}
+                      onClick={() =>
+                        feedbackMutation.mutate({
+                          vulnId: selectedDetail.id,
+                          feedback: "REJECTED",
+                        })
+                      }
+                    >
+                      Reject finding
+                    </button>
+                  </div>
+                </>
+              )}
+            </section>
+
+            <section className="review-aside-card">
+              <p className="eyebrow">Decision protocol</p>
+              <h3>Keep the feedback trace calm and explicit</h3>
+              <ul className="review-trust-list">
+                <li>Accept when the finding reflects a real exploitable path.</li>
+                <li>Reject when code context or repository history disproves the detection.</li>
+                <li>Return to the scan workspace if another branch needs a fresh review.</li>
+              </ul>
+            </section>
+          </aside>
+        </div>
+      ) : (
+        <section className="review-section" aria-label="Missing scan context">
+          <div className="review-inline-alert" role="alert">
+            <strong>Scan context unavailable</strong>
+            <p>The requested vulnerability review is missing a scan identifier.</p>
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}
+
+function formatLineRange(lineStart: number, lineEnd: number | null) {
+  return lineEnd && lineEnd !== lineStart ? `${lineStart}-${lineEnd}` : `${lineStart}`;
+}
+
+function formatPercentage(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatStatus(status: string) {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function getErrorMessage(error: unknown) {
+  if (
+    error &&
+    typeof error === "object" &&
+    "response" in error &&
+    error.response &&
+    typeof error.response === "object" &&
+    "data" in error.response &&
+    error.response.data &&
+    typeof error.response.data === "object" &&
+    "message" in error.response.data &&
+    typeof error.response.data.message === "string"
+  ) {
+    return error.response.data.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "An unexpected error occurred.";
+}

--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -11,4 +11,9 @@ describe("router", () => {
     expect(routes[1]?.path).toBe("/login");
     expect(routes[2]?.path).toBeUndefined();
   });
+
+  it("exposes the vulnerability review workspace inside the protected scan routes", () => {
+    const protectedChildren = routes[2]?.children ?? [];
+    expect(protectedChildren.some((route) => route.path === "/scan/:scanId/review")).toBe(true);
+  });
 });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -7,6 +7,7 @@ import { LandingPage } from "./pages/LandingPage";
 import { LoginPage } from "./pages/LoginPage";
 import { ReposPage } from "./pages/ReposPage";
 import { ScanPage } from "./pages/ScanPage";
+import { VulnerabilityReviewPage } from "./pages/VulnerabilityReviewPage";
 
 export const routes: RouteObject[] = [
   {
@@ -35,6 +36,10 @@ export const routes: RouteObject[] = [
       {
         path: "/scan",
         element: <ScanPage />,
+      },
+      {
+        path: "/scan/:scanId/review",
+        element: <VulnerabilityReviewPage />,
       },
     ],
   },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1432,6 +1432,12 @@ button {
   text-decoration: none;
 }
 
+.scan-secondary-link-strong {
+  background: rgba(213, 224, 247, 0.28);
+  border-color: rgba(64, 94, 146, 0.18);
+  color: #425067;
+}
+
 .scan-history-list {
   display: grid;
   gap: 14px;
@@ -1561,10 +1567,460 @@ button {
   line-height: 1.7;
 }
 
+.scan-detail-actions {
+  display: flex;
+  margin-top: 18px;
+}
+
 .scan-trust-list {
   padding-left: 18px;
   display: grid;
   gap: 10px;
+}
+
+.review-page {
+  display: grid;
+  gap: 32px;
+}
+
+.review-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.review-hero-copy {
+  display: grid;
+  gap: 18px;
+}
+
+.review-hero-copy h2,
+.review-section-heading h3,
+.review-aside-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  color: var(--ink-strong);
+}
+
+.review-hero-copy h2 {
+  font-size: clamp(2.8rem, 4.8vw, 4.9rem);
+}
+
+.review-hero-accent {
+  max-width: 44rem;
+  padding-left: 22px;
+  border-left: 4px solid var(--trust-blue);
+}
+
+.review-hero-accent p,
+.review-state-copy,
+.review-inline-alert p,
+.review-detail-block p,
+.review-model-card p,
+.review-empty-state p,
+.review-trust-list,
+.review-finding-card p {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.7;
+}
+
+.review-hero-panel,
+.review-section,
+.review-aside-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(122, 89, 8, 0.06);
+  box-shadow: 0 18px 40px rgba(27, 28, 25, 0.06);
+}
+
+.review-hero-panel {
+  min-height: 220px;
+  padding: 28px;
+  display: flex;
+  align-items: end;
+  justify-content: end;
+  background:
+    linear-gradient(180deg, rgba(251, 249, 244, 0.12), rgba(251, 249, 244, 0.88)),
+    radial-gradient(circle at top left, rgba(64, 94, 146, 0.24), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(181, 141, 61, 0.18), transparent 28%),
+    var(--surface-low);
+}
+
+.review-hero-panel-kicker {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--trust-blue);
+  font-size: 1.24rem;
+}
+
+.review-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+  gap: 24px;
+}
+
+.review-main,
+.review-aside {
+  display: grid;
+  gap: 24px;
+}
+
+.review-section,
+.review-aside-card {
+  padding: 24px;
+}
+
+.review-section-heading {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.review-summary-grid,
+.review-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+
+.review-summary-grid dt,
+.review-detail-grid dt,
+.review-block-label {
+  color: var(--ink-faint);
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.review-summary-grid dd,
+.review-detail-grid dd {
+  margin: 6px 0 0;
+  color: var(--ink-strong);
+}
+
+.review-severity-band {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.review-severity-tile {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(245, 243, 238, 0.82);
+}
+
+.review-severity-tile span {
+  color: var(--ink-faint);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.review-severity-tile strong {
+  color: var(--ink-strong);
+  font-size: 1rem;
+}
+
+.review-severity-tile.is-critical {
+  background: rgba(255, 218, 214, 0.8);
+}
+
+.review-severity-tile.is-high {
+  background: rgba(255, 234, 201, 0.88);
+}
+
+.review-severity-tile.is-medium {
+  background: rgba(245, 243, 238, 0.9);
+}
+
+.review-severity-tile.is-low,
+.review-severity-tile.is-info {
+  background: rgba(213, 224, 247, 0.24);
+}
+
+.review-finding-list {
+  display: grid;
+  gap: 14px;
+}
+
+.review-finding-card {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  padding: 18px;
+  border: 1px solid rgba(210, 197, 178, 0.6);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.7);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.review-finding-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(64, 94, 146, 0.26);
+  box-shadow: 0 18px 36px rgba(27, 28, 25, 0.06);
+}
+
+.review-finding-card.is-selected {
+  border-color: rgba(64, 94, 146, 0.28);
+  background: linear-gradient(180deg, rgba(213, 224, 247, 0.22), rgba(255, 255, 255, 0.92));
+}
+
+.review-finding-card strong,
+.review-detail-header strong {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: -0.03em;
+}
+
+.review-finding-header,
+.review-detail-header,
+.review-model-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.review-severity-pill,
+.review-status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.review-severity-pill.is-critical {
+  background: rgba(255, 218, 214, 0.92);
+  color: var(--danger-ink);
+}
+
+.review-severity-pill.is-high {
+  background: rgba(255, 234, 201, 0.88);
+  color: #8b5a00;
+}
+
+.review-severity-pill.is-medium {
+  background: rgba(245, 243, 238, 0.92);
+  color: var(--ink-muted);
+}
+
+.review-severity-pill.is-low,
+.review-severity-pill.is-info {
+  background: rgba(213, 224, 247, 0.4);
+  color: #425067;
+}
+
+.review-status-chip.is-open {
+  background: rgba(245, 243, 238, 0.92);
+  color: var(--ink-muted);
+}
+
+.review-status-chip.is-accepted {
+  background: rgba(221, 237, 220, 0.72);
+  color: #34513c;
+}
+
+.review-status-chip.is-rejected {
+  background: rgba(255, 218, 214, 0.92);
+  color: var(--danger-ink);
+}
+
+.review-status-chip.is-fixed {
+  background: rgba(213, 224, 247, 0.4);
+  color: #425067;
+}
+
+.review-finding-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--ink-faint);
+  font-size: 0.82rem;
+}
+
+.review-detail-block,
+.review-model-list,
+.review-reference-list {
+  display: grid;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.review-code-block {
+  margin-top: 20px;
+  padding: 18px;
+  border-radius: 16px;
+  background: #1b1c19;
+  color: var(--surface-base);
+}
+
+.review-code-block pre {
+  margin: 10px 0 0;
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+}
+
+.review-model-card {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(245, 243, 238, 0.82);
+}
+
+.review-model-header span {
+  color: var(--ink-faint);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.review-reference-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  padding: 0 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  color: var(--brass-deep);
+}
+
+.review-feedback-actions,
+.review-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.review-primary-action,
+.review-secondary-action,
+.review-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0 18px;
+  font: inherit;
+  text-decoration: none;
+}
+
+.review-primary-action {
+  border: 0;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+  box-shadow: 0 18px 36px rgba(122, 89, 8, 0.18);
+}
+
+.review-secondary-action,
+.review-secondary-link {
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  background: transparent;
+  color: var(--brass-deep);
+}
+
+.review-primary-action:disabled,
+.review-secondary-action:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+.review-inline-alert {
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(186, 26, 26, 0.12);
+  color: var(--danger-ink);
+}
+
+.review-inline-alert-neutral {
+  background: rgba(213, 224, 247, 0.28);
+  border: 1px solid rgba(64, 94, 146, 0.14);
+  color: #425067;
+}
+
+.review-inline-alert strong,
+.review-empty-state strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.review-empty-state {
+  padding: 22px;
+  border-radius: 16px;
+  background: rgba(245, 243, 238, 0.78);
+}
+
+.review-trust-list {
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+}
+
+.review-pagination,
+.review-pagination-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.review-pagination {
+  margin-bottom: 18px;
+}
+
+.review-pagination-copy {
+  margin: 0;
+  color: var(--ink-faint);
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.review-pagination-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  background: transparent;
+  color: var(--brass-deep);
+  padding: 0 14px;
+  cursor: pointer;
+}
+
+.review-pagination-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 @media (max-width: 900px) {
@@ -1636,10 +2092,14 @@ button {
   .repos-toolbar,
   .scan-hero,
   .scan-layout,
+  .review-hero,
+  .review-layout,
   .scan-form-grid,
   .scan-form-footer,
   .scan-detail-grid,
-  .scan-summary-band {
+  .scan-summary-band,
+  .review-summary-grid,
+  .review-detail-grid {
     grid-template-columns: 1fr;
     flex-direction: column;
     align-items: stretch;
@@ -1647,8 +2107,17 @@ button {
 
   .scan-severity-list,
   .scan-severity-matrix,
-  .scan-repo-selector {
+  .scan-repo-selector,
+  .review-severity-band {
     grid-template-columns: 1fr;
+  }
+
+  .review-feedback-actions,
+  .review-empty-actions,
+  .review-pagination,
+  .review-pagination-actions {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 

--- a/docs/superpowers/plans/2026-03-27-vulnerability-review-page-ui.md
+++ b/docs/superpowers/plans/2026-03-27-vulnerability-review-page-ui.md
@@ -1,0 +1,17 @@
+# #87 Vulnerability Review Page UI Plan
+
+1. Add failing frontend tests for:
+   - the protected vulnerability review route
+   - the scan-to-review entrypoint on completed scans
+   - the vulnerability review list, detail, feedback, empty, and error states
+2. Add frontend API helpers for vulnerability list, detail, and feedback against the shared contract.
+3. Implement a protected `VulnerabilityReviewPage` that:
+   - loads scan context and vulnerability list
+   - blocks review until the selected scan is `DONE`
+   - auto-selects the first finding
+   - respects paginated vulnerability responses
+   - shows detail, consensus, and feedback actions
+   - handles empty and error states
+4. Wire `/scan/:scanId/review` into the router and expose a completed-scan CTA from `/scan`.
+5. Apply minimal CSS required to keep the new review workspace aligned with the existing Stitch-derived protected scan tone.
+6. Run targeted frontend tests, then workspace `lint`, `test`, `typecheck`, and `build`.

--- a/docs/superpowers/specs/2026-03-27-vulnerability-review-page-design.md
+++ b/docs/superpowers/specs/2026-03-27-vulnerability-review-page-design.md
@@ -1,0 +1,65 @@
+# #87 Vulnerability Review Page UI Design
+
+## Summary
+
+This issue opens the first protected workspace for scan-result triage. The backend vulnerability module is not implemented yet, so the UI should follow the shared contract and OpenAPI shape now, then stay stable when the real endpoints arrive. The goal is a calm review surface that extends the existing Stitch-led scan workspace instead of inventing a new visual language.
+
+## Goals
+
+- Preserve the existing protected scan workspace tone and layout rhythm.
+- Add a dedicated review page that supports vulnerability list, detail, and feedback in one screen.
+- Connect the completed scan state to the review page with a clear CTA.
+- Keep the implementation aligned with shared contracts so backend work can slot in later.
+- Cover loading, empty, error, and no-findings states with explicit UI.
+
+## Non-Goals
+
+- No backend vulnerability module implementation in this issue.
+- No redesign of the public landing or login flows.
+- No broad protected navigation redesign beyond the minimum route addition for review.
+- No manual redesign that discards the Stitch-derived scan workspace structure.
+
+## UX Direction
+
+### Protected Review Workspace
+
+The page should feel like the natural next panel after `Scan Status` and `Scan Results`. The user should land on a completed scan review surface with:
+
+- scan context and severity distribution at the top
+- a persistent findings list on the left
+- a focused detail and feedback panel on the right
+
+The reading experience should feel deliberate and editorial rather than dashboard-heavy.
+
+### Decision Surface
+
+Each vulnerability entry should quickly answer:
+
+- what is it
+- how severe is it
+- where is it
+- what do the models agree on
+- what decision did the reviewer record
+
+Feedback actions should be explicit and binary for MVP: accept or reject.
+
+### Empty And Error States
+
+- If no findings exist, the page should explain that the scan completed without persisted vulnerabilities and offer a return path to `/scan`.
+- If the review data cannot load, the error should stay inside the protected workspace and explain that vulnerability review is unavailable without collapsing the page chrome.
+- If a user opens the route before the scan finishes, the page should block review and send them back to the scan workspace instead of attempting vulnerability queries.
+- If a scan contains more findings than fit on one page, the page must expose pagination controls instead of silently hiding later items.
+
+## Contract Strategy
+
+This issue should use the shared vulnerability contracts and the existing OpenAPI path structure:
+
+- `GET /scans/{scanId}/vulnerabilities`
+- `GET /vulnerabilities/{vulnId}`
+- `POST /vulnerabilities/{vulnId}/feedback`
+
+Because the backend module is not live yet, frontend tests should mock these contract-facing API helpers and prove that the workspace behavior is already stable.
+
+## Stitch Note
+
+Fresh Stitch generation for a dedicated vulnerability review screen currently fails with an invalid-argument response. The design baseline for this issue should therefore come from the existing protected `Scan Results` / `Scan Status` Stitch workspace. Code implementation should preserve that protected tone and only add the minimum structure required for real list, detail, and feedback behavior.

--- a/packages/shared/src/types/vulnerability.ts
+++ b/packages/shared/src/types/vulnerability.ts
@@ -1,3 +1,5 @@
+import type { PageQuery, PageResponse } from "./common";
+
 export type Severity = 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'INFO';
 export type VulnStatus = 'OPEN' | 'FIXED' | 'ACCEPTED' | 'REJECTED';
 export type UserFeedback = 'ACCEPTED' | 'REJECTED';
@@ -56,3 +58,9 @@ export interface VulnerabilityFeedbackResponse {
   status: Extract<VulnStatus, 'ACCEPTED' | 'REJECTED'>;
   userFeedback: UserFeedback;
 }
+
+export interface ListScanVulnerabilitiesQuery extends PageQuery {
+  scanId: string;
+}
+
+export type VulnerabilityPageResponse = PageResponse<VulnerabilityListItem>;


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/87-vulnerability-review-page-ui`
- 이슈: `#87`

## 🔎 주요 변경 사항

- `/scan/:scanId/review` protected route와 vulnerability review workspace UI를 추가했습니다.
- scan context, vulnerability list, selected detail, model consensus, feedback action을 한 화면에서 다룰 수 있도록 구성했습니다.
- `apps/web/src/api/vulnerabilities.ts`에 vulnerability list, detail, feedback API helper를 추가했습니다.
- `packages/shared/src/types/vulnerability.ts`에 vulnerability page contract 타입을 보강했습니다.
- completed scan에서만 review로 진입하도록 `/scan` 페이지에 review CTA를 연결했습니다.
- review route는 `DONE` scan에서만 열리도록 guardrail을 추가했고, paginated vulnerability response도 UI에서 탐색할 수 있도록 보강했습니다.
- vulnerability review, router, scan entrypoint 회귀 테스트를 추가 및 확장했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- Stitch protected workspace 톤을 기준으로 구현했고, 기능 연결과 상태/반응형 보정에 필요한 최소 수정만 적용했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated vulnerability review interface for completed scans, allowing users to view discovered vulnerabilities in a paginated list, examine detailed findings with evidence and model consensus, and submit accept/reject feedback.
  * Added navigation link from completed scans to the new review workspace.

* **Documentation**
  * Added design specifications and implementation plan for the vulnerability review feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->