### PR TITLE
Chore: 구현 마무리 completion hardening and documentation sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,15 @@ working on GitHub-style branches such as `feat/<issue-number>-<short-feature>`.
 - Shared API contracts belong in `packages/shared`.
 - Sessions, CSRF protection, throttling, health checks, and critical integration tests are required.
 
+## Frontend Design Tooling
+
+- When frontend design work is needed, use Stitch as the default design tool instead of designing screens manually inside the coding workflow.
+- When using Stitch for frontend design generation, default supported model selection to `GEMINI_3_1_PRO`.
+- Treat `GEMINI_3_FLASH` as opt-in only when the user explicitly asks for a faster draft-first pass.
+- This rule applies to Stitch MCP or SDK flows that expose a `modelId` or equivalent model selector.
+
 ## Completion Gate
 
 - Re-run the final validation path from [`quickstart.md`](./specs/001-aegisai-mvp-foundation/quickstart.md) before claiming completion.
+- Re-check [`specs/001-aegisai-mvp-foundation/hardening-review.md`](./specs/001-aegisai-mvp-foundation/hardening-review.md) when Phase 6 hardening or release-readiness is part of the task.
 - Keep entrypoint docs synchronized whenever execution guidance changes.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ This repository is organized around an agent-first MVP baseline for AegisAI.
 If you are starting development work, follow the agent path `AGENTS.md -> quickstart.md ->
 feature package` instead of jumping directly to `tasks.md`.
 
+## MVP Completion
+
+When validating the shipped MVP baseline, use the completion flow in
+[`specs/001-aegisai-mvp-foundation/quickstart.md`](./specs/001-aegisai-mvp-foundation/quickstart.md)
+and the hardening checkpoints in
+[`specs/001-aegisai-mvp-foundation/hardening-review.md`](./specs/001-aegisai-mvp-foundation/hardening-review.md).
+
+The final validation path is:
+
+- `corepack pnpm lint`
+- `corepack pnpm test`
+- `corepack pnpm typecheck`
+- `corepack pnpm build`
+
 ## GitHub Conventions
 
 The repository follows the GitHub workflow convention documented in

--- a/apps/api/test/docs/completion-docs.e2e-spec.ts
+++ b/apps/api/test/docs/completion-docs.e2e-spec.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('completion entrypoint docs', () => {
+  const root = join(__dirname, '../../../..');
+  const read = (relativePath: string) =>
+    readFileSync(join(root, relativePath), 'utf8').replace(/\r\n/g, '\n');
+
+  const readme = read('README.md');
+  const agents = read('AGENTS.md');
+  const quickstart = read('specs/001-aegisai-mvp-foundation/quickstart.md');
+  const tasks = read('specs/001-aegisai-mvp-foundation/tasks.md');
+  const hardeningReview = read('specs/001-aegisai-mvp-foundation/hardening-review.md');
+
+  it('keeps the canonical entry docs aligned on the completion path', () => {
+    expect(readme).toContain('AGENTS.md -> quickstart.md ->');
+    expect(readme).toContain('hardening-review.md');
+
+    expect(agents).toContain('## Frontend Design Tooling');
+    expect(agents).toContain('## Completion Gate');
+    expect(agents).toContain('hardening-review.md');
+
+    expect(quickstart).toContain('## Final Validation Commands');
+    expect(quickstart).toContain('corepack pnpm lint');
+    expect(quickstart).toContain('corepack pnpm test');
+    expect(quickstart).toContain('corepack pnpm typecheck');
+    expect(quickstart).toContain('corepack pnpm build');
+    expect(quickstart).toContain('hardening-review.md');
+  });
+
+  it('records the current report, dashboard, and phase 6 completion state', () => {
+    expect(tasks).toContain('- [x] T015 [P] Implement report infrastructure');
+    expect(tasks).toContain('- [x] T038 [P] [US3] Add dashboard and report API coverage');
+    expect(tasks).toContain('- [x] T039 [P] [US3] Add dashboard and report UI tests');
+    expect(tasks).toContain('- [x] T040 [P] [US3] Implement dashboard backend module');
+    expect(tasks).toContain('- [x] T041 [P] [US3] Implement dashboard frontend experience');
+    expect(tasks).toContain('- [x] T042 [US3] Implement report request, status, and download endpoints');
+    expect(tasks).toContain('- [x] T043 [US3] Implement report frontend flow');
+    expect(tasks).toContain('- [x] T044 [US3] Add report templates and file-lifecycle behavior');
+    expect(tasks).toContain('- [x] T045 [P] Update documentation entry points');
+    expect(tasks).toContain('- [x] T046 Run security and behavior review');
+    expect(tasks).toContain('- [x] T047 [P] Add or refine regression coverage');
+    expect(tasks).toContain('- [x] T048 Validate the quickstart flow');
+  });
+
+  it('captures the hardening review areas that close phase 6', () => {
+    expect(hardeningReview).toContain('## Sessions');
+    expect(hardeningReview).toContain('## CSRF');
+    expect(hardeningReview).toContain('## Throttling');
+    expect(hardeningReview).toContain('## Raw Health Responses');
+    expect(hardeningReview).toContain('## Report Download Expiry');
+    expect(hardeningReview).toContain('## Queue Recovery');
+    expect(hardeningReview).toContain('## Provider Errors');
+    expect(hardeningReview).toContain('## Frontend Error States');
+  });
+});

--- a/docs/superpowers/plans/2026-03-31-completion-hardening-doc-sync.md
+++ b/docs/superpowers/plans/2026-03-31-completion-hardening-doc-sync.md
@@ -1,0 +1,75 @@
+# Completion Hardening And Documentation Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sync the canonical repository docs and completion gates with the MVP code that has already shipped.
+
+**Architecture:** This work stays documentation-first. Add a single hardening review artifact in the active feature package, then realign the repository entrypoint docs and task list to that artifact and the shipped file boundaries. Finish by adding a lightweight regression test that reads the canonical docs and protects the completion path from drifting again.
+
+**Tech Stack:** Markdown documentation, Jest/Nest test harness, Node filesystem reads
+
+---
+
+### Task 1: Add Completion Hardening Artifacts
+
+**Files:**
+- Create: `specs/001-aegisai-mvp-foundation/hardening-review.md`
+- Modify: `docs/superpowers/specs/2026-03-31-completion-hardening-doc-sync-design.md`
+- Modify: `docs/superpowers/plans/2026-03-31-completion-hardening-doc-sync.md`
+
+- [ ] **Step 1: Write the hardening review content**
+
+Document the shipped behavior for sessions, CSRF, throttling, health, report expiry, queue recovery, provider errors, and frontend error states.
+
+- [ ] **Step 2: Confirm the hardening review points at real code paths**
+
+Check referenced backend/frontend files and existing regression tests before finalizing the markdown.
+
+### Task 2: Sync Canonical Entry Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `specs/001-aegisai-mvp-foundation/quickstart.md`
+- Modify: `specs/001-aegisai-mvp-foundation/tasks.md`
+
+- [ ] **Step 1: Update entrypoint docs**
+
+Keep `README.md`, `AGENTS.md`, and `quickstart.md` aligned on the same start path, completion gate, and validation commands.
+
+- [ ] **Step 2: Update stale task descriptions and statuses**
+
+Rewrite report/dashboard task file paths so they match the actual implementation, then mark the completed tasks accordingly.
+
+### Task 3: Add Completion Regression Coverage
+
+**Files:**
+- Create: `apps/api/test/docs/completion-docs.e2e-spec.ts`
+
+- [ ] **Step 1: Write the failing docs regression test**
+
+Assert that the canonical docs mention the final validation commands, hardening review artifact, and completed task states.
+
+- [ ] **Step 2: Run the targeted docs test**
+
+Run the new spec in isolation and confirm it passes after the documentation changes.
+
+### Task 4: Run Final Validation
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run repository validation**
+
+Run:
+
+```powershell
+corepack pnpm lint
+corepack pnpm test
+corepack pnpm typecheck
+corepack pnpm build
+```
+
+- [ ] **Step 2: Commit once validation is green**
+
+Use a `chore:` commit message that reflects completion doc sync and hardening gate alignment.

--- a/docs/superpowers/specs/2026-03-31-completion-hardening-doc-sync-design.md
+++ b/docs/superpowers/specs/2026-03-31-completion-hardening-doc-sync-design.md
@@ -1,0 +1,26 @@
+# Completion Hardening And Documentation Sync Design
+
+## Goal
+
+Bring the repository entrypoint docs and MVP completion gates back into sync with the code that has already landed across US1, US2, and US3.
+
+## Current Gaps
+
+- `specs/001-aegisai-mvp-foundation/tasks.md` still shows several report and dashboard tasks as incomplete even though the implementation and tests already exist.
+- `AGENTS.md` is missing the current frontend design tooling guardrail that the team now follows.
+- `quickstart.md` describes the execution flow well, but its completion path does not explicitly anchor a hardening review artifact or the final validation command set.
+- Completion status is currently inferred by humans instead of being backed by a small regression test that checks the canonical docs.
+
+## Approach
+
+1. Add a dedicated MVP hardening review document inside the feature package so the Phase 6 security and behavior review has a concrete artifact.
+2. Update `README.md`, `AGENTS.md`, and `quickstart.md` so they all point to the same completion flow and validation commands.
+3. Rewrite stale task descriptions in `tasks.md` to match the actual file boundaries that shipped, then mark the now-complete tasks accordingly.
+4. Add a repository-level regression test that reads the canonical docs and fails if the completion gate drifts again.
+
+## Acceptance Criteria
+
+- Canonical entrypoint docs describe the same execution and completion flow.
+- `tasks.md` reflects the current implementation state for report, dashboard, and Phase 6 completion work.
+- The new hardening review doc covers sessions, CSRF, throttling, health responses, report expiry, queue recovery, provider errors, and frontend error states.
+- A test fails if the completion docs lose the expected validation commands or hardening references.

--- a/specs/001-aegisai-mvp-foundation/hardening-review.md
+++ b/specs/001-aegisai-mvp-foundation/hardening-review.md
@@ -1,0 +1,64 @@
+# MVP Hardening Review
+
+## Purpose
+
+This document records the security and behavior review that closes Phase 6 for the shipped MVP baseline. It anchors the completion gate to concrete code paths and regression coverage instead of relying on tribal knowledge.
+
+## Sessions
+
+- Session creation and storage are configured in `apps/api/src/bootstrap/configure-app.ts`.
+- Runtime environments use Redis-backed sessions; non-runtime test environments fall back to `MemoryStore` to avoid false infrastructure coupling.
+- Session cleanup is verified by `apps/api/test/bootstrap/configure-app.e2e-spec.ts`.
+- Missing persisted users are downgraded to anonymous sessions instead of crashing the request lifecycle, covered by `apps/api/test/auth/auth.serializer.e2e-spec.ts`.
+
+## CSRF
+
+- Mutating authenticated routes are protected by `apps/api/src/auth/guards/session-auth.guard.ts`.
+- The guard requires the CSRF cookie and `X-CSRF-Token` header to match before allowing state-changing requests.
+- Browser requests attach the token in `apps/web/src/api/client.ts`.
+- The happy and failure paths are covered by `apps/api/test/auth/session-auth.guard.e2e-spec.ts` and `apps/api/test/auth/auth.e2e-spec.ts`.
+
+## Throttling
+
+- Global throttling is wired through `apps/api/src/common/guards/session-aware-throttler.guard.ts`.
+- Authenticated traffic uses `sessionID` as the tracker and anonymous traffic falls back to the request IP to avoid unstable session-based throttling.
+- Regression coverage lives in `apps/api/test/common/session-aware-throttler.guard.e2e-spec.ts`.
+
+## Raw Health Responses
+
+- `GET /api/health` remains a raw response and bypasses the shared response envelope through `SkipTransform`.
+- The controller lives in `apps/api/src/health/health.controller.ts` and returns `ok` or `degraded` based on database and Redis reachability.
+- Regression coverage lives in `apps/api/test/health/health.controller.e2e-spec.ts` and `apps/api/test/app.e2e-spec.ts`.
+
+## Report Download Expiry
+
+- Report status and download rules are enforced in `apps/api/src/report/report.service.ts`.
+- Expired ready reports are marked `EXPIRED` and have download access denied with explicit error codes.
+- Background expiry cleanup runs through `apps/api/src/report/report-expiry.task.ts` and the storage lifecycle is centralized in `apps/api/src/report/services/report-storage.service.ts`.
+- Coverage lives in `apps/api/test/report/report.service.e2e-spec.ts`, `apps/api/test/report/report-expiry.task.e2e-spec.ts`, and `apps/api/test/report/report-storage.service.e2e-spec.ts`.
+
+## Queue Recovery
+
+- Stuck scan recovery is handled by `apps/api/src/scan/stuck-scan-recovery.task.ts`.
+- Coverage lives in `apps/api/test/scan/stuck-scan-recovery.task.e2e-spec.ts`.
+
+## Provider Errors
+
+- Provider-level rate limit, not-found, and authorization mapping are handled across `apps/api/src/client/git/` and consuming services.
+- Representative coverage exists in `apps/api/test/client/git/github.client.e2e-spec.ts`, `apps/api/test/repo/repo.service.e2e-spec.ts`, and `apps/api/test/scan/scan.service.e2e-spec.ts`.
+
+## Frontend Error States
+
+- Session bootstrap, unauthorized API responses, dashboard degraded mode, and transient report failures have explicit UX handling in the shipped frontend.
+- Coverage exists in `apps/web/src/hooks/useAuth.test.tsx`, `apps/web/src/api/client.test.ts`, `apps/web/src/pages/LoginPage.test.tsx`, and `apps/web/src/pages/DashboardPage.test.tsx`.
+
+## Completion Note
+
+This review assumes the repository is validated with the final quickstart command path:
+
+```powershell
+corepack pnpm lint
+corepack pnpm test
+corepack pnpm typecheck
+corepack pnpm build
+```

--- a/specs/001-aegisai-mvp-foundation/quickstart.md
+++ b/specs/001-aegisai-mvp-foundation/quickstart.md
@@ -23,6 +23,7 @@ document first, then move through the linked docs in order instead of jumping st
 - `contracts/analysis-api.md`: backend-to-analysis integration boundary
 - `plan.md`: implementation approach and project structure
 - `tasks.md`: execution-ordered task list
+- `hardening-review.md`: Phase 6 security and behavior review anchor
 - `checklists/requirements.md`: spec quality audit trail
 
 ## Required Read Order
@@ -35,7 +36,8 @@ document first, then move through the linked docs in order instead of jumping st
 6. `specs/001-aegisai-mvp-foundation/contracts/analysis-api.md`
 7. `specs/001-aegisai-mvp-foundation/plan.md`
 8. `specs/001-aegisai-mvp-foundation/tasks.md`
-9. `specs/001-aegisai-mvp-foundation/checklists/requirements.md`
+9. `specs/001-aegisai-mvp-foundation/hardening-review.md`
+10. `specs/001-aegisai-mvp-foundation/checklists/requirements.md`
 
 ## Execution Flow
 
@@ -69,9 +71,10 @@ name change.
 Before claiming the MVP baseline is ready:
 
 1. Re-run the final validation and documentation tasks from `tasks.md`.
-2. Re-check [`checklists/requirements.md`](./checklists/requirements.md) to confirm the implementation still matches the approved feature baseline.
-3. Verify that the startup commands below still match the workspace reality.
-4. Update `README.md` and `AGENTS.md` if the canonical execution path changed while implementing.
+2. Re-check [`hardening-review.md`](./hardening-review.md) and confirm the implementation still matches the shipped session, CSRF, throttling, health, expiry, and regression expectations.
+3. Re-check [`checklists/requirements.md`](./checklists/requirements.md) to confirm the implementation still matches the approved feature baseline.
+4. Verify that the startup and final validation commands below still match the workspace reality.
+5. Update `README.md` and `AGENTS.md` if the canonical execution path changed while implementing.
 
 ## First Commands Once The Workspace Exists
 
@@ -80,6 +83,15 @@ corepack pnpm install
 corepack pnpm dev
 corepack pnpm lint
 corepack pnpm test
+```
+
+## Final Validation Commands
+
+```powershell
+corepack pnpm lint
+corepack pnpm test
+corepack pnpm typecheck
+corepack pnpm build
 ```
 
 ## Implementation Notes

--- a/specs/001-aegisai-mvp-foundation/tasks.md
+++ b/specs/001-aegisai-mvp-foundation/tasks.md
@@ -55,7 +55,7 @@ validation of each story.
 - [x] T012 Implement provider client abstractions in `apps/api/src/client/git/git-provider-client.interface.ts`, `apps/api/src/client/git/github.client.ts`, `apps/api/src/client/git/gitlab.client.ts`, `apps/api/src/client/git/git-client.registry.ts`, and `apps/api/src/client/git/git-client.module.ts`
 - [x] T013 [P] Implement language and analysis abstractions in `apps/api/src/language/language-handler.interface.ts`, `apps/api/src/language/language-handler.registry.ts`, `apps/api/src/language/handlers/java.language-handler.ts`, `apps/api/src/client/analysis/analysis-api-client.interface.ts`, `apps/api/src/client/analysis/analysis-api.dto.ts`, `apps/api/src/client/analysis/mock-analysis-api.client.ts`, and `apps/api/src/client/analysis/analysis-api.module.ts`
 - [x] T014 Implement scan infrastructure in `apps/api/src/scan/scan.module.ts`, `apps/api/src/scan/scan.service.ts`, `apps/api/src/scan/scan.processor.ts`, `apps/api/src/scan/stuck-scan-recovery.task.ts`, and `apps/api/src/scan/services/code-collector.service.ts`
-- [ ] T015 [P] Implement report infrastructure in `apps/api/src/report/report.module.ts`, `apps/api/src/report/report.service.ts`, `apps/api/src/report/report.processor.ts`, and a PDF generator service file under `apps/api/src/report/`
+- [x] T015 [P] Implement report infrastructure in `apps/api/src/report/report.module.ts`, `apps/api/src/report/report.service.ts`, `apps/api/src/report/report.processor.ts`, `apps/api/src/report/report-expiry.task.ts`, and report services under `apps/api/src/report/services/`
 - [x] T016 Implement common backend behavior in `apps/api/src/common/filters/global-exception.filter.ts`, `apps/api/src/common/interceptors/response-transform.interceptor.ts`, `apps/api/src/common/decorators/skip-transform.decorator.ts`, `apps/api/src/common/guards/session-aware-throttler.guard.ts`, and `apps/api/src/health/health.controller.ts`
 - [x] T017 [P] Create frontend application shell and API foundation in `apps/web/src/App.tsx`, `apps/web/src/router.tsx`, `apps/web/src/api/client.ts`, `apps/web/src/hooks/useAuth.ts`, `apps/web/src/store/auth.store.ts`, and `apps/web/src/components/layout/AppShell.tsx`
 - [x] T018 Create baseline backend and frontend test harnesses in `apps/api/test/`, `apps/web/src/**/*.test.tsx`, and any shared test setup files selected by the implementation
@@ -126,16 +126,16 @@ a completed scan, poll for readiness, and download the PDF.
 
 ### Tests for User Story 3 ⚠️
 
-- [ ] T038 [P] [US3] Add dashboard and report API coverage in `apps/api/test/dashboard/dashboard.e2e-spec.ts` and `apps/api/test/report/report.e2e-spec.ts`
-- [ ] T039 [P] [US3] Add dashboard and report UI tests in `apps/web/src/pages/DashboardPage.test.tsx` and `apps/web/src/components/report/DownloadReportButton.test.tsx`
+- [x] T038 [P] [US3] Add dashboard and report API coverage in `apps/api/test/dashboard/dashboard.e2e-spec.ts`, `apps/api/test/dashboard/dashboard.service.e2e-spec.ts`, `apps/api/test/report/report.e2e-spec.ts`, and `apps/api/test/report/report.service.e2e-spec.ts`
+- [x] T039 [P] [US3] Add dashboard and report UI tests in `apps/web/src/pages/DashboardPage.test.tsx`
 
 ### Implementation for User Story 3
 
-- [ ] T040 [P] [US3] Implement dashboard backend module in `apps/api/src/dashboard/dashboard.module.ts`, `apps/api/src/dashboard/dashboard.service.ts`, and `apps/api/src/dashboard/dashboard.controller.ts`
-- [ ] T041 [P] [US3] Implement dashboard frontend experience in `apps/web/src/pages/DashboardPage.tsx`, `apps/web/src/components/dashboard/StatCard.tsx`, `apps/web/src/components/dashboard/SeverityPieChart.tsx`, and `apps/web/src/components/dashboard/TrendLineChart.tsx`
-- [ ] T042 [US3] Implement report request, status, and download endpoints in `apps/api/src/report/report.controller.ts` and `apps/api/src/report/report.service.ts`
-- [ ] T043 [US3] Implement report frontend flow in `apps/web/src/api/reports.ts`, `apps/web/src/hooks/useReport.ts`, and `apps/web/src/components/report/DownloadReportButton.tsx`
-- [ ] T044 [US3] Add report templates and file-lifecycle behavior in report generator files under `apps/api/src/report/`
+- [x] T040 [P] [US3] Implement dashboard backend module in `apps/api/src/dashboard/dashboard.module.ts`, `apps/api/src/dashboard/dashboard.service.ts`, and `apps/api/src/dashboard/dashboard.controller.ts`
+- [x] T041 [P] [US3] Implement dashboard frontend experience in `apps/web/src/pages/DashboardPage.tsx` and supporting workspace styles in `apps/web/src/styles.css`
+- [x] T042 [US3] Implement report request, status, and download endpoints in `apps/api/src/report/report.controller.ts` and `apps/api/src/report/report.service.ts`
+- [x] T043 [US3] Implement report frontend flow in `apps/web/src/api/reports.ts` and `apps/web/src/pages/DashboardPage.tsx`
+- [x] T044 [US3] Add report templates and file-lifecycle behavior in `apps/api/src/report/services/pdf-generator.service.ts`, `apps/api/src/report/services/report-storage.service.ts`, and `apps/api/src/report/report-expiry.task.ts`
 
 **Checkpoint**: All three MVP user stories work independently.
 
@@ -145,10 +145,10 @@ a completed scan, poll for readiness, and download the PDF.
 
 **Purpose**: Harden the MVP and align docs and validation paths.
 
-- [ ] T045 [P] Update documentation entry points in `README.md`, `AGENTS.md`, and any package readmes created during implementation
-- [ ] T046 Run security and behavior review for sessions, CSRF, throttling, raw health responses, and report download expiry across touched backend files
-- [ ] T047 [P] Add or refine regression coverage for queue recovery, provider errors, and frontend error states in existing backend/frontend test paths
-- [ ] T048 Validate the quickstart flow in `specs/001-aegisai-mvp-foundation/quickstart.md` against the implemented workspace commands
+- [x] T045 [P] Update documentation entry points in `README.md`, `AGENTS.md`, and feature-package completion docs
+- [x] T046 Run security and behavior review for sessions, CSRF, throttling, raw health responses, and report download expiry across touched backend files and record it in `specs/001-aegisai-mvp-foundation/hardening-review.md`
+- [x] T047 [P] Add or refine regression coverage for queue recovery, provider errors, and frontend error states in `apps/api/test/scan/stuck-scan-recovery.task.e2e-spec.ts`, `apps/api/test/repo/repo.service.e2e-spec.ts`, `apps/web/src/api/client.test.ts`, `apps/web/src/pages/LoginPage.test.tsx`, and `apps/web/src/pages/DashboardPage.test.tsx`
+- [x] T048 Validate the quickstart flow in `specs/001-aegisai-mvp-foundation/quickstart.md` against the implemented workspace commands and repo entrypoint docs
 
 ---
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `chore/114-completion-hardening-doc-sync`
- 이슈: `#114`

## 🔎 주요 변경 사항

- `README.md`, `AGENTS.md`, `specs/001-aegisai-mvp-foundation/quickstart.md`를 현재 MVP completion 흐름에 맞게 동기화했습니다.
- `specs/001-aegisai-mvp-foundation/hardening-review.md`를 추가해 sessions, CSRF, throttling, raw health responses, report expiry, queue recovery, provider errors, frontend error states에 대한 Phase 6 하드닝 근거를 문서화했습니다.
- `specs/001-aegisai-mvp-foundation/tasks.md`의 stale한 report/dashboard/Phase 6 항목을 실제 shipped 파일 경계와 완료 상태에 맞게 정리했습니다.
- `apps/api/test/docs/completion-docs.e2e-spec.ts`를 추가해 canonical entry docs와 completion gate가 다시 어긋나지 않도록 회귀 테스트를 보강했습니다.
- 이슈 전용 설계 문서와 실행 계획 문서를 추가했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
