### PR TITLE
Fix: 로그아웃 후 stale session UI 상태 정리

### DIFF
--- a/apps/web/src/hooks/useAuth.test.tsx
+++ b/apps/web/src/hooks/useAuth.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchCurrentUser, logout } from "../api/auth";
@@ -68,6 +69,28 @@ describe("useAuth", () => {
     });
   });
 
+  it("clears local auth state when logout succeeds", async () => {
+    vi.mocked(fetchCurrentUser).mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      name: "Aegis User",
+      avatarUrl: null,
+      connectedProviders: ["github"],
+    });
+    vi.mocked(logout).mockResolvedValue(null);
+
+    renderHarness();
+
+    expect(await screen.findByText("Aegis User")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().user).toBeNull();
+      expect(useAuthStore.getState().initialized).toBe(true);
+    });
+  });
+
   it("exposes an error bootstrap state when GET /api/auth/me fails", async () => {
     vi.mocked(fetchCurrentUser).mockRejectedValue(new Error("session bootstrap failed"));
 
@@ -77,6 +100,32 @@ describe("useAuth", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("bootstrap-state")).toHaveTextContent("error");
+      expect(useAuthStore.getState().user).toBeNull();
+      expect(useAuthStore.getState().initialized).toBe(true);
+    });
+  });
+
+  it("clears local auth state when logout returns unauthorized", async () => {
+    vi.mocked(fetchCurrentUser).mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      name: "Aegis User",
+      avatarUrl: null,
+      connectedProviders: ["github"],
+    });
+    vi.mocked(logout).mockRejectedValue({
+      response: {
+        status: 401,
+      },
+    });
+
+    renderHarness();
+
+    expect(await screen.findByText("Aegis User")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /logout/i }));
+
+    await waitFor(() => {
       expect(useAuthStore.getState().user).toBeNull();
       expect(useAuthStore.getState().initialized).toBe(true);
     });

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import axios from "axios";
 import { useEffect } from "react";
 
 import { fetchCurrentUser, logout as logoutRequest } from "../api/auth";
@@ -41,15 +42,19 @@ export function useAuth() {
     }
   }, [meQuery.data, meQuery.status, setUser, clearUser, markInitialized]);
 
+  const finalizeLogout = async () => {
+    await queryClient.cancelQueries({
+      queryKey: AUTH_QUERY_KEY,
+    });
+    clearUser();
+    markInitialized();
+    queryClient.setQueryData(AUTH_QUERY_KEY, null);
+  };
+
   const logoutMutation = useMutation({
     mutationFn: logoutRequest,
     onSuccess: async () => {
-      clearUser();
-      markInitialized();
-      queryClient.setQueryData(AUTH_QUERY_KEY, null);
-      await queryClient.invalidateQueries({
-        queryKey: AUTH_QUERY_KEY,
-      });
+      await finalizeLogout();
     },
   });
 
@@ -59,7 +64,16 @@ export function useAuth() {
     isAuthenticated: Boolean(user),
     bootstrapState: getBootstrapState(initialized, meQuery.status),
     logout: async () => {
-      await logoutMutation.mutateAsync();
+      try {
+        await logoutMutation.mutateAsync();
+      } catch (error) {
+        if (isTerminalLogoutError(error)) {
+          await finalizeLogout();
+          return;
+        }
+
+        throw error;
+      }
     },
     refresh: async () => {
       await queryClient.invalidateQueries({
@@ -82,4 +96,24 @@ function getBootstrapState(
   }
 
   return "ready";
+}
+
+function isTerminalLogoutError(error: unknown): boolean {
+  const status = getErrorStatus(error);
+
+  return status === 401 || status === 403;
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (axios.isAxiosError(error)) {
+    return error.response?.status;
+  }
+
+  if (typeof error !== "object" || error === null || !("response" in error)) {
+    return undefined;
+  }
+
+  const { response } = error as { response?: { status?: unknown } };
+
+  return typeof response?.status === "number" ? response.status : undefined;
 }


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `fix/121-logout-session-stale-ui`
- 이슈: `#121`

## 🔎 주요 변경 사항

- `apps/web/src/hooks/useAuth.ts`에서 logout 성공 시 local auth state와 auth query cache를 즉시 정리하도록 보강했습니다.
- logout 요청이 `401` 또는 `403`으로 종료되는 terminal auth error에서도 stale user 상태가 남지 않도록 처리했습니다.
- `apps/web/src/hooks/useAuth.test.tsx`에 로그아웃 성공, unauthorized logout 이후 local auth state가 정리되는 회귀 테스트를 추가했습니다.
- web auth bootstrap과 logout 흐름이 충돌하지 않도록 web 범위 lint, test, typecheck, build를 다시 검증했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logout to properly handle and recover from authentication errors, ensuring the app clears user data and maintains state consistency even when logout encounters HTTP authorization failures.

* **Tests**
  * Added test coverage for logout functionality, validating both successful logouts and error scenarios with proper state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->