### PR TITLE
Build: pricing page main 릴리즈 정리

### DIFF
--- a/apps/web/src/pages/LandingPage.test.tsx
+++ b/apps/web/src/pages/LandingPage.test.tsx
@@ -26,7 +26,10 @@ describe("LandingPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /product/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /security/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /pricing/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^pricing$/i })).toHaveAttribute(
+      "href",
+      "/pricing"
+    );
     expect(screen.getByRole("link", { name: /resources/i })).toBeInTheDocument();
     const githubCtas = screen.getAllByRole("link", { name: /connect github/i });
 
@@ -40,6 +43,10 @@ describe("LandingPage", () => {
     expect(screen.getByRole("link", { name: /log in/i })).toHaveAttribute(
       "href",
       "/login"
+    );
+    expect(screen.getByRole("link", { name: /view pricing/i })).toHaveAttribute(
+      "href",
+      "/pricing"
     );
   });
 

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -60,7 +60,7 @@ export function LandingPage() {
             <nav className="landing-topnav" aria-label="Public">
               <a href="#product">Product</a>
               <a href="#security">Security</a>
-              <a href="#pricing">Pricing</a>
+              <Link to="/pricing">Pricing</Link>
               <a href="#resources">Resources</a>
             </nav>
           </div>
@@ -215,9 +215,14 @@ export function LandingPage() {
             Join security-first engineering teams that trust AegisAI to safeguard the Java systems
             they cannot afford to get wrong.
           </p>
-          <a className="landing-primary-cta-v2" href={getProviderLoginUrl("github")}>
-            Connect GitHub
-          </a>
+          <div className="landing-cta-row-v2">
+            <a className="landing-primary-cta-v2" href={getProviderLoginUrl("github")}>
+              Connect GitHub
+            </a>
+            <Link className="landing-secondary-cta-v2" to="/pricing">
+              View pricing
+            </Link>
+          </div>
           <span className="landing-pricing-note">Free tier available for Open Source</span>
         </section>
 

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -60,9 +60,9 @@ export function LoginPage() {
           </div>
 
           <div className="login-topbar-actions-v2">
-            <a className="landing-inline-link" href="/#pricing">
+            <Link className="landing-inline-link" to="/pricing">
               Enterprise
-            </a>
+            </Link>
           </div>
         </div>
       </header>

--- a/apps/web/src/pages/PricingPage.test.tsx
+++ b/apps/web/src/pages/PricingPage.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { PricingPage } from "./PricingPage";
+
+function renderPricingPage() {
+  return render(
+    <MemoryRouter initialEntries={["/pricing"]}>
+      <Routes>
+        <Route path="/pricing" element={<PricingPage />} />
+        <Route path="/" element={<div>overview route</div>} />
+        <Route path="/login" element={<div>login route</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("PricingPage", () => {
+  it("renders the pricing hero and plan comparison narrative", () => {
+    renderPricingPage();
+
+    expect(
+      screen.getByRole("heading", {
+        name: /choose a review cadence that fits how your java repositories actually ship/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Starter" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Team" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Enterprise" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /questions teams usually ask before rollout/i })
+    ).toBeInTheDocument();
+  });
+
+  it("routes its primary actions into the existing public flow", () => {
+    renderPricingPage();
+
+    expect(screen.getByRole("link", { name: /^overview$/i })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: /log in/i })).toHaveAttribute("href", "/login");
+    expect(screen.getByRole("link", { name: /start secure review/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+    expect(screen.getByRole("link", { name: /open secure access/i })).toHaveAttribute(
+      "href",
+      "/login"
+    );
+  });
+});

--- a/apps/web/src/pages/PricingPage.tsx
+++ b/apps/web/src/pages/PricingPage.tsx
@@ -1,0 +1,349 @@
+import { Link } from "react-router-dom";
+
+import { getProviderLoginUrl } from "../api/auth";
+
+interface PricingPlan {
+  name: string;
+  price: string;
+  cadence: string;
+  description: string;
+  highlights: string[];
+  featured?: boolean;
+}
+
+const plans: PricingPlan[] = [
+  {
+    name: "Starter",
+    price: "$79",
+    cadence: "per month",
+    description:
+      "For solo reviewers and small Java services that need a dependable security pass before every release.",
+    highlights: [
+      "Up to 5 connected repositories",
+      "50 scan runs each month",
+      "Vulnerability review workspace",
+      "Exportable PDF reports",
+    ],
+  },
+  {
+    name: "Team",
+    price: "$329",
+    cadence: "per month",
+    featured: true,
+    description:
+      "For product teams that want shared triage, higher scan velocity, and polished reporting for every sprint.",
+    highlights: [
+      "Up to 20 connected repositories",
+      "300 scan runs each month",
+      "Shared reviewer workspace",
+      "Priority report generation and support",
+    ],
+  },
+  {
+    name: "Enterprise",
+    price: "Talk to us",
+    cadence: "custom rollout",
+    description:
+      "For security programs that need rollout guidance, tailored retention, and controlled onboarding across many repos.",
+    highlights: [
+      "Unlimited repository onboarding",
+      "Custom scan throughput",
+      "Dedicated onboarding lane",
+      "Security review and procurement support",
+    ],
+  },
+];
+
+const comparisonRows = [
+  {
+    label: "Repository scope",
+    starter: "Focused coverage for a small set of production repos.",
+    team: "Shared coverage for multiple squads and release branches.",
+    enterprise: "Portfolio-level onboarding with policy review.",
+  },
+  {
+    label: "Review rhythm",
+    starter: "Manual scans before release windows.",
+    team: "Recurring sprint and pre-merge review cycles.",
+    enterprise: "Structured rollout plans with queue tuning.",
+  },
+  {
+    label: "Report flow",
+    starter: "PDF exports for handoff and audit notes.",
+    team: "Fast report generation for security and engineering syncs.",
+    enterprise: "Extended retention and guided stakeholder distribution.",
+  },
+  {
+    label: "Support posture",
+    starter: "Core documentation and email support.",
+    team: "Faster response and rollout guidance.",
+    enterprise: "Dedicated onboarding and operating reviews.",
+  },
+] as const;
+
+const faqItems = [
+  {
+    question: "Is there a trial before we commit to a paid plan?",
+    answer:
+      "Yes. Teams can begin in the secure review workspace, connect a repository, and validate the flow before choosing a paid operating model.",
+  },
+  {
+    question: "Do all plans support private repositories?",
+    answer:
+      "Yes. Pricing assumes private Java repositories and keeps code handling inside the same authenticated review path.",
+  },
+  {
+    question: "What happens to PDF reports after generation?",
+    answer:
+      "Reports are generated inside the secured workspace and follow the same lifecycle controls as the rest of the review flow, including expiry handling.",
+  },
+  {
+    question: "Can we move to annual billing later?",
+    answer:
+      "Yes. Team and Enterprise rollouts can move to annual agreements once scan cadence and repository scope are stable.",
+  },
+  {
+    question: "What does Enterprise onboarding include?",
+    answer:
+      "Enterprise onboarding covers repository rollout planning, scan capacity calibration, report delivery expectations, and stakeholder handoff.",
+  },
+] as const;
+
+const trustSignals = [
+  {
+    title: "Same-origin secure access",
+    body: "Authentication, review, and report delivery stay within the same public entry and protected workspace flow.",
+  },
+  {
+    title: "Private code handling",
+    body: "Pricing is built around private repository review, not public showcase scanning.",
+  },
+  {
+    title: "Reviewable evidence",
+    body: "Each tier keeps the vulnerability review workspace, evidence trails, and PDF handoff artifacts in reach.",
+  },
+] as const;
+
+export function PricingPage() {
+  return (
+    <main className="pricing-page-v2">
+      <header className="pricing-topbar-v2">
+        <div className="pricing-topbar-inner-v2">
+          <div className="pricing-brand-group-v2">
+            <Link className="pricing-wordmark-v2" to="/">
+              AegisAI
+            </Link>
+
+            <nav className="pricing-topnav-v2" aria-label="Public pricing navigation">
+              <Link to="/">Overview</Link>
+              <a href="#plans">Plans</a>
+              <a href="#assurance">Assurance</a>
+              <a href="#faq">FAQ</a>
+            </nav>
+          </div>
+
+          <div className="pricing-topbar-actions-v2">
+            <Link className="landing-inline-link" to="/login">
+              Log in
+            </Link>
+            <a className="landing-topbar-cta" href={getProviderLoginUrl("github")}>
+              Connect GitHub
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <div className="pricing-shell-v2">
+        <section className="pricing-hero-v2">
+          <div className="pricing-hero-copy-v2">
+            <p className="pricing-eyebrow-v2">Pricing for deliberate security review</p>
+            <h1>
+              Choose a review cadence that fits how your Java repositories
+              <span> actually ship.</span>
+            </h1>
+            <p className="pricing-lead-v2">
+              AegisAI combines scan orchestration, evidence-backed vulnerability review,
+              and polished PDF reporting in a quieter security workspace built for teams
+              that prefer signal over noise.
+            </p>
+
+            <div className="pricing-cta-row-v2">
+              <Link className="landing-primary-cta-v2" to="/login">
+                Start secure review
+              </Link>
+              <a className="landing-secondary-cta-v2" href="#plans">
+                Compare plans
+              </a>
+            </div>
+
+            <ul className="pricing-summary-list-v2" aria-label="Pricing summary">
+              <li>Java-first review flow</li>
+              <li>Private repository access</li>
+              <li>PDF handoff included</li>
+            </ul>
+          </div>
+
+          <aside className="pricing-hero-panel-v2" aria-label="Pricing philosophy">
+            <span className="pricing-panel-badge-v2">Editorial pricing philosophy</span>
+            <h2>Pay for a calmer review loop, not a louder dashboard.</h2>
+            <p>
+              Every tier keeps the vulnerability review workspace, report generation,
+              and evidence-led triage visible. Higher plans widen repository scope,
+              scan throughput, and rollout support rather than hiding core review tools.
+            </p>
+
+            <dl className="pricing-metrics-v2">
+              <div>
+                <dt>3</dt>
+                <dd>clear tiers</dd>
+              </div>
+              <div>
+                <dt>1</dt>
+                <dd>same-origin entry flow</dd>
+              </div>
+              <div>
+                <dt>100%</dt>
+                <dd>private repo focus</dd>
+              </div>
+            </dl>
+          </aside>
+        </section>
+
+        <section
+          className="pricing-assurance-band-v2"
+          id="assurance"
+          aria-labelledby="pricing-assurance-heading"
+        >
+          <div className="pricing-section-heading-v2">
+            <p className="pricing-eyebrow-v2">Assurance built into every tier</p>
+            <h2 id="pricing-assurance-heading">
+              Security pricing should explain how code is handled, not leave it implied.
+            </h2>
+          </div>
+
+          <div className="pricing-trust-grid-v2">
+            {trustSignals.map((signal) => (
+              <article className="pricing-trust-card-v2" key={signal.title}>
+                <h3>{signal.title}</h3>
+                <p>{signal.body}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="pricing-plans-v2" id="plans" aria-labelledby="pricing-plans-heading">
+          <div className="pricing-section-heading-v2">
+            <p className="pricing-eyebrow-v2">Plans</p>
+            <h2 id="pricing-plans-heading">
+              Three operating shapes, each built around review clarity.
+            </h2>
+          </div>
+
+          <div className="pricing-plan-grid-v2">
+            {plans.map((plan) => (
+              <article
+                key={plan.name}
+                className={`pricing-plan-card-v2${plan.featured ? " is-featured" : ""}`}
+              >
+                <div className="pricing-plan-header-v2">
+                  <div>
+                    <h3>{plan.name}</h3>
+                    <p>{plan.description}</p>
+                  </div>
+                  {plan.featured ? <span className="pricing-plan-badge-v2">Recommended</span> : null}
+                </div>
+
+                <p className="pricing-plan-price-v2">
+                  <span>{plan.price}</span>
+                  <small>{plan.cadence}</small>
+                </p>
+
+                <ul className="pricing-plan-list-v2">
+                  {plan.highlights.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+
+                <Link
+                  className={plan.featured ? "landing-primary-cta-v2" : "landing-secondary-cta-v2"}
+                  to="/login"
+                >
+                  {plan.name === "Enterprise" ? "Plan enterprise rollout" : `Choose ${plan.name}`}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section
+          className="pricing-comparison-v2"
+          aria-labelledby="pricing-comparison-heading"
+        >
+          <div className="pricing-section-heading-v2">
+            <p className="pricing-eyebrow-v2">What changes as you grow</p>
+            <h2 id="pricing-comparison-heading">
+              An editorial comparison instead of a spreadsheet wall.
+            </h2>
+          </div>
+
+          <div className="pricing-comparison-table-v2" role="table" aria-label="Plan comparison">
+            <div className="pricing-comparison-head-v2" role="rowgroup">
+              <div role="row">
+                <span role="columnheader">Focus area</span>
+                <span role="columnheader">Starter</span>
+                <span role="columnheader">Team</span>
+                <span role="columnheader">Enterprise</span>
+              </div>
+            </div>
+
+            <div className="pricing-comparison-body-v2" role="rowgroup">
+              {comparisonRows.map((row) => (
+                <div className="pricing-comparison-row-v2" role="row" key={row.label}>
+                  <span role="rowheader">{row.label}</span>
+                  <p role="cell">{row.starter}</p>
+                  <p role="cell">{row.team}</p>
+                  <p role="cell">{row.enterprise}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="pricing-faq-v2" id="faq" aria-labelledby="pricing-faq-heading">
+          <div className="pricing-section-heading-v2">
+            <p className="pricing-eyebrow-v2">FAQ</p>
+            <h2 id="pricing-faq-heading">Questions teams usually ask before rollout.</h2>
+          </div>
+
+          <div className="pricing-faq-grid-v2">
+            {faqItems.map((item) => (
+              <article className="pricing-faq-card-v2" key={item.question}>
+                <h3>{item.question}</h3>
+                <p>{item.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="pricing-final-cta-v2" aria-labelledby="pricing-final-heading">
+          <div>
+            <p className="pricing-eyebrow-v2">Ready to set the review pace?</p>
+            <h2 id="pricing-final-heading">
+              Move from repository connection to reviewable evidence without changing
+              tools halfway through.
+            </h2>
+          </div>
+
+          <div className="pricing-final-actions-v2">
+            <Link className="landing-primary-cta-v2" to="/login">
+              Open secure access
+            </Link>
+            <Link className="landing-secondary-cta-v2" to="/">
+              Return to overview
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -7,13 +7,14 @@ describe("router", () => {
     expect(routes[0]?.path).toBe("/");
   });
 
-  it("keeps /login separate from the protected workspace routes", () => {
+  it("keeps the public routes separate from the protected workspace routes", () => {
     expect(routes[1]?.path).toBe("/login");
-    expect(routes[2]?.path).toBeUndefined();
+    expect(routes[2]?.path).toBe("/pricing");
+    expect(routes[3]?.path).toBeUndefined();
   });
 
   it("exposes the vulnerability review workspace inside the protected scan routes", () => {
-    const protectedChildren = routes[2]?.children ?? [];
+    const protectedChildren = routes[3]?.children ?? [];
     expect(protectedChildren.some((route) => route.path === "/scan/:scanId/review")).toBe(true);
   });
 });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -5,6 +5,7 @@ import { ProtectedRoute } from "./components/layout/ProtectedRoute";
 import { DashboardPage } from "./pages/DashboardPage";
 import { LandingPage } from "./pages/LandingPage";
 import { LoginPage } from "./pages/LoginPage";
+import { PricingPage } from "./pages/PricingPage";
 import { ReposPage } from "./pages/ReposPage";
 import { ScanPage } from "./pages/ScanPage";
 import { VulnerabilityReviewPage } from "./pages/VulnerabilityReviewPage";
@@ -17,6 +18,10 @@ export const routes: RouteObject[] = [
   {
     path: "/login",
     element: <LoginPage />,
+  },
+  {
+    path: "/pricing",
+    element: <PricingPage />,
   },
   {
     element: (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1149,6 +1149,385 @@ button {
   justify-content: center;
 }
 
+.pricing-page-v2 {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(181, 141, 61, 0.14), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(64, 94, 146, 0.08), transparent 20%),
+    linear-gradient(180deg, #fbf9f4 0%, #f3f0e8 100%);
+}
+
+.pricing-topbar-v2 {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(251, 249, 244, 0.88);
+  backdrop-filter: blur(16px);
+}
+
+.pricing-topbar-inner-v2,
+.pricing-shell-v2 {
+  width: min(1440px, 100%);
+  margin: 0 auto;
+  padding-left: 32px;
+  padding-right: 32px;
+}
+
+.pricing-topbar-inner-v2 {
+  padding-top: 24px;
+  padding-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.pricing-brand-group-v2 {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
+.pricing-wordmark-v2,
+.pricing-hero-copy-v2 h1,
+.pricing-hero-panel-v2 h2,
+.pricing-section-heading-v2 h2,
+.pricing-plan-card-v2 h3,
+.pricing-faq-card-v2 h3,
+.pricing-final-cta-v2 h2 {
+  font-family: var(--font-display);
+  color: var(--ink-strong);
+}
+
+.pricing-wordmark-v2 {
+  font-size: 1.7rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.pricing-topnav-v2 {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+
+.pricing-topnav-v2 a {
+  color: var(--ink-muted);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.05rem;
+  transition: color 180ms ease;
+}
+
+.pricing-topnav-v2 a:hover {
+  color: var(--brass-deep);
+}
+
+.pricing-topbar-actions-v2 {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.pricing-shell-v2 {
+  padding-top: 56px;
+  padding-bottom: 80px;
+  display: grid;
+  gap: 32px;
+}
+
+.pricing-hero-v2 {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(360px, 0.85fr);
+  gap: 42px;
+  align-items: start;
+  padding: 24px 0 16px;
+}
+
+.pricing-hero-copy-v2,
+.pricing-section-heading-v2 {
+  display: grid;
+  gap: 20px;
+}
+
+.pricing-eyebrow-v2 {
+  margin: 0;
+  color: var(--brass-deep);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.pricing-hero-copy-v2 h1,
+.pricing-section-heading-v2 h2,
+.pricing-final-cta-v2 h2,
+.pricing-hero-panel-v2 h2 {
+  margin: 0;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+}
+
+.pricing-hero-copy-v2 h1 {
+  font-size: clamp(3.4rem, 6vw, 5.8rem);
+  max-width: 11ch;
+}
+
+.pricing-hero-copy-v2 h1 span {
+  font-style: italic;
+  color: var(--brass-deep);
+}
+
+.pricing-lead-v2,
+.pricing-hero-panel-v2 p,
+.pricing-trust-card-v2 p,
+.pricing-plan-card-v2 p,
+.pricing-comparison-row-v2 p,
+.pricing-faq-card-v2 p {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.72;
+}
+
+.pricing-lead-v2 {
+  max-width: 42rem;
+  font-size: 1.08rem;
+}
+
+.pricing-cta-row-v2,
+.pricing-final-actions-v2 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.pricing-summary-list-v2,
+.pricing-plan-list-v2 {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pricing-summary-list-v2 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 44rem;
+}
+
+.pricing-summary-list-v2 li,
+.pricing-plan-list-v2 li {
+  position: relative;
+  padding-left: 20px;
+  color: var(--ink-muted);
+}
+
+.pricing-summary-list-v2 li::before,
+.pricing-plan-list-v2 li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--brass-deep), var(--brass-warm));
+}
+
+.pricing-hero-panel-v2,
+.pricing-trust-card-v2,
+.pricing-plan-card-v2,
+.pricing-faq-card-v2,
+.pricing-assurance-band-v2,
+.pricing-comparison-v2,
+.pricing-final-cta-v2 {
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 24px 48px -12px rgba(27, 28, 25, 0.06);
+}
+
+.pricing-hero-panel-v2,
+.pricing-assurance-band-v2,
+.pricing-comparison-v2,
+.pricing-final-cta-v2 {
+  padding: 28px;
+}
+
+.pricing-hero-panel-v2 {
+  display: grid;
+  gap: 18px;
+}
+
+.pricing-panel-badge-v2,
+.pricing-plan-badge-v2 {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 2rem;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(213, 224, 247, 0.78);
+  color: #425067;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.pricing-metrics-v2 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.pricing-metrics-v2 div {
+  padding: 14px;
+  border-radius: 0.75rem;
+  background: var(--surface-low);
+}
+
+.pricing-metrics-v2 dt {
+  margin: 0 0 4px;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: -0.04em;
+}
+
+.pricing-metrics-v2 dd {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+}
+
+.pricing-assurance-band-v2,
+.pricing-comparison-v2 {
+  background: rgba(245, 243, 238, 0.92);
+}
+
+.pricing-section-heading-v2 h2,
+.pricing-final-cta-v2 h2 {
+  font-size: clamp(2.2rem, 4vw, 3.6rem);
+  max-width: 16ch;
+}
+
+.pricing-trust-grid-v2,
+.pricing-plan-grid-v2,
+.pricing-faq-grid-v2 {
+  display: grid;
+  gap: 20px;
+}
+
+.pricing-trust-grid-v2 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 28px;
+}
+
+.pricing-trust-card-v2,
+.pricing-plan-card-v2,
+.pricing-faq-card-v2 {
+  padding: 24px;
+}
+
+.pricing-trust-card-v2 h3,
+.pricing-plan-card-v2 h3,
+.pricing-faq-card-v2 h3 {
+  margin: 0 0 12px;
+  font-size: 1.6rem;
+  letter-spacing: -0.03em;
+}
+
+.pricing-plans-v2,
+.pricing-faq-v2 {
+  display: grid;
+  gap: 28px;
+}
+
+.pricing-plan-grid-v2 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.pricing-plan-card-v2 {
+  display: grid;
+  gap: 18px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.pricing-plan-card-v2.is-featured {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(245, 243, 238, 0.98));
+}
+
+.pricing-plan-header-v2 {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pricing-plan-price-v2 {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.pricing-plan-price-v2 span {
+  font-family: var(--font-display);
+  font-size: 3rem;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  color: var(--ink-strong);
+}
+
+.pricing-plan-price-v2 small {
+  color: var(--ink-faint);
+  padding-bottom: 6px;
+}
+
+.pricing-comparison-table-v2 {
+  display: grid;
+  gap: 14px;
+}
+
+.pricing-comparison-head-v2 div,
+.pricing-comparison-row-v2 {
+  display: grid;
+  grid-template-columns: 1.1fr repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.pricing-comparison-head-v2 div {
+  color: var(--ink-faint);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.pricing-comparison-row-v2 {
+  padding: 18px 20px;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.pricing-comparison-row-v2 span[role="rowheader"] {
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  letter-spacing: -0.03em;
+}
+
+.pricing-faq-grid-v2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.pricing-final-cta-v2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  background:
+    linear-gradient(135deg, rgba(122, 89, 8, 0.1), rgba(181, 141, 61, 0.06)),
+    rgba(234, 232, 227, 0.92);
+}
+
 .ghost-button {
   border: 1px solid rgba(122, 89, 8, 0.12);
   border-radius: 999px;
@@ -2423,16 +2802,20 @@ button {
 
   .landing-topbar-inner,
   .login-topbar-inner-v2,
+  .pricing-topbar-inner-v2,
   .landing-shell,
-  .login-shell-v2 {
+  .login-shell-v2,
+  .pricing-shell-v2 {
     padding-left: 20px;
     padding-right: 20px;
   }
 
   .landing-brand-group,
   .login-brand-group-v2,
+  .pricing-brand-group-v2,
   .landing-topbar-inner,
   .login-topbar-inner-v2,
+  .pricing-topbar-inner-v2,
   .landing-footer-v2 {
     flex-direction: column;
     align-items: flex-start;
@@ -2440,14 +2823,21 @@ button {
 
   .landing-topnav,
   .login-topnav-v2,
+  .pricing-topnav-v2,
   .landing-topbar-actions,
   .login-topbar-actions-v2,
+  .pricing-topbar-actions-v2,
   .landing-footer-links {
     flex-wrap: wrap;
   }
 
   .landing-hero-v2,
-  .landing-security-story {
+  .landing-security-story,
+  .pricing-hero-v2,
+  .pricing-trust-grid-v2,
+  .pricing-plan-grid-v2,
+  .pricing-faq-grid-v2,
+  .pricing-final-cta-v2 {
     grid-template-columns: 1fr;
   }
 
@@ -2461,7 +2851,17 @@ button {
 
   .landing-step-grid-v2,
   .login-trust-grid-v2,
-  .repos-record-meta {
+  .repos-record-meta,
+  .pricing-summary-list-v2,
+  .pricing-metrics-v2 {
+    grid-template-columns: 1fr;
+  }
+
+  .pricing-comparison-head-v2 {
+    display: none;
+  }
+
+  .pricing-comparison-row-v2 {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `release/119-pricing-page-main-release`
- 이슈: `#119`

## 🔎 주요 변경 사항

- `dev`에 반영된 public pricing page UI를 `main` 릴리즈 후보 브랜치로 정리했습니다.
- `/pricing` public route를 추가하고, landing/login public entry에서 pricing으로 자연스럽게 이동할 수 있도록 연결했습니다.
- pricing page는 Stitch public-entry baseline을 기준으로 구현했고, 기존 public visual language를 유지하면서 필요한 정보 구조만 확장했습니다.
- release branch 기준으로 pricing 관련 web 변경만 포함되는 것을 다시 확인했습니다.
- release branch 기준으로 `pnpm install`, `web test`, `web lint`, `web typecheck`, `web build`를 fresh하게 다시 검증했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?
