### PR TITLE
feat: persist GitHub App installation state and webhooks

### DIFF
--- a/apps/api/src/control-plane/control-plane.module.ts
+++ b/apps/api/src/control-plane/control-plane.module.ts
@@ -4,14 +4,29 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "../config/config.module";
 import { ControlPlaneService } from "./control-plane.service";
 import { GithubAppInstallationClient } from "./github-app-installation.client";
+import { GithubAppInstallationStateService } from "./github-app-installation-state.service";
+import { GithubWebhooksController } from "./github-webhooks.controller";
 import { IntegrationsController } from "./integrations.controller";
 import { RepositoryBindingsController } from "./repository-bindings.controller";
 import { ScanRequestsController } from "./scan-requests.controller";
 
 @Module({
   imports: [ConfigModule, HttpModule],
-  controllers: [IntegrationsController, RepositoryBindingsController, ScanRequestsController],
-  providers: [ControlPlaneService, GithubAppInstallationClient],
-  exports: [ControlPlaneService, GithubAppInstallationClient]
+  controllers: [
+    IntegrationsController,
+    RepositoryBindingsController,
+    ScanRequestsController,
+    GithubWebhooksController
+  ],
+  providers: [
+    ControlPlaneService,
+    GithubAppInstallationClient,
+    GithubAppInstallationStateService
+  ],
+  exports: [
+    ControlPlaneService,
+    GithubAppInstallationClient,
+    GithubAppInstallationStateService
+  ]
 })
 export class ControlPlaneModule {}

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import {
   buildCanonicalScanKey,
   shouldEscalateIsolation,
@@ -10,10 +10,15 @@ import type {
   ControlPlaneRepositoryBinding,
   ControlPlaneScanRequest,
   CreateScanRequestInput,
+  GithubInstallationWebhookAck,
+  GithubInstallationWebhookInput,
+  GithubWebhookRepositoryInput,
   InstallIntegrationInput,
-  InstallIntegrationOptions
+  InstallIntegrationOptions,
+  InstallRepositoryInput
 } from "./control-plane.types";
 import { GithubAppInstallationClient } from "./github-app-installation.client";
+import { GithubAppInstallationStateService } from "./github-app-installation-state.service";
 
 @Injectable()
 export class ControlPlaneService {
@@ -25,14 +30,17 @@ export class ControlPlaneService {
   private repositorySequence = 0;
   private scanSequence = 0;
 
-  constructor(private readonly githubAppInstallationClient: GithubAppInstallationClient) {}
+  constructor(
+    private readonly githubAppInstallationClient: GithubAppInstallationClient,
+    private readonly githubAppInstallationState: GithubAppInstallationStateService
+  ) {}
 
   async installGithubAppIntegration(input: InstallIntegrationInput): Promise<ControlPlaneIntegration> {
     const repositories =
       input.repositories ??
       (await this.githubAppInstallationClient.listInstallationRepositories(input.externalInstallationId));
 
-    return this.installIntegration(
+    const integration = this.installIntegration(
       {
         ...input,
         repositories
@@ -42,6 +50,10 @@ export class ControlPlaneService {
         integrationType: "GITHUB_APP"
       }
     );
+
+    await this.githubAppInstallationState.persistInstallation(integration, repositories);
+
+    return integration;
   }
 
   installIntegration(
@@ -102,6 +114,50 @@ export class ControlPlaneService {
     return Array.from(this.repositoryBindings.values()).filter((binding) => binding.tenantId === tenantId);
   }
 
+  async reconcileGithubInstallationWebhook(
+    event: string,
+    input: GithubInstallationWebhookInput
+  ): Promise<GithubInstallationWebhookAck> {
+    const externalInstallationId = String(input.installation?.id ?? "");
+    if (!externalInstallationId) {
+      throw new BadRequestException("GitHub installation webhook is missing installation id");
+    }
+
+    const integration = this.findGithubAppIntegration(externalInstallationId, input.tenantId);
+
+    const addedRepositories = this.normalizeGithubRepositories(
+      input.repositories_added ?? (input.action === "created" ? input.repositories : undefined)
+    );
+    const removedProviderRepoIds = this.normalizeGithubRepositories(input.repositories_removed).map(
+      (repository) => repository.providerRepoId
+    );
+
+    for (const repository of addedRepositories) {
+      this.upsertRepositoryBinding(integration, repository);
+    }
+
+    for (const providerRepoId of removedProviderRepoIds) {
+      this.removeRepositoryBinding(integration, providerRepoId);
+    }
+
+    await this.githubAppInstallationState.reconcileRepositories(
+      integration,
+      addedRepositories,
+      removedProviderRepoIds,
+      event,
+      input.action
+    );
+
+    return {
+      acknowledged: true,
+      provider: "GITHUB",
+      event,
+      externalInstallationId,
+      addedRepositoryCount: addedRepositories.length,
+      removedRepositoryCount: removedProviderRepoIds.length
+    };
+  }
+
   createScanRequest(input: CreateScanRequestInput): ControlPlaneScanRequest {
     const repositoryBinding = this.repositoryBindings.get(input.repositoryBindingId);
     if (!repositoryBinding || repositoryBinding.tenantId !== input.tenantId) {
@@ -137,5 +193,84 @@ export class ControlPlaneService {
     }
 
     return scanRequest;
+  }
+
+  private findGithubAppIntegration(
+    externalInstallationId: string,
+    tenantId?: string
+  ): ControlPlaneIntegration {
+    const integration = Array.from(this.integrations.values()).find(
+      (candidate) =>
+        candidate.provider === "GITHUB" &&
+        candidate.integrationType === "GITHUB_APP" &&
+        candidate.externalInstallationId === externalInstallationId &&
+        (!tenantId || candidate.tenantId === tenantId)
+    );
+
+    if (!integration) {
+      throw new NotFoundException("GitHub App installation integration not found");
+    }
+
+    return integration;
+  }
+
+  private upsertRepositoryBinding(
+    integration: ControlPlaneIntegration,
+    repository: InstallRepositoryInput
+  ): ControlPlaneRepositoryBinding {
+    const existing = Array.from(this.repositoryBindings.values()).find(
+      (binding) =>
+        binding.tenantId === integration.tenantId &&
+        binding.scmIntegrationId === integration.id &&
+        binding.providerRepoId === repository.providerRepoId
+    );
+
+    const binding: ControlPlaneRepositoryBinding = {
+      id: existing?.id ?? `repository_binding_${++this.repositorySequence}`,
+      tenantId: integration.tenantId,
+      scmIntegrationId: integration.id,
+      providerRepoId: repository.providerRepoId,
+      fullName: repository.fullName,
+      defaultBranch: repository.defaultBranch,
+      isPrivate: repository.isPrivate
+    };
+
+    this.repositoryBindings.set(binding.id, binding);
+
+    return binding;
+  }
+
+  private removeRepositoryBinding(
+    integration: ControlPlaneIntegration,
+    providerRepoId: string
+  ): void {
+    for (const binding of this.repositoryBindings.values()) {
+      if (
+        binding.tenantId === integration.tenantId &&
+        binding.scmIntegrationId === integration.id &&
+        binding.providerRepoId === providerRepoId
+      ) {
+        this.repositoryBindings.delete(binding.id);
+      }
+    }
+  }
+
+  private normalizeGithubRepositories(
+    repositories: GithubWebhookRepositoryInput[] | undefined
+  ): InstallRepositoryInput[] {
+    return (repositories ?? []).map((repository) => {
+      const providerRepoId = String(repository.providerRepoId ?? repository.id ?? "");
+      const fullName = repository.fullName ?? repository.full_name ?? "";
+      if (!providerRepoId || !fullName) {
+        throw new BadRequestException("GitHub repository webhook entry is missing repository id or full name");
+      }
+
+      return {
+        providerRepoId,
+        fullName,
+        defaultBranch: repository.defaultBranch ?? repository.default_branch ?? "main",
+        isPrivate: repository.isPrivate ?? repository.private ?? true
+      };
+    });
   }
 }

--- a/apps/api/src/control-plane/control-plane.types.ts
+++ b/apps/api/src/control-plane/control-plane.types.ts
@@ -15,6 +15,37 @@ export interface InstallRepositoryInput {
   isPrivate: boolean;
 }
 
+export interface GithubWebhookRepositoryInput {
+  id?: string | number;
+  providerRepoId?: string;
+  full_name?: string;
+  fullName?: string;
+  default_branch?: string;
+  defaultBranch?: string;
+  private?: boolean;
+  isPrivate?: boolean;
+}
+
+export interface GithubInstallationWebhookInput {
+  tenantId?: string;
+  action: string;
+  installation: {
+    id: string | number;
+  };
+  repositories?: GithubWebhookRepositoryInput[];
+  repositories_added?: GithubWebhookRepositoryInput[];
+  repositories_removed?: GithubWebhookRepositoryInput[];
+}
+
+export interface GithubInstallationWebhookAck {
+  acknowledged: true;
+  provider: "GITHUB";
+  event: string;
+  externalInstallationId: string;
+  addedRepositoryCount: number;
+  removedRepositoryCount: number;
+}
+
 export interface InstallIntegrationInput {
   tenantId: string;
   externalInstallationId: string;

--- a/apps/api/src/control-plane/github-app-installation-state.service.ts
+++ b/apps/api/src/control-plane/github-app-installation-state.service.ts
@@ -1,0 +1,157 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+
+import { PrismaService } from "../prisma/prisma.service";
+import type {
+  ControlPlaneIntegration,
+  InstallRepositoryInput
+} from "./control-plane.types";
+
+@Injectable()
+export class GithubAppInstallationStateService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async persistInstallation(
+    integration: ControlPlaneIntegration,
+    repositories: InstallRepositoryInput[]
+  ): Promise<void> {
+    await this.upsertTenant(integration.tenantId);
+
+    await this.prisma.scmIntegration.upsert({
+      where: {
+        tenantId_provider_externalInstallationId: {
+          tenantId: integration.tenantId,
+          provider: "GITHUB",
+          externalInstallationId: integration.externalInstallationId
+        }
+      },
+      update: {
+        repoReadPrincipalId: integration.repoReadPrincipalId,
+        commentWritePrincipalId: integration.commentWritePrincipalId,
+        integrationAdminPrincipalId: integration.integrationAdminPrincipalId,
+        status: "ACTIVE"
+      },
+      create: {
+        id: integration.id,
+        tenantId: integration.tenantId,
+        provider: "GITHUB",
+        integrationType: "GITHUB_APP",
+        externalInstallationId: integration.externalInstallationId,
+        repoReadPrincipalId: integration.repoReadPrincipalId,
+        commentWritePrincipalId: integration.commentWritePrincipalId,
+        integrationAdminPrincipalId: integration.integrationAdminPrincipalId,
+        status: "ACTIVE"
+      }
+    });
+
+    for (const repository of repositories) {
+      await this.upsertRepositoryBinding(integration, repository);
+    }
+
+    await this.recordAuditEvent(
+      integration,
+      "github_app.installation.persisted",
+      {
+        externalInstallationId: integration.externalInstallationId,
+        repositoryCount: repositories.length
+      }
+    );
+  }
+
+  async reconcileRepositories(
+    integration: ControlPlaneIntegration,
+    addedRepositories: InstallRepositoryInput[],
+    removedProviderRepoIds: string[],
+    event: string,
+    action: string
+  ): Promise<void> {
+    await this.upsertTenant(integration.tenantId);
+
+    for (const repository of addedRepositories) {
+      await this.upsertRepositoryBinding(integration, repository);
+    }
+
+    if (removedProviderRepoIds.length > 0) {
+      await this.prisma.repositoryBinding.deleteMany({
+        where: {
+          tenantId: integration.tenantId,
+          scmIntegrationId: integration.id,
+          providerRepoId: { in: removedProviderRepoIds }
+        }
+      });
+    }
+
+    await this.recordAuditEvent(
+      integration,
+      "github_app.installation_repositories.reconciled",
+      {
+        event,
+        action,
+        addedRepositoryCount: addedRepositories.length,
+        removedRepositoryCount: removedProviderRepoIds.length
+      }
+    );
+  }
+
+  private async upsertTenant(tenantId: string): Promise<void> {
+    await this.prisma.tenant.upsert({
+      where: { id: tenantId },
+      update: {},
+      create: {
+        id: tenantId,
+        slug: this.toTenantSlug(tenantId),
+        name: tenantId,
+        status: "ACTIVE"
+      }
+    });
+  }
+
+  private async upsertRepositoryBinding(
+    integration: ControlPlaneIntegration,
+    repository: InstallRepositoryInput
+  ): Promise<void> {
+    await this.prisma.repositoryBinding.upsert({
+      where: {
+        tenantId_scmIntegrationId_providerRepoId: {
+          tenantId: integration.tenantId,
+          scmIntegrationId: integration.id,
+          providerRepoId: repository.providerRepoId
+        }
+      },
+      update: {
+        fullName: repository.fullName,
+        defaultBranch: repository.defaultBranch,
+        isPrivate: repository.isPrivate
+      },
+      create: {
+        tenantId: integration.tenantId,
+        scmIntegrationId: integration.id,
+        providerRepoId: repository.providerRepoId,
+        fullName: repository.fullName,
+        defaultBranch: repository.defaultBranch,
+        isPrivate: repository.isPrivate
+      }
+    });
+  }
+
+  private async recordAuditEvent(
+    integration: ControlPlaneIntegration,
+    eventType: string,
+    metadata: Prisma.InputJsonObject
+  ): Promise<void> {
+    await this.prisma.auditEvent.create({
+      data: {
+        tenantId: integration.tenantId,
+        eventType,
+        actor: "github-app",
+        targetType: "scm_integration",
+        targetId: integration.id,
+        metadata
+      }
+    });
+  }
+
+  private toTenantSlug(tenantId: string): string {
+    return tenantId.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "tenant";
+  }
+}

--- a/apps/api/src/control-plane/github-webhooks.controller.ts
+++ b/apps/api/src/control-plane/github-webhooks.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Headers, HttpCode, Post } from "@nestjs/common";
+
+import { ControlPlaneService } from "./control-plane.service";
+import type { GithubInstallationWebhookInput } from "./control-plane.types";
+
+@Controller("webhooks/github")
+export class GithubWebhooksController {
+  constructor(private readonly controlPlaneService: ControlPlaneService) {}
+
+  @Post()
+  @HttpCode(202)
+  reconcileInstallationRepositories(
+    @Headers("x-github-event") githubEvent: string | undefined,
+    @Body() body: GithubInstallationWebhookInput
+  ) {
+    return this.controlPlaneService.reconcileGithubInstallationWebhook(
+      githubEvent ?? "unknown",
+      body
+    );
+  }
+}

--- a/apps/api/test/control-plane/control-plane.e2e-spec.ts
+++ b/apps/api/test/control-plane/control-plane.e2e-spec.ts
@@ -4,6 +4,17 @@ import request from "supertest";
 
 describe("Control Plane skeleton (e2e)", () => {
   let app: INestApplication;
+  let prismaMock: {
+    $connect: jest.Mock;
+    $disconnect: jest.Mock;
+    onModuleInit: jest.Mock;
+    onModuleDestroy: jest.Mock;
+    $queryRawUnsafe: jest.Mock;
+    tenant: { upsert: jest.Mock };
+    scmIntegration: { upsert: jest.Mock };
+    repositoryBinding: { upsert: jest.Mock; deleteMany: jest.Mock };
+    auditEvent: { create: jest.Mock };
+  };
 
   beforeAll(async () => {
     process.env.NODE_ENV = "test";
@@ -27,17 +38,26 @@ describe("Control Plane skeleton (e2e)", () => {
       import("../../src/prisma/prisma.service")
     ]);
 
+    prismaMock = {
+      $connect: jest.fn().mockResolvedValue(undefined),
+      $disconnect: jest.fn().mockResolvedValue(undefined),
+      onModuleInit: jest.fn().mockResolvedValue(undefined),
+      onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+      $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }]),
+      tenant: { upsert: jest.fn().mockResolvedValue({}) },
+      scmIntegration: { upsert: jest.fn().mockResolvedValue({}) },
+      repositoryBinding: {
+        upsert: jest.fn().mockResolvedValue({}),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 })
+      },
+      auditEvent: { create: jest.fn().mockResolvedValue({}) }
+    };
+
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule]
     })
       .overrideProvider(PrismaService)
-      .useValue({
-        $connect: jest.fn().mockResolvedValue(undefined),
-        $disconnect: jest.fn().mockResolvedValue(undefined),
-        onModuleInit: jest.fn().mockResolvedValue(undefined),
-        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
-        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
-      })
+      .useValue(prismaMock)
       .overrideProvider(GithubAppInstallationClient)
       .useValue({
         listInstallationRepositories: jest.fn().mockResolvedValue([
@@ -70,6 +90,14 @@ describe("Control Plane skeleton (e2e)", () => {
 
     return body as T;
   };
+
+  beforeEach(() => {
+    prismaMock.tenant.upsert.mockClear();
+    prismaMock.scmIntegration.upsert.mockClear();
+    prismaMock.repositoryBinding.upsert.mockClear();
+    prismaMock.repositoryBinding.deleteMany.mockClear();
+    prismaMock.auditEvent.create.mockClear();
+  });
 
   it("installs a GitHub App integration and exposes tenant-scoped repository bindings", async () => {
     const install = await request(app.getHttpServer())
@@ -166,6 +194,145 @@ describe("Control Plane skeleton (e2e)", () => {
         isPrivate: true
       })
     ]);
+  });
+
+  it("persists GitHub App installation state without storing runtime token values", async () => {
+    const install = await request(app.getHttpServer())
+      .post("/api/integrations/github/install")
+      .send({
+        tenantId: "tenant_persisted_github_app",
+        externalInstallationId: "98766",
+        repoReadPrincipalId: "github-app-installation:98766:repo-read",
+        commentWritePrincipalId: "github-app-installation:98766:comment-write"
+      })
+      .expect(201);
+
+    const installData = dataOf<Record<string, unknown>>(install.body);
+
+    expect(prismaMock.tenant.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "tenant_persisted_github_app" }
+      })
+    );
+    expect(prismaMock.scmIntegration.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId_provider_externalInstallationId: {
+            tenantId: "tenant_persisted_github_app",
+            provider: "GITHUB",
+            externalInstallationId: "98766"
+          }
+        }
+      })
+    );
+    expect(prismaMock.repositoryBinding.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId_scmIntegrationId_providerRepoId: {
+            tenantId: "tenant_persisted_github_app",
+            scmIntegrationId: installData.id,
+            providerRepoId: "3003"
+          }
+        }
+      })
+    );
+    expect(prismaMock.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tenantId: "tenant_persisted_github_app",
+          eventType: "github_app.installation.persisted",
+          targetType: "scm_integration",
+          targetId: installData.id
+        })
+      })
+    );
+    expect(JSON.stringify(prismaMock.scmIntegration.upsert.mock.calls)).not.toMatch(
+      /accessToken|installation-token|secretValue|tokenValue/i
+    );
+  });
+
+  it("reconciles GitHub installation repository webhook changes into tenant bindings", async () => {
+    const install = await request(app.getHttpServer())
+      .post("/api/integrations/github/install")
+      .send({
+        tenantId: "tenant_webhook_github_app",
+        externalInstallationId: "98767",
+        repoReadPrincipalId: "github-app-installation:98767:repo-read",
+        commentWritePrincipalId: "github-app-installation:98767:comment-write"
+      })
+      .expect(201);
+
+    const installData = dataOf<Record<string, unknown>>(install.body);
+
+    const webhook = await request(app.getHttpServer())
+      .post("/api/webhooks/github")
+      .set("X-GitHub-Event", "installation_repositories")
+      .send({
+        tenantId: "tenant_webhook_github_app",
+        action: "added",
+        installation: { id: "98767" },
+        repositories_added: [
+          {
+            id: 4004,
+            full_name: "acme/new-service",
+            default_branch: "trunk",
+            private: false
+          }
+        ],
+        repositories_removed: [
+          {
+            id: 3003,
+            full_name: "acme/runtime-bound"
+          }
+        ]
+      })
+      .expect(202);
+
+    expect(dataOf<Record<string, unknown>>(webhook.body)).toMatchObject({
+      acknowledged: true,
+      provider: "GITHUB",
+      event: "installation_repositories",
+      externalInstallationId: "98767",
+      addedRepositoryCount: 1,
+      removedRepositoryCount: 1
+    });
+
+    const repositories = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_webhook_github_app" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(repositories.body)).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant_webhook_github_app",
+        scmIntegrationId: installData.id,
+        providerRepoId: "4004",
+        fullName: "acme/new-service",
+        defaultBranch: "trunk",
+        isPrivate: false
+      })
+    ]);
+    expect(prismaMock.repositoryBinding.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId_scmIntegrationId_providerRepoId: {
+            tenantId: "tenant_webhook_github_app",
+            scmIntegrationId: installData.id,
+            providerRepoId: "4004"
+          }
+        }
+      })
+    );
+    expect(prismaMock.repositoryBinding.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId: "tenant_webhook_github_app",
+          scmIntegrationId: installData.id,
+          providerRepoId: { in: ["3003"] }
+        }
+      })
+    );
+    expect(JSON.stringify(webhook.body)).not.toMatch(/accessToken|installation-token|secretValue|tokenValue/i);
   });
 
   it("creates scan requests with canonical keys and risk-based isolation escalation", async () => {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -54,6 +54,11 @@ The Control Plane may exchange an app JWT for a short-lived installation token t
 installation repositories and create repository bindings. Installation token values are
 runtime-only and must not be returned by public APIs, stored in tenant records, or logged.
 
+Installation state is persisted as tenant-scoped `ScmIntegration` and `RepositoryBinding`
+records. The Control Plane may acknowledge GitHub `installation_repositories` webhooks and
+reconcile repository additions/removals into repository bindings. Webhook acknowledgements
+must not include or persist GitHub App installation token values.
+
 ## Scan Plane Boundary
 
 Scan Plane accepts scan-scoped repository access and emits scanner runs, raw artifact

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -55,9 +55,15 @@
 - [x] T030 Add GitHub App runtime configuration placeholders without making token values persistent
 - [x] T031 Add e2e coverage for installation repository binding and missing credential guardrails
 
+## Phase 9: GitHub App Installation State and Webhook Slice
+
+- [x] T032 Persist GitHub App installation metadata through tenant-scoped Prisma upserts without token values
+- [x] T033 Add GitHub installation repository webhook acknowledgement endpoint
+- [x] T034 Reconcile GitHub installation repository added/removed events into repository bindings
+- [x] T035 Add e2e coverage for installation persistence, webhook reconciliation, and token leakage guardrails
+
 ## Deferred
 
-- [ ] Persist GitHub App installation state and reconcile installation webhooks
 - [ ] Implement GitLab Cloud integration runtime
 - [ ] Implement Token Broker credential issuance
 - [ ] Implement Opengrep/Trivy/Syft sandbox execution


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/133-github-app-installation-webhooks`
- 이슈: #133

## 주요 변경 사항

- GitHub App install flow에서 tenant-scoped `ScmIntegration` 및 `RepositoryBinding` persistence upsert 경계를 추가했습니다.
- `/api/webhooks/github` installation repository webhook acknowledgement endpoint를 추가했습니다.
- GitHub `installation_repositories` added/removed payload를 repository binding에 reconcile하고 audit event를 남깁니다.
- runtime installation token, secret, token value가 API 응답이나 persistence payload에 포함되지 않도록 e2e guardrail을 추가했습니다.
- `specs/002-production-scan-architecture` contract/tasks 문서를 Phase 9 상태로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명은 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지는 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`