### PR TITLE
Feat: report controller and download endpoints 구현

### DIFF
--- a/apps/api/src/report/report.controller.ts
+++ b/apps/api/src/report/report.controller.ts
@@ -1,0 +1,53 @@
+import type { AuthUser } from '@aegisai/shared';
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Res,
+  StreamableFile,
+  UseGuards
+} from '@nestjs/common';
+import type { Response } from 'express';
+
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SessionAuthGuard } from '../auth/guards/session-auth.guard';
+import { SkipTransform } from '../common/decorators/skip-transform.decorator';
+import { ReportService } from './report.service';
+
+@Controller('reports')
+@UseGuards(SessionAuthGuard)
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  @Post('scans/:scanId/pdf')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async requestReport(@CurrentUser() user: AuthUser, @Param('scanId') scanId: string) {
+    return this.reportService.requestReport({
+      userId: user.id,
+      scanId
+    });
+  }
+
+  @Get(':reportId')
+  async getReportDetail(@CurrentUser() user: AuthUser, @Param('reportId') reportId: string) {
+    return this.reportService.getReportDetail(user.id, reportId);
+  }
+
+  @Get(':reportId/download')
+  @SkipTransform()
+  async downloadReport(
+    @CurrentUser() user: AuthUser,
+    @Param('reportId') reportId: string,
+    @Res({ passthrough: true }) response: Response
+  ) {
+    const download = await this.reportService.getReportDownload(user.id, reportId);
+
+    response.setHeader('Content-Type', download.mimeType);
+    response.setHeader('Content-Disposition', `attachment; filename="${download.fileName}"`);
+
+    return new StreamableFile(download.buffer);
+  }
+}

--- a/apps/api/src/report/report.module.ts
+++ b/apps/api/src/report/report.module.ts
@@ -4,6 +4,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '../config/config.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { REPORT_QUEUE } from './report.constants';
+import { ReportController } from './report.controller';
 import { ReportExpiryTask } from './report-expiry.task';
 import { ReportProcessor } from './report.processor';
 import { ReportService } from './report.service';
@@ -34,6 +35,7 @@ const queueProviders =
 
 @Module({
   imports: [...queueImports, PrismaModule, ConfigModule],
+  controllers: [ReportController],
   providers: [
     ReportService,
     PdfGeneratorService,

--- a/apps/api/src/report/report.service.ts
+++ b/apps/api/src/report/report.service.ts
@@ -1,11 +1,14 @@
 import type { ReportDetail, ReportRequestResponse } from '@aegisai/shared';
 import {
   BadRequestException,
+  ConflictException,
+  GoneException,
   Injectable,
   NotFoundException,
   ServiceUnavailableException
 } from '@nestjs/common';
 import { ReportStatus, ScanStatus } from '@prisma/client';
+import path from 'node:path';
 
 import { PrismaService } from '../prisma/prisma.service';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -24,6 +27,12 @@ interface CreateGeneratingReportResult {
     status: ReportStatus;
   };
   reused: boolean;
+}
+
+interface ReportDownloadPayload {
+  fileName: string;
+  mimeType: 'application/pdf';
+  buffer: Buffer;
 }
 
 @Injectable()
@@ -142,17 +151,7 @@ export class ReportService {
   }
 
   async getReportDetail(userId: string, reportId: string): Promise<ReportDetail> {
-    const report = await this.prisma.report.findFirst({
-      where: {
-        id: reportId,
-        userId,
-        scan: {
-          connectedRepo: {
-            userId
-          }
-        }
-      }
-    });
+    const report = await this.findOwnedReport(userId, reportId);
 
     if (!report) {
       throw new NotFoundException({
@@ -170,6 +169,66 @@ export class ReportService {
       createdAt: report.createdAt.toISOString(),
       expiresAt: report.expiresAt?.toISOString() ?? null
     };
+  }
+
+  async getReportDownload(userId: string, reportId: string): Promise<ReportDownloadPayload> {
+    const report = await this.findOwnedReport(userId, reportId);
+
+    if (!report) {
+      throw new NotFoundException({
+        message: 'Report not found.',
+        errorCode: 'REPORT_NOT_FOUND'
+      });
+    }
+
+    if (report.status === ReportStatus.GENERATING) {
+      throw new ConflictException({
+        message: 'Report generation is still in progress.',
+        errorCode: 'REPORT_NOT_READY'
+      });
+    }
+
+    if (report.status === ReportStatus.FAILED) {
+      throw new ConflictException({
+        message: report.errorMessage ?? 'Report generation failed.',
+        errorCode: 'REPORT_FAILED'
+      });
+    }
+
+    if (report.status === ReportStatus.EXPIRED) {
+      throw new GoneException({
+        message: 'Report expired.',
+        errorCode: 'REPORT_EXPIRED'
+      });
+    }
+
+    if (await this.shouldExpireReport(report.expiresAt, report.filePath)) {
+      await this.expireReport(report.id);
+
+      throw new GoneException({
+        message: 'Report expired.',
+        errorCode: 'REPORT_EXPIRED'
+      });
+    }
+
+    try {
+      return {
+        fileName: path.basename(report.filePath!),
+        mimeType: 'application/pdf',
+        buffer: await this.storage.read(report.filePath!)
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        await this.expireReport(report.id);
+
+        throw new GoneException({
+          message: 'Report expired.',
+          errorCode: 'REPORT_EXPIRED'
+        });
+      }
+
+      throw error;
+    }
   }
 
   private toErrorMessage(error: unknown): string {
@@ -190,6 +249,20 @@ export class ReportService {
         }
       },
       orderBy: [{ createdAt: 'desc' }, { id: 'desc' }]
+    });
+  }
+
+  private async findOwnedReport(userId: string, reportId: string) {
+    return this.prisma.report.findFirst({
+      where: {
+        id: reportId,
+        userId,
+        scan: {
+          connectedRepo: {
+            userId
+          }
+        }
+      }
     });
   }
 
@@ -222,6 +295,13 @@ export class ReportService {
       : false;
 
     return !refreshedExpired && refreshedHasFile;
+  }
+
+  private async shouldExpireReport(expiresAt: Date | null, filePath: string | null) {
+    const isExpired = expiresAt !== null && expiresAt.getTime() <= Date.now();
+    const hasFile = filePath ? await this.storage.exists(filePath) : false;
+
+    return isExpired || !hasFile;
   }
 
   private async createGeneratingReport(
@@ -284,5 +364,18 @@ export class ReportService {
       'code' in error &&
       (error as { code?: string }).code === 'P2002'
     );
+  }
+
+  private async expireReport(reportId: string): Promise<void> {
+    await this.prisma.report.update({
+      where: {
+        id: reportId
+      },
+      data: {
+        status: ReportStatus.EXPIRED,
+        downloadUrl: null,
+        errorMessage: 'Report expired.'
+      }
+    });
   }
 }

--- a/apps/api/src/report/services/report-storage.service.ts
+++ b/apps/api/src/report/services/report-storage.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { access, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
 import path from 'node:path';
 
@@ -44,6 +44,10 @@ export class ReportStorageService {
     await rm(this.resolve(filePath), {
       force: true
     });
+  }
+
+  async read(filePath: string): Promise<Buffer> {
+    return readFile(this.resolve(filePath));
   }
 
   private getStorageDir(): string {

--- a/apps/api/test/report/report.e2e-spec.ts
+++ b/apps/api/test/report/report.e2e-spec.ts
@@ -1,0 +1,190 @@
+import type { AuthUser } from '@aegisai/shared';
+import { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+
+class MockSessionAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ user?: AuthUser }>();
+
+    request.user = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Aegis User',
+      avatarUrl: null,
+      connectedProviders: ['github']
+    };
+
+    return true;
+  }
+}
+
+describe('ReportController (e2e)', () => {
+  let app: INestApplication;
+  const reportService = {
+    requestReport: jest.fn(),
+    getReportDetail: jest.fn(),
+    getReportDownload: jest.fn()
+  };
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.PORT = '3000';
+    process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/aegisai';
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    process.env.SESSION_SECRET = 'test-session-secret-value';
+    process.env.CSRF_SECRET = 'test-csrf-secret-value';
+    process.env.GITHUB_CLIENT_ID = 'github-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'github-client-secret';
+    process.env.GITLAB_CLIENT_ID = 'gitlab-client-id';
+    process.env.GITLAB_CLIENT_SECRET = 'gitlab-client-secret';
+    process.env.APP_URL = 'http://localhost:3000';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+    process.env.SESSION_COOKIE_NAME = 'connect.sid';
+    process.env.CSRF_COOKIE_NAME = 'csrf_token';
+    process.env.COOKIE_DOMAIN = '';
+    process.env.TOKEN_ENCRYPTION_KEY =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    process.env.ANALYSIS_CLIENT_MODE = 'mock';
+    process.env.AI_SERVER_URL = 'http://localhost:8000';
+    process.env.USE_INTERNAL_AI = 'false';
+    process.env.INTERNAL_API_SECRET = '';
+    process.env.GITHUB_APP_WEBHOOK_SECRET = '';
+    process.env.GITLAB_WEBHOOK_SECRET = '';
+    process.env.REPORT_STORAGE_PATH = './tmp/reports';
+    process.env.REPORT_EXPIRY_HOURS = '24';
+
+    const [{ AppModule }, { configureApp }, { PrismaService }, { SessionAuthGuard }] =
+      await Promise.all([
+        import('../../src/app.module'),
+        import('../../src/bootstrap/configure-app'),
+        import('../../src/prisma/prisma.service'),
+        import('../../src/auth/guards/session-auth.guard')
+      ]);
+
+    let ReportService: object | null = null;
+
+    try {
+      ({ ReportService } = await import('../../src/report/report.service'));
+    } catch {
+      ReportService = null;
+    }
+
+    const builder = Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .overrideGuard(SessionAuthGuard)
+      .useClass(MockSessionAuthGuard);
+
+    if (ReportService) {
+      builder.overrideProvider(ReportService).useValue(reportService);
+    }
+
+    const moduleRef = await builder.compile();
+
+    app = moduleRef.createNestApplication();
+    await configureApp(app);
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('returns wrapped report request data from POST /api/reports/scans/:scanId/pdf', async () => {
+    reportService.requestReport.mockResolvedValue({
+      reportId: 'report-1',
+      status: 'GENERATING',
+      message: 'PDF report generation has started.'
+    });
+
+    await request(app.getHttpServer())
+      .post('/api/reports/scans/scan-1/pdf')
+      .expect(202)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            reportId: 'report-1',
+            status: 'GENERATING'
+          },
+          message: null
+        });
+      });
+
+    expect(reportService.requestReport).toHaveBeenCalledWith({
+      userId: 'user-1',
+      scanId: 'scan-1'
+    });
+  });
+
+  it('returns wrapped report detail from GET /api/reports/:reportId', async () => {
+    reportService.getReportDetail.mockResolvedValue({
+      id: 'report-1',
+      scanId: 'scan-1',
+      status: 'READY',
+      downloadUrl: '/api/reports/report-1/download',
+      errorMessage: null,
+      createdAt: '2026-03-31T00:00:00.000Z',
+      expiresAt: '2026-04-01T00:00:00.000Z'
+    });
+
+    await request(app.getHttpServer())
+      .get('/api/reports/report-1')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toMatchObject({
+          success: true,
+          data: {
+            id: 'report-1',
+            status: 'READY',
+            downloadUrl: '/api/reports/report-1/download'
+          },
+          message: null
+        });
+      });
+
+    expect(reportService.getReportDetail).toHaveBeenCalledWith('user-1', 'report-1');
+  });
+
+  it('returns a raw PDF stream from GET /api/reports/:reportId/download', async () => {
+    reportService.getReportDownload.mockResolvedValue({
+      fileName: 'aegisai-scan-report-scan-1-report-1.pdf',
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4\n')
+    });
+
+    const response = await request(app.getHttpServer())
+      .get('/api/reports/report-1/download')
+      .buffer()
+      .parse((res, callback) => {
+        const chunks: Buffer[] = [];
+
+        res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on('end', () => callback(null, Buffer.concat(chunks)));
+      })
+      .expect(200);
+
+    expect(response.headers['content-type']).toMatch(/application\/pdf/);
+    expect(response.headers['content-disposition']).toContain(
+      'attachment; filename="aegisai-scan-report-scan-1-report-1.pdf"'
+    );
+    expect(Buffer.isBuffer(response.body)).toBe(true);
+    expect(response.body.subarray(0, 5).toString('utf8')).toBe('%PDF-');
+    expect(reportService.getReportDownload).toHaveBeenCalledWith('user-1', 'report-1');
+  });
+});

--- a/apps/api/test/report/report.service.e2e-spec.ts
+++ b/apps/api/test/report/report.service.e2e-spec.ts
@@ -1,5 +1,7 @@
 import {
   BadRequestException,
+  ConflictException,
+  GoneException,
   NotFoundException,
   ServiceUnavailableException
 } from '@nestjs/common';
@@ -320,5 +322,154 @@ describe('ReportService', () => {
         errorMessage: 'Redis unavailable'
       }
     });
+  });
+
+  it('returns a downloadable PDF for an owned ready report with an existing file', async () => {
+    const prisma = {
+      report: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          scanId: 'scan-1',
+          userId: 'user-1',
+          status: 'READY',
+          filePath: './tmp/reports/report-1.pdf',
+          expiresAt: new Date(Date.now() + 60_000)
+        }),
+        update: jest.fn()
+      }
+    };
+    const storage = {
+      exists: jest.fn().mockResolvedValue(true),
+      read: jest.fn().mockResolvedValue(Buffer.from('%PDF-1.4\n'))
+    };
+
+    const service = new ReportService(prisma as never, { add: jest.fn() } as never, storage as never);
+
+    await expect(service.getReportDownload('user-1', 'report-1')).resolves.toEqual({
+      fileName: 'report-1.pdf',
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4\n')
+    });
+
+    expect(storage.exists).toHaveBeenCalledWith('./tmp/reports/report-1.pdf');
+    expect(storage.read).toHaveBeenCalledWith('./tmp/reports/report-1.pdf');
+    expect(prisma.report.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects report download while generation is still in progress', async () => {
+    const prisma = {
+      report: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          scanId: 'scan-1',
+          userId: 'user-1',
+          status: 'GENERATING',
+          filePath: null,
+          expiresAt: null
+        })
+      }
+    };
+
+    const service = new ReportService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { exists: jest.fn(), read: jest.fn() } as never
+    );
+
+    await expect(service.getReportDownload('user-1', 'report-1')).rejects.toBeInstanceOf(
+      ConflictException
+    );
+  });
+
+  it('expires a stale ready report and rejects download when the file is missing', async () => {
+    const prisma = {
+      report: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          scanId: 'scan-1',
+          userId: 'user-1',
+          status: 'READY',
+          filePath: './tmp/reports/report-1.pdf',
+          expiresAt: new Date(Date.now() + 60_000)
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          status: 'EXPIRED'
+        })
+      }
+    };
+    const storage = {
+      exists: jest.fn().mockResolvedValue(false),
+      read: jest.fn()
+    };
+
+    const service = new ReportService(prisma as never, { add: jest.fn() } as never, storage as never);
+
+    await expect(service.getReportDownload('user-1', 'report-1')).rejects.toBeInstanceOf(
+      GoneException
+    );
+
+    expect(prisma.report.update).toHaveBeenCalledWith({
+      where: {
+        id: 'report-1'
+      },
+      data: {
+        status: 'EXPIRED',
+        downloadUrl: null,
+        errorMessage: 'Report expired.'
+      }
+    });
+    expect(storage.read).not.toHaveBeenCalled();
+  });
+
+  it('rejects report download when generation failed', async () => {
+    const prisma = {
+      report: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          scanId: 'scan-1',
+          userId: 'user-1',
+          status: 'FAILED',
+          filePath: null,
+          expiresAt: null,
+          errorMessage: 'Renderer crashed'
+        })
+      }
+    };
+
+    const service = new ReportService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { exists: jest.fn(), read: jest.fn() } as never
+    );
+
+    await expect(service.getReportDownload('user-1', 'report-1')).rejects.toBeInstanceOf(
+      ConflictException
+    );
+  });
+
+  it('rejects report download when the report is already expired', async () => {
+    const prisma = {
+      report: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'report-1',
+          scanId: 'scan-1',
+          userId: 'user-1',
+          status: 'EXPIRED',
+          filePath: './tmp/reports/report-1.pdf',
+          expiresAt: new Date(Date.now() - 60_000)
+        })
+      }
+    };
+
+    const service = new ReportService(
+      prisma as never,
+      { add: jest.fn() } as never,
+      { exists: jest.fn(), read: jest.fn() } as never
+    );
+
+    await expect(service.getReportDownload('user-1', 'report-1')).rejects.toBeInstanceOf(
+      GoneException
+    );
   });
 });

--- a/docs/superpowers/plans/2026-03-31-report-controller-download-endpoints.md
+++ b/docs/superpowers/plans/2026-03-31-report-controller-download-endpoints.md
@@ -1,0 +1,8 @@
+# Report Controller And Download Endpoints Plan
+
+1. Add RED tests for report request, detail, and download behavior.
+2. Implement `ReportController` with protected request/detail/download routes.
+3. Extend `ReportService` with owned download resolution and state-aware error handling.
+4. Extend `ReportStorageService` with PDF read support.
+5. Sync shared report types and OpenAPI report schemas to current runtime behavior.
+6. Run targeted report tests, then full workspace verification.

--- a/docs/superpowers/specs/2026-03-31-report-controller-download-endpoints-design.md
+++ b/docs/superpowers/specs/2026-03-31-report-controller-download-endpoints-design.md
@@ -1,0 +1,56 @@
+# Report Controller And Download Endpoints Design
+
+## Goal
+
+Expose the existing report infrastructure as protected API endpoints for requesting report generation, checking report status, and downloading generated PDFs.
+
+## Scope
+
+- Add `ReportController` under `apps/api/src/report/`
+- Expose:
+  - `POST /api/reports/scans/:scanId/pdf`
+  - `GET /api/reports/:reportId`
+  - `GET /api/reports/:reportId/download`
+- Keep ownership checks inside `ReportService`
+- Support raw PDF download without response envelope
+- Align OpenAPI and shared report contracts with the implemented behavior
+
+## Design
+
+### Request Endpoint
+
+`POST /api/reports/scans/:scanId/pdf` delegates to the existing `ReportService.requestReport`.
+
+- authenticated only
+- accepted only for owned `DONE` scans
+- returns wrapped `GENERATING` or `READY` response
+
+### Status Endpoint
+
+`GET /api/reports/:reportId` delegates to `ReportService.getReportDetail`.
+
+- authenticated only
+- owned report only
+- returns wrapped report detail including `EXPIRED`
+
+### Download Endpoint
+
+`GET /api/reports/:reportId/download` delegates to a new `ReportService.getReportDownload`.
+
+- authenticated only
+- owned report only
+- `READY` returns raw `application/pdf`
+- `GENERATING` returns `409 REPORT_NOT_READY`
+- `FAILED` returns `409 REPORT_FAILED`
+- `EXPIRED` returns `410 REPORT_EXPIRED`
+- stale `READY` rows with missing files or past expiry are converted to `EXPIRED` before returning `410`
+
+## Storage Behavior
+
+`ReportStorageService` gains a `read(filePath)` helper so controller/service code can stream the generated PDF using the same storage abstraction used for write/delete.
+
+## Testing
+
+- service tests for download-ready, generating, failed, expired, and stale-file cases
+- controller e2e tests for request, detail, and raw download responses
+- full workspace lint, test, typecheck, build

--- a/packages/shared/src/types/report.ts
+++ b/packages/shared/src/types/report.ts
@@ -1,5 +1,13 @@
 export type ReportStatus = 'GENERATING' | 'READY' | 'FAILED' | 'EXPIRED';
 
+export interface RequestReportParams {
+  scanId: string;
+}
+
+export interface ReportParams {
+  reportId: string;
+}
+
 export interface ReportRequestResponse {
   reportId: string;
   status: 'GENERATING' | 'READY';

--- a/specs/001-aegisai-mvp-foundation/contracts/mvp-openapi.yaml
+++ b/specs/001-aegisai-mvp-foundation/contracts/mvp-openapi.yaml
@@ -323,6 +323,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /reports/{reportId}:
     get:
       summary: Get report status
@@ -356,6 +360,8 @@ paths:
                 format: binary
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '404':
           $ref: '#/components/responses/NotFound'
         '410':
@@ -627,10 +633,16 @@ components:
           type: string
         status:
           type: string
-          enum: [GENERATING, READY, FAILED]
+          enum: [GENERATING, READY, FAILED, EXPIRED]
         downloadUrl:
           type: [string, 'null']
-      required: [id, scanId, status]
+        errorMessage:
+          type: [string, 'null']
+        createdAt:
+          type: string
+        expiresAt:
+          type: [string, 'null']
+      required: [id, scanId, status, downloadUrl, errorMessage, createdAt, expiresAt]
     ApiEnvelopeAuthUser:
       type: object
       properties:
@@ -702,7 +714,11 @@ components:
           type: boolean
         data:
           $ref: '#/components/schemas/ReportDetail'
-      required: [success, data]
+        message:
+          type: [string, 'null']
+        timestamp:
+          type: string
+      required: [success, data, message, timestamp]
     ProviderRepoPage:
       type: object
       properties:
@@ -855,7 +871,7 @@ components:
           type: string
         status:
           type: string
-          enum: [GENERATING]
+          enum: [GENERATING, READY]
         message:
           type: string
       required: [reportId, status, message]
@@ -906,4 +922,8 @@ components:
           type: boolean
         data:
           $ref: '#/components/schemas/ReportRequestAccepted'
-      required: [success, data]
+        message:
+          type: [string, 'null']
+        timestamp:
+          type: string
+      required: [success, data, message, timestamp]


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/108-report-controller-download-endpoints`
- 이슈: `#108`

## 🔎 주요 변경 사항

- `apps/api/src/report/report.controller.ts`를 추가해 `POST /api/reports/scans/:scanId/pdf`, `GET /api/reports/:reportId`, `GET /api/reports/:reportId/download` 엔드포인트를 구현했습니다.
- `ReportService`에 owned report 기준 download resolution을 추가하고, `GENERATING`, `FAILED`, `EXPIRED`, stale `READY` 상태별 에러 처리를 정리했습니다.
- `ReportStorageService`에 PDF read helper를 추가해 report storage abstraction 안에서 다운로드 흐름을 처리하도록 구성했습니다.
- download 엔드포인트는 `@SkipTransform()`을 적용해 `application/pdf` raw response와 attachment header를 그대로 반환하도록 구성했습니다.
- shared report contract에 report path parameter 타입을 추가하고, OpenAPI report schema를 현재 구현과 응답 envelope에 맞게 동기화했습니다.
- report controller/service 회귀 테스트와 이슈 전용 설계 문서, 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
