### PR TITLE
Feat: dashboard summary and report entry UI 구현

### DIFF
--- a/apps/web/src/api/dashboard.test.ts
+++ b/apps/web/src/api/dashboard.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDashboardWorkspaceData } from "./dashboard";
+import { listConnectedRepos } from "./repos";
+import { listRepoScans } from "./scans";
+
+vi.mock("./repos", () => ({
+  listConnectedRepos: vi.fn(),
+}));
+
+vi.mock("./scans", () => ({
+  listRepoScans: vi.fn(),
+}));
+
+const mockedListConnectedRepos = vi.mocked(listConnectedRepos);
+const mockedListRepoScans = vi.mocked(listRepoScans);
+
+describe("dashboard api helper", () => {
+  beforeEach(() => {
+    mockedListConnectedRepos.mockReset();
+    mockedListRepoScans.mockReset();
+  });
+
+  it("aggregates connected repositories into a recent dashboard snapshot", async () => {
+    mockedListConnectedRepos.mockResolvedValue([
+      {
+        id: "repo-1",
+        provider: "github",
+        fullName: "acme/payments-service",
+        cloneUrl: "https://github.com/acme/payments-service.git",
+        defaultBranch: "main",
+        isPrivate: true,
+        lastScanAt: "2026-03-31T08:00:00.000Z",
+        lastScanStatus: "DONE",
+      },
+      {
+        id: "repo-2",
+        provider: "gitlab",
+        fullName: "ops/compliance-service",
+        cloneUrl: "https://gitlab.com/ops/compliance-service.git",
+        defaultBranch: "trunk",
+        isPrivate: true,
+        lastScanAt: "2026-03-31T07:30:00.000Z",
+        lastScanStatus: "RUNNING",
+      },
+    ]);
+
+    mockedListRepoScans.mockImplementation(async (repoId) => {
+      if (repoId === "repo-1") {
+        return {
+          items: [
+            {
+              id: "scan-1",
+              repoFullName: "acme/payments-service",
+              branch: "main",
+              commitSha: "abc1234",
+              status: "DONE",
+              language: "java",
+              totalFiles: 40,
+              totalLines: 8100,
+              summary: {
+                critical: 1,
+                high: 2,
+                medium: 1,
+                low: 0,
+                info: 0,
+              },
+              startedAt: "2026-03-31T08:00:00.000Z",
+              completedAt: "2026-03-31T08:06:00.000Z",
+              errorMessage: null,
+              createdAt: "2026-03-31T07:58:00.000Z",
+            },
+          ],
+          totalCount: 3,
+          page: 1,
+          totalPages: 1,
+        };
+      }
+
+      return {
+        items: [
+          {
+            id: "scan-2",
+            repoFullName: "ops/compliance-service",
+            branch: "release/2026",
+            commitSha: "def5678",
+            status: "RUNNING",
+            language: "java",
+            totalFiles: 12,
+            totalLines: 1900,
+            summary: {
+              critical: 0,
+              high: 1,
+              medium: 2,
+              low: 1,
+              info: 0,
+            },
+            startedAt: "2026-03-31T09:00:00.000Z",
+            completedAt: null,
+            errorMessage: null,
+            createdAt: "2026-03-31T08:55:00.000Z",
+          },
+        ],
+        totalCount: 4,
+        page: 1,
+        totalPages: 1,
+      };
+    });
+
+    const result = await getDashboardWorkspaceData();
+
+    expect(result.totalRepos).toBe(2);
+    expect(result.totalScans).toBe(7);
+    expect(result.openVulnerabilities).toEqual({
+      critical: 1,
+      high: 3,
+      medium: 3,
+      low: 1,
+      info: 0,
+    });
+    expect(result.recentScans.map((scan) => scan.id)).toEqual(["scan-2", "scan-1"]);
+    expect(result.completedScans.map((scan) => scan.id)).toEqual(["scan-1"]);
+    expect(result.severitySummary).toEqual({
+      critical: 1,
+      high: 3,
+      medium: 3,
+      low: 1,
+      info: 0,
+    });
+    expect(result.trend).toEqual([
+      {
+        date: "Mar 31",
+        critical: 1,
+        high: 2,
+        medium: 1,
+      },
+    ]);
+  });
+
+  it("keeps trend labels stable for users west of UTC", async () => {
+    const originalTimezone = process.env.TZ;
+    process.env.TZ = "America/New_York";
+
+    mockedListConnectedRepos.mockResolvedValue([
+      {
+        id: "repo-1",
+        provider: "github",
+        fullName: "acme/payments-service",
+        cloneUrl: "https://github.com/acme/payments-service.git",
+        defaultBranch: "main",
+        isPrivate: true,
+        lastScanAt: "2026-03-31T08:00:00.000Z",
+        lastScanStatus: "DONE",
+      },
+    ]);
+
+    mockedListRepoScans.mockResolvedValue({
+      items: [
+        {
+          id: "scan-1",
+          repoFullName: "acme/payments-service",
+          branch: "main",
+          commitSha: "abc1234",
+          status: "DONE",
+          language: "java",
+          totalFiles: 40,
+          totalLines: 8100,
+          summary: {
+            critical: 1,
+            high: 0,
+            medium: 0,
+            low: 0,
+            info: 0,
+          },
+          startedAt: "2026-03-31T08:00:00.000Z",
+          completedAt: "2026-03-31T08:06:00.000Z",
+          errorMessage: null,
+          createdAt: "2026-03-31T07:58:00.000Z",
+        },
+      ],
+      totalCount: 1,
+      page: 1,
+      totalPages: 1,
+    });
+
+    const result = await getDashboardWorkspaceData();
+
+    expect(result.trend[0]?.date).toBe("Mar 31");
+
+    process.env.TZ = originalTimezone;
+  });
+
+  it("marks the dashboard degraded when only part of the scan surface can be loaded", async () => {
+    mockedListConnectedRepos.mockResolvedValue([
+      {
+        id: "repo-1",
+        provider: "github",
+        fullName: "acme/payments-service",
+        cloneUrl: "https://github.com/acme/payments-service.git",
+        defaultBranch: "main",
+        isPrivate: true,
+        lastScanAt: "2026-03-31T08:00:00.000Z",
+        lastScanStatus: "DONE",
+      },
+      {
+        id: "repo-2",
+        provider: "gitlab",
+        fullName: "ops/compliance-service",
+        cloneUrl: "https://gitlab.com/ops/compliance-service.git",
+        defaultBranch: "trunk",
+        isPrivate: true,
+        lastScanAt: "2026-03-31T07:30:00.000Z",
+        lastScanStatus: "FAILED",
+      },
+    ]);
+
+    mockedListRepoScans
+      .mockResolvedValueOnce({
+        items: [],
+        totalCount: 1,
+        page: 1,
+        totalPages: 1,
+      })
+      .mockRejectedValueOnce(new Error("Provider archive unavailable."));
+
+    const result = await getDashboardWorkspaceData();
+
+    expect(result.degraded).toBe(true);
+    expect(result.totalScans).toBe(1);
+  });
+});

--- a/apps/web/src/api/dashboard.ts
+++ b/apps/web/src/api/dashboard.ts
@@ -1,0 +1,144 @@
+import type {
+  ConnectedRepoItem,
+  DashboardData,
+  ScanSeveritySummary,
+  ScanSummary,
+  TrendItem,
+} from "@aegisai/shared";
+
+import { listConnectedRepos } from "./repos";
+import { listRepoScans } from "./scans";
+
+const RECENT_SCANS_PER_REPO = 4;
+const DASHBOARD_RECENT_LIMIT = 8;
+const TREND_DAY_LIMIT = 4;
+
+const EMPTY_SUMMARY: ScanSeveritySummary = {
+  critical: 0,
+  high: 0,
+  medium: 0,
+  low: 0,
+  info: 0,
+};
+
+export interface DashboardWorkspaceData extends DashboardData {
+  connectedRepos: ConnectedRepoItem[];
+  completedScans: ScanSummary[];
+  severitySummary: ScanSeveritySummary;
+  degraded: boolean;
+}
+
+export async function getDashboardWorkspaceData(): Promise<DashboardWorkspaceData> {
+  const connectedRepos = await listConnectedRepos();
+
+  if (!connectedRepos.length) {
+    return {
+      connectedRepos: [],
+      completedScans: [],
+      degraded: false,
+      openVulnerabilities: EMPTY_SUMMARY,
+      recentScans: [],
+      severitySummary: EMPTY_SUMMARY,
+      totalRepos: 0,
+      totalScans: 0,
+      trend: [],
+    };
+  }
+
+  const scanPages = await Promise.allSettled(
+    connectedRepos.map((repo) => listRepoScans(repo.id, 1, RECENT_SCANS_PER_REPO))
+  );
+
+  const successfulPages = scanPages
+    .filter(isFulfilled)
+    .map((result) => result.value);
+
+  if (!successfulPages.length) {
+    const firstFailure = scanPages.find((result) => result.status === "rejected");
+    throw firstFailure?.reason ?? new Error("Dashboard data unavailable.");
+  }
+
+  const recentScans = successfulPages
+    .flatMap((page) => page.items)
+    .sort((left, right) => toTimestamp(right) - toTimestamp(left))
+    .slice(0, DASHBOARD_RECENT_LIMIT);
+
+  const completedScans = recentScans.filter((scan) => scan.status === "DONE");
+  const severitySummary = aggregateSeverity(recentScans);
+
+  return {
+    connectedRepos,
+    completedScans,
+    degraded: successfulPages.length !== scanPages.length,
+    openVulnerabilities: severitySummary,
+    recentScans,
+    severitySummary,
+    totalRepos: connectedRepos.length,
+    totalScans: successfulPages.reduce((total, page) => total + page.totalCount, 0),
+    trend: buildTrend(completedScans),
+  };
+}
+
+function aggregateSeverity(scans: ScanSummary[]): ScanSeveritySummary {
+  return scans.reduce<ScanSeveritySummary>(
+    (summary, scan) => ({
+      critical: summary.critical + scan.summary.critical,
+      high: summary.high + scan.summary.high,
+      medium: summary.medium + scan.summary.medium,
+      low: summary.low + scan.summary.low,
+      info: summary.info + scan.summary.info,
+    }),
+    { ...EMPTY_SUMMARY }
+  );
+}
+
+function buildTrend(scans: ScanSummary[]): TrendItem[] {
+  const grouped = new Map<string, TrendItem>();
+
+  scans.forEach((scan) => {
+    const key = toDateKey(scan);
+    const existing = grouped.get(key);
+
+    if (existing) {
+      existing.critical += scan.summary.critical;
+      existing.high += scan.summary.high;
+      existing.medium += scan.summary.medium;
+      return;
+    }
+
+    grouped.set(key, {
+      date: formatTrendDate(key),
+      critical: scan.summary.critical,
+      high: scan.summary.high,
+      medium: scan.summary.medium,
+    });
+  });
+
+  return [...grouped.entries()]
+    .sort((left, right) => right[0].localeCompare(left[0]))
+    .slice(0, TREND_DAY_LIMIT)
+    .reverse()
+    .map(([, item]) => item);
+}
+
+function toTimestamp(scan: ScanSummary) {
+  return new Date(scan.completedAt ?? scan.startedAt ?? scan.createdAt).getTime();
+}
+
+function toDateKey(scan: ScanSummary) {
+  return (scan.completedAt ?? scan.startedAt ?? scan.createdAt).slice(0, 10);
+}
+
+function formatTrendDate(key: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${key}T00:00:00.000Z`));
+}
+
+function isFulfilled<T>(
+  result: PromiseSettledResult<T>
+): result is PromiseFulfilledResult<T> {
+  return result.status === "fulfilled";
+}

--- a/apps/web/src/api/reports.ts
+++ b/apps/web/src/api/reports.ts
@@ -1,0 +1,30 @@
+import type {
+  ApiResponse,
+  ReportDetail,
+  ReportRequestResponse,
+} from "@aegisai/shared";
+
+import { apiClient, resolveApiBaseUrl, unwrapApiResponse } from "./client";
+
+export async function requestPdfReport(scanId: string): Promise<ReportRequestResponse> {
+  const response = await apiClient.post<ApiResponse<ReportRequestResponse>>(
+    `/reports/scans/${scanId}/pdf`
+  );
+
+  return unwrapApiResponse(response.data);
+}
+
+export async function getReportDetail(reportId: string): Promise<ReportDetail> {
+  const response = await apiClient.get<ApiResponse<ReportDetail>>(`/reports/${reportId}`);
+  return unwrapApiResponse(response.data);
+}
+
+export function getReportDownloadUrl(reportId: string): string {
+  const baseUrl = resolveApiBaseUrl().replace(/\/$/, "");
+
+  try {
+    return new URL(`reports/${reportId}/download`, `${baseUrl}/`).toString();
+  } catch {
+    return `${baseUrl}/reports/${reportId}/download`.replace(/(?<!:)\/{2,}/g, "/");
+  }
+}

--- a/apps/web/src/pages/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage.test.tsx
@@ -1,0 +1,323 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDashboardWorkspaceData } from "../api/dashboard";
+import { getReportDetail, requestPdfReport } from "../api/reports";
+import { createQueryClient } from "../query-client";
+import { DashboardPage } from "./DashboardPage";
+
+vi.mock("../api/dashboard", () => ({
+  getDashboardWorkspaceData: vi.fn(),
+}));
+
+vi.mock("../api/reports", () => ({
+  requestPdfReport: vi.fn(),
+  getReportDetail: vi.fn(),
+  getReportDownloadUrl: (reportId: string) => `/api/reports/${reportId}/download`,
+}));
+
+const mockedGetDashboardWorkspaceData = vi.mocked(getDashboardWorkspaceData);
+const mockedRequestPdfReport = vi.mocked(requestPdfReport);
+const mockedGetReportDetail = vi.mocked(getReportDetail);
+
+function renderDashboardPage() {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    mockedGetDashboardWorkspaceData.mockReset();
+    mockedRequestPdfReport.mockReset();
+    mockedGetReportDetail.mockReset();
+
+    mockedGetDashboardWorkspaceData.mockResolvedValue({
+      totalRepos: 2,
+      totalScans: 8,
+      openVulnerabilities: {
+        critical: 1,
+        high: 3,
+        medium: 2,
+        low: 1,
+        info: 0,
+      },
+      trend: [
+        {
+          date: "Mar 30",
+          critical: 0,
+          high: 1,
+          medium: 1,
+        },
+        {
+          date: "Mar 31",
+          critical: 1,
+          high: 2,
+          medium: 0,
+        },
+      ],
+      recentScans: [
+        {
+          id: "scan-1",
+          repoFullName: "acme/payments-service",
+          branch: "main",
+          commitSha: "abc1234",
+          status: "DONE",
+          language: "java",
+          totalFiles: 44,
+          totalLines: 8120,
+          summary: {
+            critical: 1,
+            high: 2,
+            medium: 0,
+            low: 1,
+            info: 0,
+          },
+          startedAt: "2026-03-31T08:00:00.000Z",
+          completedAt: "2026-03-31T08:06:00.000Z",
+          errorMessage: null,
+          createdAt: "2026-03-31T07:58:00.000Z",
+        },
+        {
+          id: "scan-2",
+          repoFullName: "ops/compliance-service",
+          branch: "release/2026",
+          commitSha: "def5678",
+          status: "RUNNING",
+          language: "java",
+          totalFiles: 18,
+          totalLines: 2200,
+          summary: {
+            critical: 0,
+            high: 1,
+            medium: 2,
+            low: 0,
+            info: 0,
+          },
+          startedAt: "2026-03-31T09:00:00.000Z",
+          completedAt: null,
+          errorMessage: null,
+          createdAt: "2026-03-31T08:58:00.000Z",
+        },
+      ],
+      severitySummary: {
+        critical: 1,
+        high: 3,
+        medium: 2,
+        low: 1,
+        info: 0,
+      },
+      completedScans: [
+        {
+          id: "scan-1",
+          repoFullName: "acme/payments-service",
+          branch: "main",
+          commitSha: "abc1234",
+          status: "DONE",
+          language: "java",
+          totalFiles: 44,
+          totalLines: 8120,
+          summary: {
+            critical: 1,
+            high: 2,
+            medium: 0,
+            low: 1,
+            info: 0,
+          },
+          startedAt: "2026-03-31T08:00:00.000Z",
+          completedAt: "2026-03-31T08:06:00.000Z",
+          errorMessage: null,
+          createdAt: "2026-03-31T07:58:00.000Z",
+        },
+      ],
+      connectedRepos: [
+        {
+          id: "repo-1",
+          provider: "github",
+          fullName: "acme/payments-service",
+          cloneUrl: "https://github.com/acme/payments-service.git",
+          defaultBranch: "main",
+          isPrivate: true,
+          lastScanAt: "2026-03-31T08:06:00.000Z",
+          lastScanStatus: "DONE",
+        },
+        {
+          id: "repo-2",
+          provider: "gitlab",
+          fullName: "ops/compliance-service",
+          cloneUrl: "https://gitlab.com/ops/compliance-service.git",
+          defaultBranch: "trunk",
+          isPrivate: true,
+          lastScanAt: "2026-03-31T09:00:00.000Z",
+          lastScanStatus: "RUNNING",
+        },
+      ],
+      degraded: false,
+    });
+
+    mockedRequestPdfReport.mockResolvedValue({
+      reportId: "report-1",
+      status: "GENERATING",
+      message: "PDF report generation has started.",
+    });
+
+    mockedGetReportDetail.mockResolvedValue({
+      id: "report-1",
+      scanId: "scan-1",
+      status: "READY",
+      downloadUrl: null,
+      errorMessage: null,
+      createdAt: "2026-03-31T08:07:00.000Z",
+      expiresAt: "2026-03-31T20:07:00.000Z",
+    });
+  });
+
+  it("renders the dashboard workspace and connects report entry to a completed scan", async () => {
+    const user = userEvent.setup();
+
+    renderDashboardPage();
+
+    expect(
+      screen.getByRole("heading", { name: /read the latest security posture/i })
+    ).toBeInTheDocument();
+
+    const summaryRegion = await screen.findByRole("region", { name: /summary snapshot/i });
+    expect(within(summaryRegion).getByText(/^Connected repos$/)).toBeInTheDocument();
+    expect(within(summaryRegion).getByText(/^Tracked scans$/)).toBeInTheDocument();
+
+    const reportRegion = screen.getByRole("region", { name: /report entry/i });
+    expect(await within(reportRegion).findByText("acme/payments-service")).toBeInTheDocument();
+
+    await user.click(
+      within(reportRegion).getByRole("button", { name: /generate pdf report/i })
+    );
+
+    await waitFor(() => {
+      expect(mockedRequestPdfReport).toHaveBeenCalledWith(
+        "scan-1",
+        expect.objectContaining({
+          client: expect.any(Object),
+        })
+      );
+    });
+
+    expect(await within(reportRegion).findByText(/generation has started/i)).toBeInTheDocument();
+    expect(await within(reportRegion).findByText("READY")).toBeInTheDocument();
+    expect(
+      within(reportRegion).getByRole("link", { name: /download pdf report/i })
+    ).toHaveAttribute("href", "/api/reports/report-1/download");
+  });
+
+  it("renders a degraded state when only part of the dashboard surface is available", async () => {
+    mockedGetDashboardWorkspaceData.mockResolvedValueOnce({
+      totalRepos: 1,
+      totalScans: 2,
+      openVulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      trend: [],
+      recentScans: [],
+      severitySummary: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      completedScans: [],
+      connectedRepos: [
+        {
+          id: "repo-1",
+          provider: "github",
+          fullName: "acme/payments-service",
+          cloneUrl: "https://github.com/acme/payments-service.git",
+          defaultBranch: "main",
+          isPrivate: true,
+          lastScanAt: null,
+          lastScanStatus: null,
+        },
+      ],
+      degraded: true,
+    });
+
+    renderDashboardPage();
+
+    expect(await screen.findByText(/dashboard is running in a degraded mode/i)).toBeInTheDocument();
+  });
+
+  it("keeps polling report detail after a transient status failure", async () => {
+    const user = userEvent.setup();
+
+    mockedGetReportDetail
+      .mockRejectedValueOnce(new Error("Temporary report status outage."))
+      .mockResolvedValue({
+        id: "report-1",
+        scanId: "scan-1",
+        status: "READY",
+        downloadUrl: null,
+        errorMessage: null,
+        createdAt: "2026-03-31T08:07:00.000Z",
+        expiresAt: "2026-03-31T20:07:00.000Z",
+      });
+
+    renderDashboardPage();
+
+    const reportRegion = await screen.findByRole("region", { name: /report entry/i });
+
+    await user.click(
+      within(reportRegion).getByRole("button", { name: /generate pdf report/i })
+    );
+
+    expect(await within(reportRegion).findByText(/report status unavailable/i)).toBeInTheDocument();
+    expect(
+      await within(reportRegion).findByRole("link", { name: /download pdf report/i }, { timeout: 5000 })
+    ).toHaveAttribute("href", "/api/reports/report-1/download");
+  });
+
+  it("renders an empty state when no repositories are connected yet", async () => {
+    mockedGetDashboardWorkspaceData.mockResolvedValueOnce({
+      totalRepos: 0,
+      totalScans: 0,
+      openVulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      trend: [],
+      recentScans: [],
+      severitySummary: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+      },
+      completedScans: [],
+      connectedRepos: [],
+      degraded: false,
+    });
+
+    renderDashboardPage();
+
+    expect(
+      await screen.findByText(/connect a repository before the dashboard can summarize activity/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /go to repository connections/i })).toHaveAttribute(
+      "href",
+      "/repos"
+    );
+  });
+});

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,19 +1,556 @@
-export function DashboardPage() {
-  return <PlaceholderPage title="Dashboard" description="Dashboard widgets arrive in later issues." />;
-}
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
-function PlaceholderPage({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
+import { getDashboardWorkspaceData } from "../api/dashboard";
+import {
+  getReportDetail,
+  getReportDownloadUrl,
+  requestPdfReport,
+} from "../api/reports";
+
+const ACTIVE_SCAN_STATUSES = new Set(["PENDING", "RUNNING"]);
+
+export function DashboardPage() {
+  const [selectedScanId, setSelectedScanId] = useState<string | null>(null);
+  const [reportIdsByScan, setReportIdsByScan] = useState<Record<string, string>>({});
+  const [reportMessage, setReportMessage] = useState<string | null>(null);
+
+  const dashboardQuery = useQuery({
+    queryKey: ["dashboard", "workspace"],
+    queryFn: getDashboardWorkspaceData,
+    refetchInterval: (query) =>
+      query.state.data?.recentScans.some((scan) => ACTIVE_SCAN_STATUSES.has(scan.status))
+        ? 5000
+        : false,
+  });
+
+  useEffect(() => {
+    const firstScanId = dashboardQuery.data?.recentScans[0]?.id ?? null;
+
+    if (!selectedScanId && firstScanId) {
+      setSelectedScanId(firstScanId);
+      return;
+    }
+
+    if (
+      selectedScanId &&
+      dashboardQuery.data &&
+      !dashboardQuery.data.recentScans.some((scan) => scan.id === selectedScanId)
+    ) {
+      setSelectedScanId(firstScanId);
+    }
+  }, [dashboardQuery.data, selectedScanId]);
+
+  const selectedScan =
+    dashboardQuery.data?.recentScans.find((scan) => scan.id === selectedScanId) ?? null;
+  const selectedReportId = selectedScan ? reportIdsByScan[selectedScan.id] ?? null : null;
+
+  const selectedReportQuery = useQuery({
+    queryKey: ["reports", "detail", selectedReportId],
+    queryFn: () => getReportDetail(selectedReportId!),
+    enabled: Boolean(selectedReportId),
+    refetchInterval: (query) => {
+      if (!selectedReportId) {
+        return false;
+      }
+
+      if (query.state.data?.status === "GENERATING") {
+        return 4000;
+      }
+
+      if (!query.state.data && query.state.error) {
+        return 4000;
+      }
+
+      return false;
+    },
+  });
+
+  const requestReportMutation = useMutation({
+    mutationFn: requestPdfReport,
+    onSuccess: (response, scanId) => {
+      setReportIdsByScan((current) => ({
+        ...current,
+        [scanId]: response.reportId,
+      }));
+      setReportMessage(response.message);
+    },
+  });
+
+  const severitySummary = dashboardQuery.data?.severitySummary ?? {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+
+  const selectedScanFindings = useMemo(() => {
+    if (!selectedScan) {
+      return 0;
+    }
+
+    return (
+      selectedScan.summary.critical +
+      selectedScan.summary.high +
+      selectedScan.summary.medium +
+      selectedScan.summary.low +
+      selectedScan.summary.info
+    );
+  }, [selectedScan]);
+
+  const reportActionLabel = getReportActionLabel({
+    isPending:
+      requestReportMutation.isPending && requestReportMutation.variables === selectedScan?.id,
+    reportStatus: selectedReportQuery.data?.status,
+  });
+
   return (
-    <section className="placeholder-card">
-      <p className="eyebrow">Foundation ready</p>
-      <h2>{title}</h2>
-      <p>{description}</p>
+    <section className="dashboard-page">
+      <header className="dashboard-hero">
+        <div className="dashboard-hero-copy">
+          <p className="eyebrow">Operational overview</p>
+          <h2>Read the latest security posture before you open the next report</h2>
+          <div className="dashboard-hero-accent">
+            <p>
+              AegisAI summarizes the most recent repository reviews, highlights where
+              severity is clustering, and keeps PDF export one click away for completed scans.
+            </p>
+          </div>
+        </div>
+
+        <div className="dashboard-hero-panel" aria-hidden="true">
+          <span className="dashboard-hero-panel-kicker">Recent signal, not vanity totals.</span>
+        </div>
+      </header>
+
+      {dashboardQuery.error ? (
+        <div className="dashboard-inline-alert" role="alert">
+          <strong>Dashboard summary unavailable</strong>
+          <p>{getErrorMessage(dashboardQuery.error)}</p>
+        </div>
+      ) : dashboardQuery.isLoading ? (
+        <section className="dashboard-section">
+          <p className="dashboard-state-copy">Loading recent scan posture...</p>
+        </section>
+      ) : !dashboardQuery.data?.connectedRepos.length ? (
+        <section className="dashboard-section dashboard-empty-state">
+          <strong>Connect a repository before the dashboard can summarize activity.</strong>
+          <p>
+            Once a source is linked, AegisAI will surface recent scans, severity movement,
+            and PDF report entry from this workspace.
+          </p>
+          <div className="dashboard-empty-actions">
+            <Link className="dashboard-secondary-link" to="/repos">
+              Go to repository connections
+            </Link>
+          </div>
+        </section>
+      ) : (
+        <div className="dashboard-layout">
+          <div className="dashboard-main">
+            {dashboardQuery.data.degraded ? (
+              <div className="dashboard-inline-alert dashboard-inline-alert-neutral" role="status">
+                <strong>Dashboard is running in a degraded mode.</strong>
+                <p>
+                  One or more repository histories could not be refreshed. The snapshot below
+                  still reflects the scan data that was available.
+                </p>
+              </div>
+            ) : null}
+
+            <section className="dashboard-section" aria-label="Summary snapshot">
+              <div className="dashboard-section-heading">
+                <p className="eyebrow">Summary snapshot</p>
+                <h3>Recent signal across connected repositories</h3>
+              </div>
+
+              <div className="dashboard-metric-grid">
+                <article className="dashboard-metric-tile">
+                  <span>Connected repos</span>
+                  <strong>{dashboardQuery.data.totalRepos}</strong>
+                  <p>Sources with active session access.</p>
+                </article>
+                <article className="dashboard-metric-tile">
+                  <span>Tracked scans</span>
+                  <strong>{dashboardQuery.data.totalScans}</strong>
+                  <p>Known scan records across connected repos.</p>
+                </article>
+                <article className="dashboard-metric-tile">
+                  <span>Recent findings</span>
+                  <strong>{getTotalFindingsFromSummary(dashboardQuery.data.openVulnerabilities)}</strong>
+                  <p>Severity volume inside the current dashboard window.</p>
+                </article>
+                <article className="dashboard-metric-tile">
+                  <span>Report-ready scans</span>
+                  <strong>{dashboardQuery.data.completedScans.length}</strong>
+                  <p>Completed reviews that can open PDF export.</p>
+                </article>
+              </div>
+
+              <div className="dashboard-severity-band">
+                {Object.entries(severitySummary).map(([severity, count]) => (
+                  <div
+                    key={severity}
+                    className={`dashboard-severity-tile is-${severity}`}
+                  >
+                    <span>{capitalize(severity)}</span>
+                    <strong>{count}</strong>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="dashboard-section" aria-label="Severity trend">
+              <div className="dashboard-section-heading">
+                <p className="eyebrow">Trend</p>
+                <h3>Where critical and high findings were surfacing most recently</h3>
+              </div>
+
+              {dashboardQuery.data.trend.length ? (
+                <div className="dashboard-trend-grid">
+                  {dashboardQuery.data.trend.map((item) => (
+                    <article key={item.date} className="dashboard-trend-card">
+                      <strong>{item.date}</strong>
+                      <div className="dashboard-trend-stack">
+                        <span>
+                          Critical <b>{item.critical}</b>
+                        </span>
+                        <span>
+                          High <b>{item.high}</b>
+                        </span>
+                        <span>
+                          Medium <b>{item.medium}</b>
+                        </span>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <p className="dashboard-state-copy">
+                  Trend tiles appear once completed scans are available in the recent window.
+                </p>
+              )}
+            </section>
+
+            <section className="dashboard-section" aria-label="Recent scans">
+              <div className="dashboard-section-heading">
+                <p className="eyebrow">Recent scans</p>
+                <h3>Choose the scan that should anchor the next report</h3>
+              </div>
+
+              {dashboardQuery.data.recentScans.length ? (
+                <div className="dashboard-scan-list">
+                  {dashboardQuery.data.recentScans.map((scan) => (
+                    <button
+                      key={scan.id}
+                      className={`dashboard-scan-card${
+                        scan.id === selectedScanId ? " is-selected" : ""
+                      }`}
+                      onClick={() => {
+                        setSelectedScanId(scan.id);
+                        setReportMessage(null);
+                      }}
+                      type="button"
+                      aria-pressed={scan.id === selectedScanId}
+                    >
+                      <div className="dashboard-scan-header">
+                        <strong>{scan.repoFullName}</strong>
+                        <span className={`scan-status-pill is-${scan.status.toLowerCase()}`}>
+                          {formatStatus(scan.status)}
+                        </span>
+                      </div>
+                      <p>{scan.branch}</p>
+                      <div className="dashboard-scan-meta">
+                        <span>Findings {getTotalFindings(scan)}</span>
+                        <span>Files {scan.totalFiles ?? "??"}</span>
+                        <span>
+                          {scan.status === "DONE"
+                            ? "Report ready"
+                            : "Report opens after completion"}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className="dashboard-empty-state">
+                  <strong>No recent scans are available yet.</strong>
+                  <p>Queue the first repository review to populate dashboard reporting.</p>
+                  <div className="dashboard-empty-actions">
+                    <Link className="dashboard-secondary-link" to="/scan">
+                      Open scan workspace
+                    </Link>
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
+
+          <aside className="dashboard-aside">
+            <section className="dashboard-aside-card" aria-label="Report entry">
+              <p className="eyebrow">Report entry</p>
+              <h3>Turn the selected scan into a downloadable briefing</h3>
+
+              {!selectedScan ? (
+                <p className="dashboard-state-copy">
+                  Choose a recent scan to open report generation controls.
+                </p>
+              ) : (
+                <>
+                  <div className="dashboard-report-header">
+                    <strong>{selectedScan.repoFullName}</strong>
+                    <span className={`scan-status-pill is-${selectedScan.status.toLowerCase()}`}>
+                      {formatStatus(selectedScan.status)}
+                    </span>
+                  </div>
+
+                  <dl className="dashboard-detail-grid">
+                    <div>
+                      <dt>Branch</dt>
+                      <dd>{selectedScan.branch}</dd>
+                    </div>
+                    <div>
+                      <dt>Findings</dt>
+                      <dd>{selectedScanFindings}</dd>
+                    </div>
+                    <div>
+                      <dt>Commit</dt>
+                      <dd>{selectedScan.commitSha ?? "Pending SHA"}</dd>
+                    </div>
+                    <div>
+                      <dt>Finished</dt>
+                      <dd>{formatTimestamp(selectedScan.completedAt ?? selectedScan.createdAt)}</dd>
+                    </div>
+                  </dl>
+
+                  {selectedScan.status !== "DONE" ? (
+                    <div className="dashboard-inline-alert dashboard-inline-alert-neutral" role="status">
+                      <strong>PDF export opens after a completed scan.</strong>
+                      <p>
+                        Keep this scan selected to follow progress, or move to the scan workspace
+                        for deeper status tracking.
+                      </p>
+                    </div>
+                  ) : (
+                    <>
+                      {requestReportMutation.error ? (
+                        <div className="dashboard-inline-alert" role="alert">
+                          <strong>Report request failed</strong>
+                          <p>{getErrorMessage(requestReportMutation.error)}</p>
+                        </div>
+                      ) : null}
+
+                      {reportMessage ? (
+                        <p className="dashboard-success-note" role="status">
+                          {reportMessage}
+                        </p>
+                      ) : null}
+
+                      {selectedReportId && selectedReportQuery.error ? (
+                        <div className="dashboard-inline-alert" role="alert">
+                          <strong>Report status unavailable</strong>
+                          <p>{getErrorMessage(selectedReportQuery.error)}</p>
+                        </div>
+                      ) : null}
+
+                      <div className="dashboard-report-status-card">
+                        <div className="dashboard-report-status-header">
+                          <span>PDF status</span>
+                          <strong>
+                            {selectedReportQuery.data?.status ??
+                              (selectedReportId ? "Checking..." : "Not requested")}
+                          </strong>
+                        </div>
+
+                        <p>
+                          {getReportNarrative(
+                            selectedScan.status,
+                            selectedReportQuery.data?.status ?? null
+                          )}
+                        </p>
+
+                        {selectedReportQuery.data?.expiresAt ? (
+                          <p className="dashboard-report-expiry">
+                            Expires {formatTimestamp(selectedReportQuery.data.expiresAt)}
+                          </p>
+                        ) : null}
+
+                        {selectedReportQuery.data?.errorMessage ? (
+                          <p className="dashboard-report-expiry">
+                            {selectedReportQuery.data.errorMessage}
+                          </p>
+                        ) : null}
+                      </div>
+
+                      <div className="dashboard-report-actions">
+                        <button
+                          className="dashboard-primary-action"
+                          disabled={
+                            requestReportMutation.isPending ||
+                            selectedScan.status !== "DONE"
+                          }
+                          onClick={() => {
+                            setReportMessage(null);
+                            requestReportMutation.mutate(selectedScan.id);
+                          }}
+                          type="button"
+                        >
+                          {reportActionLabel}
+                        </button>
+
+                        {selectedReportId && selectedReportQuery.data?.status === "READY" ? (
+                          <a
+                            className="dashboard-secondary-link dashboard-secondary-link-strong"
+                            href={getReportDownloadUrl(selectedReportId)}
+                          >
+                            Download PDF report
+                          </a>
+                        ) : null}
+
+                        {selectedScan.status === "DONE" ? (
+                          <Link className="dashboard-secondary-link" to={`/scan/${selectedScan.id}/review`}>
+                            Open vulnerability review
+                          </Link>
+                        ) : (
+                          <Link className="dashboard-secondary-link" to="/scan">
+                            Open scan workspace
+                          </Link>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </>
+              )}
+            </section>
+
+            <section className="dashboard-aside-card" aria-label="Report protocol">
+              <p className="eyebrow">Report protocol</p>
+              <h3>Keep the exported brief aligned with repository state</h3>
+              <ul className="dashboard-trust-list">
+                <li>PDF export only opens after a completed repository review.</li>
+                <li>Each request reuses an active report when one is already generating or ready.</li>
+                <li>Expired reports are regenerated from the current persisted scan snapshot.</li>
+              </ul>
+            </section>
+          </aside>
+        </div>
+      )}
     </section>
   );
+}
+
+function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatStatus(status: string) {
+  return status.charAt(0) + status.slice(1).toLowerCase();
+}
+
+function formatTimestamp(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function getTotalFindings(scan: {
+  summary: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+    info: number;
+  };
+}) {
+  return (
+    scan.summary.critical +
+    scan.summary.high +
+    scan.summary.medium +
+    scan.summary.low +
+    scan.summary.info
+  );
+}
+
+function getTotalFindingsFromSummary(summary: {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  info: number;
+}) {
+  return summary.critical + summary.high + summary.medium + summary.low + summary.info;
+}
+
+function getReportNarrative(
+  scanStatus: string,
+  reportStatus: "GENERATING" | "READY" | "FAILED" | "EXPIRED" | null
+) {
+  if (scanStatus !== "DONE") {
+    return "A scan must complete before AegisAI can open report generation.";
+  }
+
+  switch (reportStatus) {
+    case "GENERATING":
+      return "AegisAI is composing the PDF brief and will refresh this status automatically.";
+    case "READY":
+      return "The latest PDF brief is ready to download from the selected scan.";
+    case "FAILED":
+      return "The last PDF generation attempt failed. Request a fresh export to try again.";
+    case "EXPIRED":
+      return "The previous PDF expired. Generate a new copy from the stored scan snapshot.";
+    default:
+      return "Request a PDF brief for this completed scan when you are ready to share results.";
+  }
+}
+
+function getReportActionLabel({
+  isPending,
+  reportStatus,
+}: {
+  isPending: boolean;
+  reportStatus: "GENERATING" | "READY" | "FAILED" | "EXPIRED" | undefined;
+}) {
+  if (isPending) {
+    return "Preparing PDF...";
+  }
+
+  switch (reportStatus) {
+    case "GENERATING":
+      return "Refresh report status";
+    case "READY":
+      return "Reuse current PDF";
+    case "FAILED":
+    case "EXPIRED":
+      return "Generate fresh PDF";
+    default:
+      return "Generate PDF report";
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  if (
+    error &&
+    typeof error === "object" &&
+    "response" in error &&
+    error.response &&
+    typeof error.response === "object" &&
+    "data" in error.response &&
+    error.response.data &&
+    typeof error.response.data === "object" &&
+    "message" in error.response.data &&
+    typeof error.response.data.message === "string"
+  ) {
+    return error.response.data.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "An unexpected error occurred.";
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2023,6 +2023,394 @@ button {
   cursor: not-allowed;
 }
 
+.dashboard-page {
+  display: grid;
+  gap: 32px;
+}
+
+.dashboard-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.dashboard-hero-copy {
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-hero-copy h2,
+.dashboard-section-heading h3,
+.dashboard-aside-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.04em;
+  line-height: 1.04;
+  color: var(--ink-strong);
+}
+
+.dashboard-hero-copy h2 {
+  font-size: clamp(2.9rem, 5vw, 5.2rem);
+}
+
+.dashboard-hero-accent {
+  max-width: 44rem;
+  padding-left: 22px;
+  border-left: 4px solid var(--trust-blue);
+}
+
+.dashboard-hero-accent p,
+.dashboard-inline-alert p,
+.dashboard-state-copy,
+.dashboard-empty-state p,
+.dashboard-metric-tile p,
+.dashboard-report-status-card p,
+.dashboard-trust-list,
+.dashboard-scan-card p,
+.dashboard-report-expiry {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.7;
+}
+
+.dashboard-hero-panel,
+.dashboard-section,
+.dashboard-aside-card {
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(122, 89, 8, 0.06);
+  box-shadow: 0 18px 40px rgba(27, 28, 25, 0.06);
+}
+
+.dashboard-hero-panel {
+  min-height: 220px;
+  padding: 28px;
+  display: flex;
+  align-items: end;
+  justify-content: end;
+  background:
+    linear-gradient(180deg, rgba(251, 249, 244, 0.12), rgba(251, 249, 244, 0.88)),
+    radial-gradient(circle at top left, rgba(64, 94, 146, 0.24), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(181, 141, 61, 0.18), transparent 28%),
+    var(--surface-low);
+}
+
+.dashboard-hero-panel-kicker {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--trust-blue);
+  font-size: 1.24rem;
+}
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(340px, 0.75fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.dashboard-main,
+.dashboard-aside {
+  display: grid;
+  gap: 24px;
+}
+
+.dashboard-section,
+.dashboard-aside-card {
+  padding: 24px;
+}
+
+.dashboard-section-heading {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.dashboard-metric-grid,
+.dashboard-trend-grid,
+.dashboard-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dashboard-metric-tile,
+.dashboard-trend-card,
+.dashboard-report-status-card {
+  padding: 18px;
+  border-radius: 16px;
+  background: rgba(245, 243, 238, 0.82);
+}
+
+.dashboard-metric-tile {
+  display: grid;
+  gap: 8px;
+}
+
+.dashboard-metric-tile span,
+.dashboard-report-status-header span,
+.dashboard-detail-grid dt,
+.dashboard-severity-tile span,
+.dashboard-trend-card strong,
+.dashboard-scan-meta span {
+  color: var(--ink-faint);
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dashboard-metric-tile strong {
+  color: var(--ink-strong);
+  font-size: 2rem;
+}
+
+.dashboard-severity-band {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.dashboard-severity-tile {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(245, 243, 238, 0.82);
+}
+
+.dashboard-severity-tile strong {
+  color: var(--ink-strong);
+  font-size: 1rem;
+}
+
+.dashboard-severity-tile.is-critical {
+  background: rgba(255, 218, 214, 0.88);
+}
+
+.dashboard-severity-tile.is-high {
+  background: rgba(255, 234, 201, 0.9);
+}
+
+.dashboard-severity-tile.is-medium {
+  background: rgba(245, 243, 238, 0.92);
+}
+
+.dashboard-severity-tile.is-low,
+.dashboard-severity-tile.is-info {
+  background: rgba(213, 224, 247, 0.26);
+}
+
+.dashboard-trend-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dashboard-trend-card {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-trend-card strong {
+  color: var(--ink-strong);
+  font-size: 0.82rem;
+}
+
+.dashboard-trend-stack {
+  display: grid;
+  gap: 8px;
+}
+
+.dashboard-trend-stack span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink-muted);
+  font-size: 0.86rem;
+}
+
+.dashboard-trend-stack b {
+  color: var(--ink-strong);
+}
+
+.dashboard-scan-list {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-scan-card {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  padding: 18px;
+  border: 1px solid rgba(210, 197, 178, 0.6);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.7);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background 160ms ease;
+}
+
+.dashboard-scan-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(64, 94, 146, 0.26);
+  box-shadow: 0 18px 36px rgba(27, 28, 25, 0.06);
+}
+
+.dashboard-scan-card.is-selected {
+  border-color: rgba(64, 94, 146, 0.28);
+  background: linear-gradient(180deg, rgba(213, 224, 247, 0.22), rgba(255, 255, 255, 0.92));
+}
+
+.dashboard-scan-header,
+.dashboard-report-header,
+.dashboard-report-status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dashboard-scan-header strong,
+.dashboard-report-header strong,
+.dashboard-aside-card h3 {
+  font-family: var(--font-display);
+  letter-spacing: -0.03em;
+}
+
+.dashboard-scan-header strong,
+.dashboard-report-header strong {
+  font-size: 1.45rem;
+}
+
+.dashboard-scan-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.dashboard-detail-grid {
+  margin: 18px 0;
+}
+
+.dashboard-detail-grid dd {
+  margin: 6px 0 0;
+  color: var(--ink-strong);
+}
+
+.dashboard-report-status-card {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.dashboard-report-status-header strong {
+  color: var(--ink-strong);
+  font-size: 1rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.dashboard-report-expiry {
+  font-size: 0.86rem;
+}
+
+.dashboard-report-actions,
+.dashboard-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.dashboard-primary-action,
+.dashboard-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.85rem;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0 18px;
+  font: inherit;
+  text-decoration: none;
+}
+
+.dashboard-primary-action {
+  border: 0;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+  box-shadow: 0 18px 36px rgba(122, 89, 8, 0.18);
+}
+
+.dashboard-primary-action:disabled {
+  opacity: 0.55;
+  cursor: progress;
+  box-shadow: none;
+}
+
+.dashboard-secondary-link {
+  border: 1px solid rgba(122, 89, 8, 0.18);
+  background: transparent;
+  color: var(--brass-deep);
+}
+
+.dashboard-secondary-link-strong {
+  background: rgba(213, 224, 247, 0.28);
+  border-color: rgba(64, 94, 146, 0.18);
+  color: #425067;
+}
+
+.dashboard-inline-alert {
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(186, 26, 26, 0.12);
+  color: var(--danger-ink);
+}
+
+.dashboard-inline-alert strong,
+.dashboard-empty-state strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.dashboard-inline-alert-neutral {
+  background: rgba(213, 224, 247, 0.28);
+  border: 1px solid rgba(64, 94, 146, 0.14);
+  color: #425067;
+}
+
+.dashboard-success-note {
+  margin: 16px 0 0;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(213, 224, 247, 0.36);
+  color: #425067;
+}
+
+.dashboard-empty-state {
+  padding: 22px;
+  border-radius: 16px;
+  background: rgba(245, 243, 238, 0.78);
+}
+
+.dashboard-trust-list {
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+}
+
 @media (max-width: 900px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -2090,10 +2478,15 @@ button {
   .repos-hero,
   .repos-layout,
   .repos-toolbar,
+  .dashboard-hero,
+  .dashboard-layout,
   .scan-hero,
   .scan-layout,
   .review-hero,
   .review-layout,
+  .dashboard-metric-grid,
+  .dashboard-trend-grid,
+  .dashboard-detail-grid,
   .scan-form-grid,
   .scan-form-footer,
   .scan-detail-grid,
@@ -2107,11 +2500,14 @@ button {
 
   .scan-severity-list,
   .scan-severity-matrix,
+  .dashboard-severity-band,
   .scan-repo-selector,
   .review-severity-band {
     grid-template-columns: 1fr;
   }
 
+  .dashboard-report-actions,
+  .dashboard-empty-actions,
   .review-feedback-actions,
   .review-empty-actions,
   .review-pagination,

--- a/docs/superpowers/plans/2026-03-31-dashboard-summary-report-entry-ui.md
+++ b/docs/superpowers/plans/2026-03-31-dashboard-summary-report-entry-ui.md
@@ -1,0 +1,33 @@
+# Dashboard Summary And Report Entry UI Plan
+
+## Goal
+
+Ship `/dashboard` as the first real User Story 3 surface by composing existing repo, scan, and
+report APIs into a Stitch-aligned protected workspace.
+
+## Steps
+
+1. Add frontend report API helpers for request, detail, and download URL handling.
+2. Add a dashboard aggregation helper that composes connected repositories and recent repo scan
+   histories into a recent snapshot.
+3. Replace the dashboard placeholder page with a real workspace UI:
+   - hero
+   - summary snapshot
+   - severity trend
+   - recent scans list
+   - selected report entry panel
+4. Add dashboard-specific styles while preserving the existing protected workspace tone.
+5. Add regression coverage for:
+   - dashboard aggregation
+   - dashboard rendering
+   - report request/download entry flow
+6. Run frontend verification and then workspace-wide verification.
+
+## Files
+
+- `apps/web/src/api/dashboard.ts`
+- `apps/web/src/api/reports.ts`
+- `apps/web/src/pages/DashboardPage.tsx`
+- `apps/web/src/pages/DashboardPage.test.tsx`
+- `apps/web/src/api/dashboard.test.ts`
+- `apps/web/src/styles.css`

--- a/docs/superpowers/specs/2026-03-31-dashboard-summary-report-entry-ui-design.md
+++ b/docs/superpowers/specs/2026-03-31-dashboard-summary-report-entry-ui-design.md
@@ -1,0 +1,75 @@
+# Dashboard Summary And Report Entry UI Design
+
+## Scope
+
+Implement the protected `/dashboard` workspace for MVP User Story 3 using the existing Stitch
+protected workspace direction as the visual baseline. The page should summarize recent scan signal,
+show a light trend view, and let users request or download PDF reports from completed scans without
+introducing a new backend dashboard module.
+
+## Design Direction
+
+- Preserve the trust-first editorial security tone already established in the protected Stitch
+  screens.
+- Reuse the same surface system, hero rhythm, warm neutrals, and restrained blue/brass accents from
+  repository, scan, and review pages.
+- Avoid introducing a new dashboard-only visual language. The page should feel like the next room in
+  the same workspace.
+
+## Data Strategy
+
+- Use existing APIs instead of waiting for a dedicated dashboard endpoint.
+- Aggregate dashboard data client-side from:
+  - connected repositories
+  - recent scan history per connected repository
+  - report request/detail endpoints for report entry
+- Treat the dashboard as a recent operational snapshot, not an all-time analytics surface.
+
+## Information Architecture
+
+### Hero
+
+- Editorial dashboard headline that frames the page as an operational readout.
+- Supporting copy clarifies that the view is based on recent scan activity and report readiness.
+
+### Summary Snapshot
+
+- Show connected repository count.
+- Show tracked scan count from loaded repository scan histories.
+- Show recent finding volume from the aggregated severity summary.
+- Show how many recent scans are report-ready.
+
+### Trend
+
+- Render a compact date-grouped trend view using recent completed scans.
+- Focus on critical/high/medium counts rather than decorative charting.
+
+### Recent Scans
+
+- Present recent scans as selectable cards.
+- Keep the selected scan as the anchor for the report entry panel.
+- Surface status, branch, finding count, and report readiness at card level.
+
+### Report Entry
+
+- Only allow report entry actions for completed scans.
+- Support request -> generating -> ready -> download within the same panel.
+- Keep vulnerability review as a sibling CTA for completed scans.
+
+## State Model
+
+- `loading`: full dashboard snapshot is being assembled
+- `error`: no usable dashboard data could be loaded
+- `empty`: no connected repositories
+- `degraded`: partial scan history is available but one or more repository histories failed
+- `ready`: dashboard snapshot and recent scans are available
+- `report generating`: selected completed scan has an active report request
+- `report ready`: selected completed scan has a downloadable PDF
+- `report failed/expired`: allow a fresh report request from the same panel
+
+## Testing Focus
+
+- Client-side aggregation should sort recent scans correctly and preserve degraded state.
+- Dashboard page should render summary/trend/recent scan sections.
+- Report request should attach to the selected completed scan and expose download entry once ready.
+- Empty and degraded states should remain explicit and actionable.


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/110-dashboard-report-entry-ui`
- 이슈: `#110`

## 🔎 주요 변경 사항

- Stitch protected dashboard baseline을 기준으로 `/dashboard` 페이지를 실제 summary and report entry workspace로 구현했습니다.
- connected repositories와 recent scans를 집계해 severity snapshot, trend, recent scan summary를 한 화면에서 볼 수 있도록 구성했습니다.
- completed scan 기준 report request CTA, report status polling, download entry를 dashboard 흐름에 연결했습니다.
- partial fetch failure가 있어도 usable data가 남아 있으면 degraded dashboard로 계속 렌더되도록 정리했습니다.
- trend label의 UTC date drift와 transient report detail failure 이후 polling이 멈추는 문제를 함께 수정했습니다.
- dashboard/report API helper, page 회귀 테스트, 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.
- Stitch 산출물을 기준으로 구현했고, 기능 연결과 반응형 보정에 필요한 최소 수정만 적용했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a comprehensive dashboard page displaying connected repositories, recent scans, and aggregated vulnerability findings with severity trends
  * Added PDF report generation and download functionality for scans with real-time status tracking
  * Added visual handling for degraded dashboard states and empty repository scenarios

* **Tests**
  * Added comprehensive test coverage for dashboard data aggregation, rendering, and report workflows

* **Documentation**
  * Added design specification and implementation plan for the dashboard UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->