### PR TITLE
Feat: vulnerability backend module and feedback endpoints 구현

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { ObservabilityModule } from './observability/observability.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { RepoModule } from './repo/repo.module';
 import { ScanModule } from './scan/scan.module';
+import { VulnerabilityModule } from './vulnerability/vulnerability.module';
 
 const runtimeFeatureModules = [ScanModule, HealthModule];
 
@@ -47,6 +48,7 @@ const runtimeFeatureModules = [ScanModule, HealthModule];
     PrismaModule,
     AuthModule,
     RepoModule,
+    VulnerabilityModule,
     GitClientModule,
     LanguageModule,
     AnalysisApiModule,

--- a/apps/api/src/vulnerability/vulnerability.controller.ts
+++ b/apps/api/src/vulnerability/vulnerability.controller.ts
@@ -1,0 +1,99 @@
+import type {
+  AuthUser,
+  ListScanVulnerabilitiesQuery,
+  UserFeedback,
+  VulnerabilityFeedbackRequest
+} from '@aegisai/shared';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards
+} from '@nestjs/common';
+
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SessionAuthGuard } from '../auth/guards/session-auth.guard';
+import { VulnerabilityService } from './vulnerability.service';
+
+const VALID_FEEDBACK: UserFeedback[] = ['ACCEPTED', 'REJECTED'];
+
+@Controller()
+@UseGuards(SessionAuthGuard)
+export class VulnerabilityController {
+  constructor(private readonly vulnerabilityService: VulnerabilityService) {}
+
+  @Get('scans/:scanId/vulnerabilities')
+  async listScanVulnerabilities(
+    @CurrentUser() user: AuthUser,
+    @Param('scanId') scanId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('size', new DefaultValuePipe(50), ParseIntPipe) size: number
+  ) {
+    return this.vulnerabilityService.listScanVulnerabilities({
+      userId: user.id,
+      scanId,
+      ...this.normalizePagination({ scanId, page, size })
+    });
+  }
+
+  @Get('vulnerabilities/:vulnerabilityId')
+  async getVulnerabilityDetail(
+    @CurrentUser() user: AuthUser,
+    @Param('vulnerabilityId') vulnerabilityId: string
+  ) {
+    return this.vulnerabilityService.getVulnerabilityDetail(user.id, vulnerabilityId);
+  }
+
+  @Post('vulnerabilities/:vulnerabilityId/feedback')
+  @HttpCode(200)
+  async submitFeedback(
+    @CurrentUser() user: AuthUser,
+    @Param('vulnerabilityId') vulnerabilityId: string,
+    @Body() body: Partial<VulnerabilityFeedbackRequest>
+  ) {
+    return this.vulnerabilityService.submitFeedback({
+      userId: user.id,
+      vulnerabilityId,
+      feedback: this.parseFeedback(body.feedback)
+    });
+  }
+
+  private normalizePagination(input: ListScanVulnerabilitiesQuery) {
+    if (!input.page || input.page < 1) {
+      throw new BadRequestException({
+        message: 'page must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    if (!input.size || input.size < 1) {
+      throw new BadRequestException({
+        message: 'size must be a positive integer.',
+        errorCode: 'BAD_REQUEST'
+      });
+    }
+
+    return {
+      page: input.page,
+      size: input.size
+    };
+  }
+
+  private parseFeedback(feedback: unknown): UserFeedback {
+    if (typeof feedback === 'string' && VALID_FEEDBACK.includes(feedback as UserFeedback)) {
+      return feedback as UserFeedback;
+    }
+
+    throw new BadRequestException({
+      message: 'feedback must be ACCEPTED or REJECTED.',
+      errorCode: 'BAD_REQUEST'
+    });
+  }
+}

--- a/apps/api/src/vulnerability/vulnerability.module.ts
+++ b/apps/api/src/vulnerability/vulnerability.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { AuthModule } from '../auth/auth.module';
+import { ConfigModule } from '../config/config.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { VulnerabilityController } from './vulnerability.controller';
+import { VulnerabilityService } from './vulnerability.service';
+
+@Module({
+  imports: [AuthModule, ConfigModule, PrismaModule],
+  controllers: [VulnerabilityController],
+  providers: [VulnerabilityService],
+  exports: [VulnerabilityService]
+})
+export class VulnerabilityModule {}

--- a/apps/api/src/vulnerability/vulnerability.service.ts
+++ b/apps/api/src/vulnerability/vulnerability.service.ts
@@ -1,0 +1,277 @@
+import type {
+  UserFeedback,
+  VulnerabilityDetail,
+  VulnerabilityFeedbackResponse,
+  VulnerabilityPageResponse
+} from '@aegisai/shared';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ScanStatus,
+  UserFeedback as PrismaUserFeedback,
+  VulnStatus,
+  type Prisma
+} from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service';
+
+interface ListScanVulnerabilitiesInput {
+  userId: string;
+  scanId: string;
+  page: number;
+  size: number;
+}
+
+interface SubmitFeedbackInput {
+  userId: string;
+  vulnerabilityId: string;
+  feedback: UserFeedback;
+}
+
+@Injectable()
+export class VulnerabilityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listScanVulnerabilities(
+    input: ListScanVulnerabilitiesInput
+  ): Promise<VulnerabilityPageResponse> {
+    await this.assertOwnedScan(input.userId, input.scanId);
+
+    const skip = (input.page - 1) * input.size;
+    const [totalCount, vulnerabilities] = await Promise.all([
+      this.prisma.vulnerability.count({
+        where: {
+          scanId: input.scanId
+        }
+      }),
+      this.prisma.vulnerability.findMany({
+        where: {
+          scanId: input.scanId
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        skip,
+        take: input.size
+      })
+    ]);
+
+    return {
+      items: vulnerabilities.map((vulnerability) => ({
+        id: vulnerability.id,
+        title: vulnerability.title,
+        severity: vulnerability.severity,
+        filePath: vulnerability.filePath,
+        lineStart: vulnerability.lineStart,
+        lineEnd: vulnerability.lineEnd,
+        cweId: vulnerability.cweId,
+        owaspCategory: vulnerability.owaspCategory,
+        status: vulnerability.status
+      })),
+      totalCount,
+      page: input.page,
+      totalPages: Math.max(1, Math.ceil(totalCount / input.size))
+    };
+  }
+
+  async getVulnerabilityDetail(userId: string, vulnerabilityId: string): Promise<VulnerabilityDetail> {
+    const vulnerability = await this.prisma.vulnerability.findFirst({
+      where: {
+        id: vulnerabilityId,
+        scan: {
+          connectedRepo: {
+            userId
+          }
+        }
+      },
+      include: {
+        scan: {
+          select: {
+            status: true
+          }
+        }
+      }
+    });
+
+    if (!vulnerability) {
+      throw new NotFoundException({
+        message: 'Vulnerability not found.',
+        errorCode: 'VULNERABILITY_NOT_FOUND'
+      });
+    }
+
+    this.assertScanResultsReady(vulnerability.scan.status);
+
+    return {
+      id: vulnerability.id,
+      title: vulnerability.title,
+      description: vulnerability.description,
+      severity: vulnerability.severity,
+      filePath: vulnerability.filePath,
+      lineStart: vulnerability.lineStart,
+      lineEnd: vulnerability.lineEnd,
+      codeSnippet: vulnerability.codeSnippet,
+      fixSuggestion: vulnerability.fixSuggestion,
+      fixExplanation: vulnerability.fixExplanation,
+      cweId: vulnerability.cweId,
+      cveId: vulnerability.cveId,
+      owaspCategory: vulnerability.owaspCategory,
+      referenceLinks: this.readReferenceLinks(vulnerability.referenceLinks),
+      consensusScore: vulnerability.consensusScore,
+      modelResults: this.readModelResults(vulnerability.modelResults),
+      status: vulnerability.status,
+      userFeedback: vulnerability.userFeedback
+    };
+  }
+
+  async submitFeedback(input: SubmitFeedbackInput): Promise<VulnerabilityFeedbackResponse> {
+    await this.assertOwnedVulnerability(input.userId, input.vulnerabilityId);
+
+    const nextStatus = this.toStatus(input.feedback);
+    const vulnerability = await this.prisma.vulnerability.update({
+      where: {
+        id: input.vulnerabilityId
+      },
+      data: {
+        status: nextStatus,
+        userFeedback: this.toUserFeedback(input.feedback)
+      }
+    });
+
+    return {
+      id: vulnerability.id,
+      status: nextStatus,
+      userFeedback: vulnerability.userFeedback as UserFeedback
+    };
+  }
+
+  private async assertOwnedScan(userId: string, scanId: string): Promise<void> {
+    const scan = await this.prisma.scan.findFirst({
+      where: {
+        id: scanId,
+        connectedRepo: {
+          userId
+        }
+      },
+      select: {
+        id: true,
+        status: true
+      }
+    });
+
+    if (!scan) {
+      throw new NotFoundException({
+        message: 'Scan not found.',
+        errorCode: 'SCAN_NOT_FOUND'
+      });
+    }
+
+    this.assertScanResultsReady(scan.status);
+  }
+
+  private async assertOwnedVulnerability(userId: string, vulnerabilityId: string): Promise<void> {
+    const vulnerability = await this.prisma.vulnerability.findFirst({
+      where: {
+        id: vulnerabilityId,
+        scan: {
+          connectedRepo: {
+            userId
+          }
+        }
+      },
+      select: {
+        id: true,
+        scan: {
+          select: {
+            status: true
+          }
+        }
+      }
+    });
+
+    if (!vulnerability) {
+      throw new NotFoundException({
+        message: 'Vulnerability not found.',
+        errorCode: 'VULNERABILITY_NOT_FOUND'
+      });
+    }
+
+    this.assertScanResultsReady(vulnerability.scan.status);
+  }
+
+  private toStatus(feedback: UserFeedback): Extract<VulnStatus, 'ACCEPTED' | 'REJECTED'> {
+    return feedback;
+  }
+
+  private toUserFeedback(feedback: UserFeedback): PrismaUserFeedback {
+    return feedback === 'ACCEPTED' ? PrismaUserFeedback.ACCEPTED : PrismaUserFeedback.REJECTED;
+  }
+
+  private assertScanResultsReady(status: ScanStatus): void {
+    if (status !== ScanStatus.DONE) {
+      throw new ConflictException({
+        message: 'Scan results are not ready for vulnerability review.',
+        errorCode: 'SCAN_RESULTS_NOT_READY'
+      });
+    }
+  }
+
+  private readReferenceLinks(
+    value: Prisma.JsonValue | null
+  ): { title: string; url: string }[] | null {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const references = value.flatMap((item) => {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        Array.isArray(item) ||
+        typeof item.title !== 'string' ||
+        typeof item.url !== 'string'
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          title: item.title,
+          url: item.url
+        }
+      ];
+    });
+
+    return references.length ? references : null;
+  }
+
+  private readModelResults(
+    value: Prisma.JsonValue | null
+  ): { model: string; detected: boolean; severity: string; reasoning: string }[] | null {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const results = value.flatMap((item) => {
+      if (
+        !item ||
+        typeof item !== 'object' ||
+        Array.isArray(item) ||
+        typeof item.model !== 'string' ||
+        typeof item.detected !== 'boolean' ||
+        typeof item.severity !== 'string' ||
+        typeof item.reasoning !== 'string'
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          model: item.model,
+          detected: item.detected,
+          severity: item.severity,
+          reasoning: item.reasoning
+        }
+      ];
+    });
+
+    return results.length ? results : null;
+  }
+}

--- a/apps/api/test/contracts/mvp-openapi.e2e-spec.ts
+++ b/apps/api/test/contracts/mvp-openapi.e2e-spec.ts
@@ -18,6 +18,15 @@ describe('MVP OpenAPI contract', () => {
     expect(contract).toContain("operationId: connectRepo");
   });
 
+  it('documents the current vulnerability review endpoints and feedback contract', () => {
+    expect(contract).toContain('/scans/{scanId}/vulnerabilities:');
+    expect(contract).toContain('/vulnerabilities/{vulnId}:');
+    expect(contract).toContain('/vulnerabilities/{vulnId}/feedback:\n    post:');
+    expect(contract).toContain('operationId: submitVulnerabilityFeedback');
+    expect(contract).toContain("$ref: '#/components/schemas/VulnerabilityFeedbackResponse'");
+    expect(contract).not.toContain('/vulnerabilities/{vulnId}/feedback:\n    patch:');
+  });
+
   it('uses the current auth, health, and session security shapes', () => {
     expect(contract).toContain('securitySchemes:');
     expect(contract).toContain('sessionCookie:');

--- a/apps/api/test/vulnerability/vulnerability.e2e-spec.ts
+++ b/apps/api/test/vulnerability/vulnerability.e2e-spec.ts
@@ -1,0 +1,254 @@
+import type { AuthUser } from '@aegisai/shared';
+import { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+class MockSessionAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ user?: AuthUser }>();
+
+    request.user = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: null,
+      connectedProviders: ['github']
+    };
+
+    return true;
+  }
+}
+
+describe('VulnerabilityController (e2e)', () => {
+  let app: INestApplication;
+  const vulnerabilityService = {
+    listScanVulnerabilities: jest.fn(),
+    getVulnerabilityDetail: jest.fn(),
+    submitFeedback: jest.fn()
+  };
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.PORT = '3000';
+    process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/aegisai';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.SESSION_SECRET = 'test-session-secret-value';
+    process.env.CSRF_SECRET = 'test-csrf-secret-value';
+    process.env.GITHUB_CLIENT_ID = 'github-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'github-client-secret';
+    process.env.GITLAB_CLIENT_ID = 'gitlab-client-id';
+    process.env.GITLAB_CLIENT_SECRET = 'gitlab-client-secret';
+    process.env.APP_URL = 'http://localhost:3000';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+    process.env.SESSION_COOKIE_NAME = 'connect.sid';
+    process.env.CSRF_COOKIE_NAME = 'csrf_token';
+    process.env.COOKIE_DOMAIN = '';
+    process.env.TOKEN_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    process.env.ANALYSIS_CLIENT_MODE = 'mock';
+    process.env.AI_SERVER_URL = 'http://localhost:8000';
+    process.env.USE_INTERNAL_AI = 'false';
+    process.env.INTERNAL_API_SECRET = '';
+    process.env.GITHUB_APP_WEBHOOK_SECRET = '';
+    process.env.GITLAB_WEBHOOK_SECRET = '';
+    process.env.REPORT_STORAGE_PATH = './tmp/reports';
+    process.env.REPORT_EXPIRY_HOURS = '24';
+
+    const [{ AppModule }, { configureApp }, { PrismaService }, { SessionAuthGuard }] =
+      await Promise.all([
+        import('../../src/app.module'),
+        import('../../src/bootstrap/configure-app'),
+        import('../../src/prisma/prisma.service'),
+        import('../../src/auth/guards/session-auth.guard')
+      ]);
+
+    let VulnerabilityService: object | null = null;
+
+    try {
+      const vulnerabilityServiceModulePath = '../../src/vulnerability/vulnerability.service';
+      ({ VulnerabilityService } = await import(vulnerabilityServiceModulePath));
+    } catch {
+      VulnerabilityService = null;
+    }
+
+    const builder = Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .overrideGuard(SessionAuthGuard)
+      .useClass(MockSessionAuthGuard);
+
+    if (VulnerabilityService) {
+      builder.overrideProvider(VulnerabilityService).useValue(vulnerabilityService);
+    }
+
+    const moduleRef = await builder.compile();
+
+    app = moduleRef.createNestApplication();
+    await configureApp(app);
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('returns wrapped paginated findings from GET /api/scans/:scanId/vulnerabilities', async () => {
+    vulnerabilityService.listScanVulnerabilities.mockResolvedValue({
+      items: [
+        {
+          id: 'vuln-1',
+          title: 'SQL Injection',
+          severity: 'HIGH',
+          filePath: 'src/main/java/com/acme/AuthController.java',
+          lineStart: 18,
+          lineEnd: 19,
+          cweId: 'CWE-89',
+          owaspCategory: 'A03:2021-Injection',
+          status: 'OPEN'
+        }
+      ],
+      totalCount: 1,
+      page: 2,
+      totalPages: 3
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/scans/scan-1/vulnerabilities')
+      .query({ page: 2, size: 25 })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            items: [
+              {
+                id: 'vuln-1',
+                title: 'SQL Injection',
+                severity: 'HIGH'
+              }
+            ],
+            totalCount: 1,
+            page: 2,
+            totalPages: 3
+          },
+          message: null
+        });
+      });
+
+    expect(vulnerabilityService.listScanVulnerabilities).toHaveBeenCalledWith({
+      userId: 'user-1',
+      scanId: 'scan-1',
+      page: 2,
+      size: 25
+    });
+  });
+
+  it('returns wrapped vulnerability detail from GET /api/vulnerabilities/:vulnId', async () => {
+    vulnerabilityService.getVulnerabilityDetail.mockResolvedValue({
+      id: 'vuln-1',
+      title: 'SQL Injection',
+      description: 'Unsanitized user input reaches a query builder.',
+      severity: 'HIGH',
+      filePath: 'src/main/java/com/acme/AuthController.java',
+      lineStart: 18,
+      lineEnd: 19,
+      codeSnippet: 'statement.execute(query)',
+      fixSuggestion: 'Use prepared statements.',
+      fixExplanation: 'Prepared statements bind values safely.',
+      cweId: 'CWE-89',
+      cveId: null,
+      owaspCategory: 'A03:2021-Injection',
+      referenceLinks: [{ title: 'OWASP Injection', url: 'https://owasp.org' }],
+      consensusScore: 0.92,
+      modelResults: [
+        {
+          model: 'gpt-5.4',
+          detected: true,
+          severity: 'HIGH',
+          reasoning: 'Tainted input reaches the SQL sink.'
+        }
+      ],
+      status: 'OPEN',
+      userFeedback: null
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/vulnerabilities/vuln-1')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            id: 'vuln-1',
+            title: 'SQL Injection',
+            consensusScore: 0.92,
+            status: 'OPEN'
+          },
+          message: null
+        });
+      });
+
+    expect(vulnerabilityService.getVulnerabilityDetail).toHaveBeenCalledWith('user-1', 'vuln-1');
+  });
+
+  it('returns wrapped feedback response from POST /api/vulnerabilities/:vulnId/feedback', async () => {
+    vulnerabilityService.submitFeedback.mockResolvedValue({
+      id: 'vuln-1',
+      status: 'ACCEPTED',
+      userFeedback: 'ACCEPTED'
+    });
+
+    await request(app.getHttpServer())
+      .post('/api/vulnerabilities/vuln-1/feedback')
+      .send({
+        feedback: 'ACCEPTED'
+      })
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            id: 'vuln-1',
+            status: 'ACCEPTED',
+            userFeedback: 'ACCEPTED'
+          },
+          message: null
+        });
+      });
+
+    expect(vulnerabilityService.submitFeedback).toHaveBeenCalledWith({
+      userId: 'user-1',
+      vulnerabilityId: 'vuln-1',
+      feedback: 'ACCEPTED'
+    });
+  });
+
+  it('returns 400 from POST /api/vulnerabilities/:vulnId/feedback for invalid feedback values', async () => {
+    await request(app.getHttpServer())
+      .post('/api/vulnerabilities/vuln-1/feedback')
+      .send({
+        feedback: 'OPEN'
+      })
+      .expect(400)
+      .expect(({ body }) => {
+        expect(body.success).toBe(false);
+        expect(body.errorCode).toBe('BAD_REQUEST');
+      });
+
+    expect(vulnerabilityService.submitFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/vulnerability/vulnerability.service.e2e-spec.ts
+++ b/apps/api/test/vulnerability/vulnerability.service.e2e-spec.ts
@@ -1,0 +1,276 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+import { VulnerabilityService } from '../../src/vulnerability/vulnerability.service';
+
+describe('VulnerabilityService', () => {
+  it('returns paginated scan vulnerabilities scoped to the authenticated user', async () => {
+    const prisma = {
+      scan: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'scan-1', status: 'DONE' })
+      },
+      vulnerability: {
+        count: jest.fn().mockResolvedValue(3),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'vuln-1',
+            title: 'SQL Injection',
+            severity: 'HIGH',
+            filePath: 'src/main/java/com/acme/AuthController.java',
+            lineStart: 18,
+            lineEnd: 19,
+            cweId: 'CWE-89',
+            owaspCategory: 'A03:2021-Injection',
+            status: 'OPEN',
+            createdAt: new Date('2026-03-27T10:00:00.000Z')
+          }
+        ])
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(
+      service.listScanVulnerabilities({
+        userId: 'user-1',
+        scanId: 'scan-1',
+        page: 2,
+        size: 1
+      })
+    ).resolves.toEqual({
+      items: [
+        {
+          id: 'vuln-1',
+          title: 'SQL Injection',
+          severity: 'HIGH',
+          filePath: 'src/main/java/com/acme/AuthController.java',
+          lineStart: 18,
+          lineEnd: 19,
+          cweId: 'CWE-89',
+          owaspCategory: 'A03:2021-Injection',
+          status: 'OPEN'
+        }
+      ],
+      totalCount: 3,
+      page: 2,
+      totalPages: 3
+    });
+
+    expect(prisma.scan.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'scan-1',
+        connectedRepo: {
+          userId: 'user-1'
+        }
+      },
+      select: {
+        id: true,
+        status: true
+      }
+    });
+    expect(prisma.vulnerability.findMany).toHaveBeenCalledWith({
+      where: {
+        scanId: 'scan-1'
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      skip: 1,
+      take: 1
+    });
+  });
+
+  it('rejects vulnerability review when the parent scan is not done yet', async () => {
+    const prisma = {
+      scan: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'scan-1',
+          status: 'FAILED'
+        })
+      },
+      vulnerability: {
+        count: jest.fn(),
+        findMany: jest.fn()
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(
+      service.listScanVulnerabilities({
+        userId: 'user-1',
+        scanId: 'scan-1',
+        page: 1,
+        size: 50
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prisma.vulnerability.findMany).not.toHaveBeenCalled();
+  });
+
+  it('maps vulnerability detail JSON fields into shared contract shapes', async () => {
+    const prisma = {
+      vulnerability: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'vuln-1',
+          title: 'SQL Injection',
+          description: 'Unsanitized user input reaches a query builder.',
+          severity: 'HIGH',
+          filePath: 'src/main/java/com/acme/AuthController.java',
+          lineStart: 18,
+          lineEnd: 19,
+          codeSnippet: 'statement.execute(query)',
+          fixSuggestion: 'Use prepared statements.',
+          fixExplanation: 'Prepared statements bind values safely.',
+          cweId: 'CWE-89',
+          cveId: null,
+          owaspCategory: 'A03:2021-Injection',
+          referenceLinks: [{ title: 'OWASP Injection', url: 'https://owasp.org' }],
+          consensusScore: 0.92,
+          modelResults: [
+            {
+              model: 'gpt-5.4',
+              detected: true,
+              severity: 'HIGH',
+              reasoning: 'Tainted input reaches the SQL sink.'
+            }
+          ],
+          status: 'OPEN',
+          userFeedback: null,
+          scan: {
+            status: 'DONE'
+          }
+        })
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(service.getVulnerabilityDetail('user-1', 'vuln-1')).resolves.toEqual({
+      id: 'vuln-1',
+      title: 'SQL Injection',
+      description: 'Unsanitized user input reaches a query builder.',
+      severity: 'HIGH',
+      filePath: 'src/main/java/com/acme/AuthController.java',
+      lineStart: 18,
+      lineEnd: 19,
+      codeSnippet: 'statement.execute(query)',
+      fixSuggestion: 'Use prepared statements.',
+      fixExplanation: 'Prepared statements bind values safely.',
+      cweId: 'CWE-89',
+      cveId: null,
+      owaspCategory: 'A03:2021-Injection',
+      referenceLinks: [{ title: 'OWASP Injection', url: 'https://owasp.org' }],
+      consensusScore: 0.92,
+      modelResults: [
+        {
+          model: 'gpt-5.4',
+          detected: true,
+          severity: 'HIGH',
+          reasoning: 'Tainted input reaches the SQL sink.'
+        }
+      ],
+      status: 'OPEN',
+      userFeedback: null
+    });
+  });
+
+  it('throws when the vulnerability does not belong to the authenticated user', async () => {
+    const prisma = {
+      vulnerability: {
+        findFirst: jest.fn().mockResolvedValue(null)
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(service.getVulnerabilityDetail('user-1', 'missing-vuln')).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+  });
+
+  it('rejects vulnerability detail when the parent scan is not done yet', async () => {
+    const prisma = {
+      vulnerability: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'vuln-1',
+          title: 'SQL Injection',
+          scan: {
+            status: 'FAILED'
+          }
+        })
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(service.getVulnerabilityDetail('user-1', 'vuln-1')).rejects.toBeInstanceOf(
+      ConflictException
+    );
+  });
+
+  it('rejects feedback submission when the parent scan is not done yet', async () => {
+    const prisma = {
+      vulnerability: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'vuln-1',
+          scan: {
+            status: 'FAILED'
+          }
+        }),
+        update: jest.fn()
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(
+      service.submitFeedback({
+        userId: 'user-1',
+        vulnerabilityId: 'vuln-1',
+        feedback: 'ACCEPTED'
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prisma.vulnerability.update).not.toHaveBeenCalled();
+  });
+
+  it('stores reviewer feedback as both status and user feedback', async () => {
+    const prisma = {
+      vulnerability: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'vuln-1',
+          scan: {
+            status: 'DONE'
+          }
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'vuln-1',
+          status: 'ACCEPTED',
+          userFeedback: 'ACCEPTED'
+        })
+      }
+    };
+
+    const service = new VulnerabilityService(prisma as never);
+
+    await expect(
+      service.submitFeedback({
+        userId: 'user-1',
+        vulnerabilityId: 'vuln-1',
+        feedback: 'ACCEPTED'
+      })
+    ).resolves.toEqual({
+      id: 'vuln-1',
+      status: 'ACCEPTED',
+      userFeedback: 'ACCEPTED'
+    });
+
+    expect(prisma.vulnerability.update).toHaveBeenCalledWith({
+      where: {
+        id: 'vuln-1'
+      },
+      data: {
+        status: 'ACCEPTED',
+        userFeedback: 'ACCEPTED'
+      }
+    });
+  });
+});

--- a/docs/superpowers/plans/2026-03-28-vulnerability-backend-feedback-endpoints.md
+++ b/docs/superpowers/plans/2026-03-28-vulnerability-backend-feedback-endpoints.md
@@ -1,0 +1,16 @@
+# #89 Vulnerability Backend Module And Feedback Endpoints Plan
+
+1. Add failing controller tests for:
+   - `GET /api/scans/:scanId/vulnerabilities`
+   - `GET /api/vulnerabilities/:vulnId`
+   - `POST /api/vulnerabilities/:vulnId/feedback`
+   - malformed feedback validation
+2. Verify the new endpoint tests fail before implementation so the missing vulnerability module is visible.
+3. Implement `VulnerabilityModule`, `VulnerabilityController`, and `VulnerabilityService`.
+4. Wire the module into `AppModule` so the endpoints are available through the real application bootstrap path.
+5. Add service tests for:
+   - scan ownership scoping
+   - vulnerability detail JSON mapping
+   - feedback persistence behavior
+6. Run targeted vulnerability tests until both controller and service coverage are green.
+7. Run workspace `lint`, `test`, `typecheck`, and `build`.

--- a/docs/superpowers/specs/2026-03-28-vulnerability-backend-feedback-design.md
+++ b/docs/superpowers/specs/2026-03-28-vulnerability-backend-feedback-design.md
@@ -1,0 +1,57 @@
+# #89 Vulnerability Backend Module And Feedback Endpoints Design
+
+## Summary
+
+This issue closes the backend half of the new vulnerability review workflow. The frontend already expects scan-scoped list data, vulnerability detail data, and explicit reviewer feedback persistence, so the backend work should add those endpoints without changing the shared contract shape that the protected review workspace already uses.
+
+## Goals
+
+- Implement a dedicated backend module for vulnerability list, detail, and feedback behavior.
+- Scope all vulnerability access to scans owned through the authenticated user's connected repositories.
+- Persist reviewer feedback in a way that keeps `status` and `userFeedback` aligned.
+- Reuse the existing global response envelope and session-auth patterns already used by repo and scan APIs.
+- Cover contract shape and domain behavior with endpoint and service tests.
+
+## Non-Goals
+
+- No redesign of the frontend vulnerability review workspace.
+- No new vulnerability scoring or triage taxonomy beyond the existing schema enums.
+- No pagination redesign beyond honoring the shared `PageResponse` contract.
+- No report/dashboard work in this issue.
+
+## API Shape
+
+The backend should implement the contract that the frontend review page already calls:
+
+- `GET /api/scans/:scanId/vulnerabilities`
+- `GET /api/vulnerabilities/:vulnId`
+- `POST /api/vulnerabilities/:vulnId/feedback`
+
+The list endpoint should default to page `1` and size `50` to match the current frontend helper. All successful responses should flow through the existing response envelope, and malformed pagination or feedback values should produce the standard `BAD_REQUEST` payload.
+
+## Ownership And Access Rules
+
+- A scan-level vulnerability list is visible only when the scan belongs to a repository connected by the authenticated user.
+- A vulnerability detail is visible only when its parent scan belongs to that user.
+- Feedback submission uses the same ownership rule and should return `VULNERABILITY_NOT_FOUND` when the record is outside scope or missing.
+
+This keeps the backend aligned with the repo and scan modules: unauthorized cross-user resources should not leak existence.
+
+## Persistence Rules
+
+The Prisma schema already stores both `status` and `userFeedback`. For MVP, feedback actions are binary:
+
+- `ACCEPTED`
+- `REJECTED`
+
+When feedback is submitted, both fields should be updated together so the frontend can trust either field when reflecting reviewer state. The response should echo the persisted status and feedback pair.
+
+## Mapping Rules
+
+`referenceLinks` and `modelResults` are stored as JSON. The service should normalize them back into the shared contract shape, returning `null` when the JSON value is absent or malformed rather than leaking raw JSON into the API boundary.
+
+## Testing Strategy
+
+- Controller e2e tests should lock the wrapped API contract, validation behavior, and response codes.
+- Service tests should lock ownership scoping, paginated list behavior, JSON field mapping, and feedback persistence.
+- Final validation should run the targeted vulnerability tests first, then workspace `lint`, `test`, `typecheck`, and `build`.

--- a/specs/001-aegisai-mvp-foundation/contracts/mvp-openapi.yaml
+++ b/specs/001-aegisai-mvp-foundation/contracts/mvp-openapi.yaml
@@ -243,6 +243,8 @@ paths:
                 $ref: '#/components/schemas/VulnerabilityPageResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '404':
           $ref: '#/components/responses/NotFound'
   /vulnerabilities/{vulnId}:
@@ -260,12 +262,14 @@ paths:
                 $ref: '#/components/schemas/VulnerabilityDetailResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '404':
           $ref: '#/components/responses/NotFound'
   /vulnerabilities/{vulnId}/feedback:
-    patch:
+    post:
       summary: Submit user feedback for a vulnerability
-      operationId: updateVulnerabilityFeedback
+      operationId: submitVulnerabilityFeedback
       parameters:
         - $ref: '#/components/parameters/VulnId'
       requestBody:
@@ -276,13 +280,15 @@ paths:
               $ref: '#/components/schemas/VulnerabilityFeedbackRequest'
       responses:
         '200':
-          description: Updated vulnerability detail
+          description: Recorded reviewer feedback
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VulnerabilityDetailResponse'
+                $ref: '#/components/schemas/VulnerabilityFeedbackResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
@@ -528,11 +534,21 @@ components:
       properties:
         model:
           type: string
-        decision:
+        detected:
+          type: boolean
+        severity:
           type: string
         reasoning:
           type: string
-      required: [model, decision, reasoning]
+      required: [model, detected, severity, reasoning]
+    ReferenceLink:
+      type: object
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+      required: [title, url]
     Vulnerability:
       type: object
       properties:
@@ -548,12 +564,15 @@ components:
         lineStart:
           type: integer
         lineEnd:
-          type: integer
-        confidenceScore:
-          type: number
-        consensusScore:
-          type: number
-      required: [id, title, severity, filePath, lineStart, lineEnd, confidenceScore, consensusScore]
+          type: [integer, 'null']
+        cweId:
+          type: [string, 'null']
+        owaspCategory:
+          type: [string, 'null']
+        status:
+          type: string
+          enum: [OPEN, FIXED, ACCEPTED, REJECTED]
+      required: [id, title, severity, filePath, lineStart, status]
     VulnerabilityDetail:
       allOf:
         - $ref: '#/components/schemas/Vulnerability'
@@ -561,19 +580,28 @@ components:
           properties:
             description:
               type: string
-            recommendation:
-              type: string
+            fixSuggestion:
+              type: [string, 'null']
+            fixExplanation:
+              type: [string, 'null']
             codeSnippet:
-              type: string
+              type: [string, 'null']
+            cveId:
+              type: [string, 'null']
+            referenceLinks:
+              type: [array, 'null']
+              items:
+                $ref: '#/components/schemas/ReferenceLink'
+            consensusScore:
+              type: [number, 'null']
             modelResults:
-              type: array
-              maxItems: 10
+              type: [array, 'null']
               items:
                 $ref: '#/components/schemas/ModelResult'
-            feedback:
-              type: string
-              enum: [OPEN, ACCEPTED, REJECTED, FIXED]
-          required: [description, recommendation, codeSnippet, modelResults, feedback]
+            userFeedback:
+              type: [string, 'null']
+              enum: [ACCEPTED, REJECTED, null]
+          required: [description]
     DashboardSummary:
       type: object
       properties:
@@ -642,7 +670,23 @@ components:
           type: boolean
         data:
           $ref: '#/components/schemas/VulnerabilityDetail'
-      required: [success, data]
+        message:
+          type: [string, 'null']
+        timestamp:
+          type: string
+      required: [success, data, message, timestamp]
+    ApiEnvelopeVulnerabilityFeedback:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          $ref: '#/components/schemas/VulnerabilityFeedback'
+        message:
+          type: [string, 'null']
+        timestamp:
+          type: string
+      required: [success, data, message, timestamp]
     ApiEnvelopeDashboard:
       type: object
       properties:
@@ -718,11 +762,11 @@ components:
             $ref: '#/components/schemas/Vulnerability'
         page:
           type: integer
-        size:
+        totalCount:
           type: integer
-        total:
+        totalPages:
           type: integer
-      required: [items, page, size, total]
+      required: [items, page, totalCount, totalPages]
     ProviderRepoPageResponse:
       type: object
       properties:
@@ -754,7 +798,11 @@ components:
           type: boolean
         data:
           $ref: '#/components/schemas/VulnerabilityPage'
-      required: [success, data]
+        message:
+          type: [string, 'null']
+        timestamp:
+          type: string
+      required: [success, data, message, timestamp]
     ConnectRepoRequest:
       type: object
       properties:
@@ -788,6 +836,18 @@ components:
           type: string
           enum: [ACCEPTED, REJECTED]
       required: [feedback]
+    VulnerabilityFeedback:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+          enum: [ACCEPTED, REJECTED]
+        userFeedback:
+          type: string
+          enum: [ACCEPTED, REJECTED]
+      required: [id, status, userFeedback]
     ReportRequestAccepted:
       type: object
       properties:
@@ -833,6 +893,8 @@ components:
       required: [success, data, message, timestamp]
     VulnerabilityDetailResponse:
       $ref: '#/components/schemas/ApiEnvelopeVulnerabilityDetail'
+    VulnerabilityFeedbackResponse:
+      $ref: '#/components/schemas/ApiEnvelopeVulnerabilityFeedback'
     DashboardResponse:
       $ref: '#/components/schemas/ApiEnvelopeDashboard'
     ReportDetailResponse:


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/89-vulnerability-backend-feedback-endpoints`
- 이슈: `#89`

## 🔎 주요 변경 사항

- `apps/api/src/vulnerability/` 아래에 `VulnerabilityModule`, `VulnerabilityController`, `VulnerabilityService`를 추가했습니다.
- `GET /api/scans/:scanId/vulnerabilities`, `GET /api/vulnerabilities/:vulnId`, `POST /api/vulnerabilities/:vulnId/feedback` 엔드포인트를 구현했습니다.
- vulnerability 조회와 feedback 저장이 connected repository ownership 기준으로만 동작하도록 구성했습니다.
- reviewer feedback 저장 시 `status`와 `userFeedback`이 함께 반영되도록 정리했습니다.
- `DONE` scan만 vulnerability review 대상으로 허용하도록 backend guardrail을 추가했습니다.
- `referenceLinks`, `modelResults` JSON 필드를 shared contract 형태로 정규화해 응답하도록 구현했습니다.
- `AppModule`에 `VulnerabilityModule`을 연결했습니다.
- vulnerability controller/service 회귀 테스트를 추가했습니다.
- OpenAPI 계약을 현재 구현 메서드와 응답 형태에 맞게 갱신했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vulnerability review endpoints to list and view vulnerability details
  * Enabled feedback submission with accepted/rejected status tracking
  * Integrated pagination support for vulnerability listings

* **Documentation**
  * Added design specifications and implementation plan for vulnerability feedback workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->