### PR TITLE
Fix: deployed web same-origin API base URL fallback 수정

### DIFF
--- a/apps/api/src/auth/guards/github-auth.guard.ts
+++ b/apps/api/src/auth/guards/github-auth.guard.ts
@@ -11,6 +11,17 @@ export class GithubAuthGuard extends AuthGuard('github') {
     super();
   }
 
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const activated = await super.canActivate(context);
+    const request = context.switchToHttp().getRequest<RequestWithSessionUser>();
+
+    if (request.user) {
+      await super.logIn(request);
+    }
+
+    return Boolean(activated);
+  }
+
   getAuthenticateOptions(context: ExecutionContext): Record<string, string> {
     const request = context.switchToHttp().getRequest();
 
@@ -19,3 +30,8 @@ export class GithubAuthGuard extends AuthGuard('github') {
     };
   }
 }
+
+type RequestWithSessionUser = {
+  user?: unknown;
+  logIn: (user: unknown, callback: (error?: Error | null) => void) => void;
+};

--- a/apps/api/src/auth/guards/gitlab-auth.guard.ts
+++ b/apps/api/src/auth/guards/gitlab-auth.guard.ts
@@ -11,6 +11,17 @@ export class GitlabAuthGuard extends AuthGuard('gitlab') {
     super();
   }
 
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const activated = await super.canActivate(context);
+    const request = context.switchToHttp().getRequest<RequestWithSessionUser>();
+
+    if (request.user) {
+      await super.logIn(request);
+    }
+
+    return Boolean(activated);
+  }
+
   getAuthenticateOptions(context: ExecutionContext): Record<string, string> {
     const request = context.switchToHttp().getRequest();
 
@@ -19,3 +30,8 @@ export class GitlabAuthGuard extends AuthGuard('gitlab') {
     };
   }
 }
+
+type RequestWithSessionUser = {
+  user?: unknown;
+  logIn: (user: unknown, callback: (error?: Error | null) => void) => void;
+};

--- a/apps/api/test/auth/oauth-session-guards.e2e-spec.ts
+++ b/apps/api/test/auth/oauth-session-guards.e2e-spec.ts
@@ -1,0 +1,79 @@
+import type { ExecutionContext } from '@nestjs/common';
+
+import { ConfigService } from '../../src/config/config.service';
+import { GithubAuthGuard } from '../../src/auth/guards/github-auth.guard';
+import { GitlabAuthGuard } from '../../src/auth/guards/gitlab-auth.guard';
+
+type ParentAuthGuard = {
+  canActivate: (context: ExecutionContext) => Promise<boolean>;
+  logIn: (request: RequestWithLogin) => Promise<void>;
+};
+
+type RequestWithLogin = {
+  user?: { id: string };
+  logIn: (user: unknown, callback: (error?: Error | null) => void) => void;
+};
+
+describe('OAuth session guards', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['github', GithubAuthGuard],
+    ['gitlab', GitlabAuthGuard]
+  ])(
+    'logs the authenticated %s user into the session after callback authentication',
+    async (_provider, GuardClass) => {
+      const guard = new GuardClass(createConfigService()) as GithubAuthGuard | GitlabAuthGuard;
+      const request: RequestWithLogin = {
+        logIn: jest.fn((_user, callback) => callback())
+      };
+      const context = createExecutionContext(request);
+      const parentGuard = Object.getPrototypeOf(GuardClass.prototype) as ParentAuthGuard;
+
+      const canActivateSpy = jest
+        .spyOn(parentGuard, 'canActivate')
+        .mockImplementation(async (innerContext: ExecutionContext) => {
+          innerContext
+            .switchToHttp()
+            .getRequest<RequestWithLogin>().user = { id: 'user-1' };
+          return true;
+        });
+      const logInSpy = jest
+        .spyOn(parentGuard, 'logIn')
+        .mockImplementation(async (innerRequest: RequestWithLogin) => {
+          await new Promise<void>((resolve, reject) => {
+            innerRequest.logIn(innerRequest.user, (error?: Error | null) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+
+              resolve();
+            });
+          });
+        });
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+
+      expect(canActivateSpy).toHaveBeenCalledWith(context);
+      expect(logInSpy).toHaveBeenCalledWith(request);
+      expect(request.logIn).toHaveBeenCalledWith({ id: 'user-1' }, expect.any(Function));
+    }
+  );
+});
+
+function createConfigService(): ConfigService {
+  return {
+    get: jest.fn().mockReturnValue('http://localhost:3000')
+  } as unknown as ConfigService;
+}
+
+function createExecutionContext(request: RequestWithLogin): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: <T>() => request as T
+    })
+  } as ExecutionContext;
+}

--- a/deploy/oracle/deploy.sh
+++ b/deploy/oracle/deploy.sh
@@ -22,5 +22,6 @@ export IMAGE_TAG
 
 echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 docker compose -f docker-compose.app.yml pull
+docker compose -f docker-compose.app.yml run --rm --no-deps api sh -lc "corepack pnpm --filter @aegisai/api prisma:migrate:deploy"
 docker compose -f docker-compose.app.yml up -d
 docker image prune -f

--- a/test/github-actions/cd-workflow.test.mjs
+++ b/test/github-actions/cd-workflow.test.mjs
@@ -104,6 +104,7 @@ test('cd workflow and oracle deployment files describe the grafana cloud plus al
 
   assert.match(deployScript, /docker login ghcr\.io/);
   assert.match(deployScript, /docker compose -f docker-compose\.app\.yml pull/);
+  assert.match(deployScript, /prisma:migrate:deploy/);
   assert.match(deployScript, /docker compose -f docker-compose\.app\.yml up -d/);
   assert.doesNotMatch(deployScript, /--remove-orphans/);
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/97-auth-session-deploy-migrations`
- 이슈: `#97`

## 🔎 주요 변경 사항

- GitHub, GitLab OAuth callback guard가 인증된 provider user를 세션에 명시적으로 기록하도록 보강했습니다.
- callback 직후 `/api/auth/me`가 401로 떨어지던 production 문제를 재현하는 회귀 테스트를 추가했습니다.
- Oracle deploy script에 Prisma migration deploy 단계를 추가해 새 스키마가 필요한 배포에서 로그인/런타임이 깨지지 않도록 정리했습니다.
- CD workflow 회귀 테스트를 갱신해 deploy script가 migration 단계를 포함하는지 검증하도록 보강했습니다.
- 이번 PR은 HTTP 운영 중 남아 있던 OAuth session persistence 문제와 운영 DB migration 누락 문제를 함께 닫는 hotfix입니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
