### PR TITLE
Fix: deployed web same-origin API base URL fallback 수정

### DIFF
--- a/apps/api/src/auth/auth-runtime.util.ts
+++ b/apps/api/src/auth/auth-runtime.util.ts
@@ -1,0 +1,95 @@
+type RequestLike = {
+  protocol?: string;
+  secure?: boolean;
+  headers?: Record<string, string | string[] | undefined>;
+  get?: (name: string) => string | undefined;
+};
+
+type Provider = 'github' | 'gitlab';
+
+export function buildProviderCallbackUrl(
+  request: RequestLike,
+  configuredAppUrl: string,
+  provider: Provider
+): string {
+  return new URL(
+    `/api/auth/${provider}/callback`,
+    resolveRuntimeBaseUrl(request, configuredAppUrl)
+  ).toString();
+}
+
+export function buildFrontendRedirectUrl(
+  request: RequestLike,
+  configuredFrontendUrl: string,
+  pathname: string
+): string {
+  return new URL(pathname, resolveRuntimeBaseUrl(request, configuredFrontendUrl)).toString();
+}
+
+export function shouldUseSecureCookies(
+  request: RequestLike,
+  fallbackUrl: string
+): boolean {
+  return new URL(resolveRequestOrigin(request, fallbackUrl)).protocol === 'https:';
+}
+
+function resolveRuntimeBaseUrl(request: RequestLike, configuredUrl: string): string {
+  const configured = new URL(configuredUrl);
+  const requestOrigin = new URL(resolveRequestOrigin(request, configuredUrl));
+
+  return configured.host === requestOrigin.host ? requestOrigin.origin : configured.origin;
+}
+
+function resolveRequestOrigin(request: RequestLike, fallbackUrl: string): string {
+  const fallback = new URL(fallbackUrl);
+  const protocol =
+    normalizeForwardedValue(getHeader(request, 'x-forwarded-proto')) ??
+    normalizeScheme(request.protocol) ??
+    (request.secure ? 'https' : null) ??
+    normalizeScheme(fallback.protocol);
+  const host =
+    normalizeForwardedValue(getHeader(request, 'x-forwarded-host')) ??
+    normalizeForwardedValue(getHeader(request, 'host'));
+
+  if (!host) {
+    return fallback.origin;
+  }
+
+  return `${protocol}://${host}`;
+}
+
+function getHeader(request: RequestLike, name: string): string | undefined {
+  const directHeader = request.get?.(name);
+
+  if (directHeader) {
+    return directHeader;
+  }
+
+  const headerValue = request.headers?.[name] ?? request.headers?.[name.toLowerCase()];
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return headerValue;
+}
+
+function normalizeForwardedValue(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const [first] = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return first ?? null;
+}
+
+function normalizeScheme(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return value.replace(/:$/, '').trim().toLowerCase();
+}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -8,17 +8,18 @@ import {
   Res,
   UseGuards
 } from '@nestjs/common';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import type session from 'express-session';
 
 import { ConfigService } from '../config/config.service';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { AuthService } from './auth.service';
+import { buildFrontendRedirectUrl, shouldUseSecureCookies } from './auth-runtime.util';
 import { GithubAuthGuard } from './guards/github-auth.guard';
 import { GitlabAuthGuard } from './guards/gitlab-auth.guard';
 import { SessionAuthGuard } from './guards/session-auth.guard';
 
-type RequestWithSession = {
+type RequestWithSession = Request & {
   session?: session.Session & Partial<session.SessionData>;
   logout?: (callback: (error?: Error | null) => void) => void;
 };
@@ -36,9 +37,9 @@ export class AuthController {
 
   @Get('github/callback')
   @UseGuards(GithubAuthGuard)
-  githubCallback(@Res() response: Response): void {
-    this.issueCsrfCookie(response);
-    response.redirect(new URL('/dashboard', this.config.get('FRONTEND_URL')).toString());
+  githubCallback(@Req() request: Request, @Res() response: Response): void {
+    this.issueCsrfCookie(request, response);
+    response.redirect(buildFrontendRedirectUrl(request, this.config.get('FRONTEND_URL'), '/dashboard'));
   }
 
   @Get('gitlab')
@@ -47,18 +48,19 @@ export class AuthController {
 
   @Get('gitlab/callback')
   @UseGuards(GitlabAuthGuard)
-  gitlabCallback(@Res() response: Response): void {
-    this.issueCsrfCookie(response);
-    response.redirect(new URL('/dashboard', this.config.get('FRONTEND_URL')).toString());
+  gitlabCallback(@Req() request: Request, @Res() response: Response): void {
+    this.issueCsrfCookie(request, response);
+    response.redirect(buildFrontendRedirectUrl(request, this.config.get('FRONTEND_URL'), '/dashboard'));
   }
 
   @Get('me')
   @UseGuards(SessionAuthGuard)
   getMe(
+    @Req() request: Request,
     @CurrentUser() user: AuthUser,
     @Res({ passthrough: true }) response: Response
   ): AuthMeResponse {
-    this.issueCsrfCookie(response);
+    this.issueCsrfCookie(request, response);
     return user;
   }
 
@@ -74,24 +76,24 @@ export class AuthController {
     response.clearCookie(this.config.get('SESSION_COOKIE_NAME'), {
       httpOnly: true,
       sameSite: 'lax',
-      secure: this.config.isProduction(),
+      secure: shouldUseSecureCookies(request, this.config.get('APP_URL')),
       domain: this.config.getOptional('COOKIE_DOMAIN') || undefined
     });
     response.clearCookie(this.config.get('CSRF_COOKIE_NAME'), {
       httpOnly: false,
       sameSite: 'lax',
-      secure: this.config.isProduction(),
+      secure: shouldUseSecureCookies(request, this.config.get('APP_URL')),
       domain: this.config.getOptional('COOKIE_DOMAIN') || undefined
     });
 
     response.status(200).json(null);
   }
 
-  private issueCsrfCookie(response: Response): void {
+  private issueCsrfCookie(request: Request, response: Response): void {
     response.cookie(this.config.get('CSRF_COOKIE_NAME'), this.authService.createCsrfToken(), {
       httpOnly: false,
       sameSite: 'lax',
-      secure: this.config.isProduction(),
+      secure: shouldUseSecureCookies(request, this.config.get('APP_URL')),
       domain: this.config.getOptional('COOKIE_DOMAIN') || undefined
     });
   }

--- a/apps/api/src/auth/guards/github-auth.guard.ts
+++ b/apps/api/src/auth/guards/github-auth.guard.ts
@@ -1,5 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import type { ExecutionContext } from '@nestjs/common';
+
+import { ConfigService } from '../../config/config.service';
+import { buildProviderCallbackUrl } from '../auth-runtime.util';
 
 @Injectable()
-export class GithubAuthGuard extends AuthGuard('github') {}
+export class GithubAuthGuard extends AuthGuard('github') {
+  constructor(private readonly config: ConfigService) {
+    super();
+  }
+
+  getAuthenticateOptions(context: ExecutionContext): Record<string, string> {
+    const request = context.switchToHttp().getRequest();
+
+    return {
+      callbackURL: buildProviderCallbackUrl(request, this.config.get('APP_URL'), 'github')
+    };
+  }
+}

--- a/apps/api/src/auth/guards/gitlab-auth.guard.ts
+++ b/apps/api/src/auth/guards/gitlab-auth.guard.ts
@@ -1,5 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import type { ExecutionContext } from '@nestjs/common';
+
+import { ConfigService } from '../../config/config.service';
+import { buildProviderCallbackUrl } from '../auth-runtime.util';
 
 @Injectable()
-export class GitlabAuthGuard extends AuthGuard('gitlab') {}
+export class GitlabAuthGuard extends AuthGuard('gitlab') {
+  constructor(private readonly config: ConfigService) {
+    super();
+  }
+
+  getAuthenticateOptions(context: ExecutionContext): Record<string, string> {
+    const request = context.switchToHttp().getRequest();
+
+    return {
+      callbackURL: buildProviderCallbackUrl(request, this.config.get('APP_URL'), 'gitlab')
+    };
+  }
+}

--- a/apps/api/src/bootstrap/configure-app.ts
+++ b/apps/api/src/bootstrap/configure-app.ts
@@ -19,7 +19,7 @@ export async function configureApp(app: INestApplication): Promise<void> {
       maxAge: 86400000,
       httpOnly: true,
       sameSite: 'lax',
-      secure: config.isProduction(),
+      secure: 'auto',
       domain: config.getOptional('COOKIE_DOMAIN') || undefined
     }
   };

--- a/apps/api/test/auth/auth-runtime.util.e2e-spec.ts
+++ b/apps/api/test/auth/auth-runtime.util.e2e-spec.ts
@@ -1,0 +1,63 @@
+import {
+  buildFrontendRedirectUrl,
+  buildProviderCallbackUrl,
+  shouldUseSecureCookies
+} from '../../src/auth/auth-runtime.util';
+
+describe('auth runtime url helpers', () => {
+  const request = {
+    protocol: 'http',
+    secure: false,
+    headers: {
+      host: '161.33.220.227'
+    }
+  };
+
+  it('prefers the incoming request origin for provider callbacks when only the scheme differs', () => {
+    expect(
+      buildProviderCallbackUrl(request, 'https://161.33.220.227', 'github')
+    ).toBe('http://161.33.220.227/api/auth/github/callback');
+  });
+
+  it('prefers the incoming request origin for frontend redirects when only the scheme differs', () => {
+    expect(
+      buildFrontendRedirectUrl(request, 'https://161.33.220.227', '/dashboard')
+    ).toBe('http://161.33.220.227/dashboard');
+  });
+
+  it('keeps a separately hosted frontend origin intact', () => {
+    expect(
+      buildFrontendRedirectUrl(
+        {
+          protocol: 'http',
+          secure: false,
+          headers: {
+            host: 'localhost:3000'
+          }
+        },
+        'http://localhost:5173',
+        '/dashboard'
+      )
+    ).toBe('http://localhost:5173/dashboard');
+  });
+
+  it('does not force secure cookies for plain-http requests', () => {
+    expect(shouldUseSecureCookies(request, 'https://161.33.220.227')).toBe(false);
+  });
+
+  it('uses secure cookies when the forwarded protocol is https', () => {
+    expect(
+      shouldUseSecureCookies(
+        {
+          protocol: 'http',
+          secure: false,
+          headers: {
+            host: 'aegisai.example.com',
+            'x-forwarded-proto': 'https'
+          }
+        },
+        'https://aegisai.example.com'
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/97-runtime-auth-origin-cookie-scheme`
- 이슈: `#97`

## 🔎 주요 변경 사항

- 운영 요청의 실제 origin과 configured URL을 함께 고려해 provider callback URL과 frontend redirect URL을 계산하는 runtime auth URL helper를 추가했습니다.
- GitHub, GitLab auth guard가 요청별 callback URL을 사용하도록 구성해 HTTP로 운영 중인 배포에서도 OAuth callback이 잘못된 HTTPS origin으로 고정되지 않도록 수정했습니다.
- auth callback 이후 dashboard redirect가 현재 요청 스킴과 맞지 않아 연결이 끊기던 문제를 보정했습니다.
- session cookie를 `secure: 'auto'`로 전환하고, CSRF cookie도 실제 요청 스킴을 기준으로 secure 여부를 결정하도록 수정했습니다.
- HTTP 운영 환경과 HTTPS 운영 환경 모두에서 runtime origin/cookie scheme 판단이 유지되도록 auth runtime 회귀 테스트를 추가했습니다.
- 이번 PR은 현재 HTTP 운영 안정화를 위한 hotfix이며, 향후 도메인과 인증서를 붙여 HTTPS로 전환할 때도 충돌하지 않는 방향으로 정리했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?