### PR TITLE
Fix: deployed web same-origin API base URL fallback 수정

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:3000/api
+VITE_API_URL=/api
 # VITE_API_BASE_URL is still supported for backward compatibility.

--- a/apps/web/src/api/client.test.ts
+++ b/apps/web/src/api/client.test.ts
@@ -61,6 +61,11 @@ describe("api client helpers", () => {
     expect(getProviderLoginUrl("github")).toBe("/api/auth/github");
   });
 
+  it("defaults to same-origin /api when no API env vars are set", () => {
+    expect(resolveApiBaseUrl()).toBe("/api");
+    expect(getProviderLoginUrl("github")).toBe("/api/auth/github");
+  });
+
   it("uses VITE_API_URL when it is set", () => {
     vi.stubEnv("VITE_API_URL", "https://api.example.com");
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -32,7 +32,7 @@ export function resolveApiBaseUrl(): string {
     return viteApiBaseUrl;
   }
 
-  return "http://localhost:3000/api";
+  return "/api";
 }
 
 export function getCookie(name: string, cookieSource = document.cookie): string | null {

--- a/apps/web/src/pages/LandingPage.test.tsx
+++ b/apps/web/src/pages/LandingPage.test.tsx
@@ -32,11 +32,11 @@ describe("LandingPage", () => {
 
     expect(githubCtas).toHaveLength(3);
     githubCtas.forEach((link) => {
-      expect(link).toHaveAttribute("href", "http://localhost:3000/api/auth/github");
+      expect(link).toHaveAttribute("href", "/api/auth/github");
     });
     expect(
       screen.getByRole("link", { name: /connect gitlab/i })
-    ).toHaveAttribute("href", "http://localhost:3000/api/auth/gitlab");
+    ).toHaveAttribute("href", "/api/auth/gitlab");
     expect(screen.getByRole("link", { name: /log in/i })).toHaveAttribute(
       "href",
       "/login"

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -49,10 +49,10 @@ describe("LoginPage", () => {
     ).toHaveAttribute("href", "/");
     expect(
       screen.getByRole("link", { name: /continue with github/i })
-    ).toHaveAttribute("href", "http://localhost:3000/api/auth/github");
+    ).toHaveAttribute("href", "/api/auth/github");
     expect(
       screen.getByRole("link", { name: /continue with gitlab/i })
-    ).toHaveAttribute("href", "http://localhost:3000/api/auth/gitlab");
+    ).toHaveAttribute("href", "/api/auth/gitlab");
     expect(screen.getByText(/soc2 compliant/i)).toBeInTheDocument();
     expect(screen.getByText(/encrypted sessions/i)).toBeInTheDocument();
   });
@@ -72,7 +72,7 @@ describe("LoginPage", () => {
     expect(screen.getByRole("status")).toHaveTextContent(/awaiting provider response/i);
     expect(
       screen.getByRole("link", { name: /continue with github/i })
-    ).toHaveAttribute("href", "http://localhost:3000/api/auth/github");
+    ).toHaveAttribute("href", "/api/auth/github");
   });
 
   it("renders an oauth failure message from the query string", () => {

--- a/apps/web/vite.config.test.ts
+++ b/apps/web/vite.config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import config from "./vite.config";
+
+describe("vite config", () => {
+  it("proxies same-origin /api requests to the local Nest backend during development", () => {
+    expect(config.server?.proxy?.["/api"]).toMatchObject({
+      target: "http://localhost:3000",
+      changeOrigin: true,
+    });
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,14 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/97-same-origin-api-base-url-fallback`
- 이슈: `#97`

## 🔎 주요 변경 사항

- 프론트 기본 API base URL fallback을 `http://localhost:3000/api`에서 same-origin `/api`로 수정했습니다.
- Vite dev server에 `/api -> http://localhost:3000` 프록시를 추가해 로컬 개발 환경에서도 동일한 경로 전략을 사용하도록 구성했습니다.
- 로그인/랜딩 화면의 OAuth CTA 기대값을 same-origin `/api/auth/...` 기준으로 정리했습니다.
- `apps/web/.env.example`를 현재 동작 기준에 맞게 `/api` 예시로 갱신했습니다.
- `apps/web/vite.config.test.ts`와 API client 회귀 테스트를 추가해 same-origin fallback과 dev proxy 구성을 검증했습니다.
- production build 산출물에 `localhost:3000/api` 문자열이 남지 않는 것을 확인했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
