### PR TITLE
feat: add GitLab Cloud integration runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
 GITLAB_CLIENT_ID=gitlab-client-id
 GITLAB_CLIENT_SECRET=gitlab-client-secret
+GITLAB_API_BASE_URL=https://gitlab.com/api/v4
 ANALYSIS_CLIENT_MODE=mock
 AI_SERVER_URL=http://localhost:8000
 USE_INTERNAL_AI=false

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,6 +16,7 @@ GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
 GITLAB_CLIENT_ID=gitlab-client-id
 GITLAB_CLIENT_SECRET=gitlab-client-secret
+GITLAB_API_BASE_URL=https://gitlab.com/api/v4
 ANALYSIS_CLIENT_MODE=mock
 AI_SERVER_URL=http://localhost:8000
 USE_INTERNAL_AI=false

--- a/apps/api/src/config/config.module.ts
+++ b/apps/api/src/config/config.module.ts
@@ -23,6 +23,7 @@ import { ConfigService } from './config.service';
         GITHUB_APP_PRIVATE_KEY: Joi.string().allow('').default(''),
         GITLAB_CLIENT_ID: Joi.string().required(),
         GITLAB_CLIENT_SECRET: Joi.string().required(),
+        GITLAB_API_BASE_URL: Joi.string().uri().default('https://gitlab.com/api/v4'),
         APP_URL: Joi.string().uri().required(),
         FRONTEND_URL: Joi.string().uri().required(),
         SESSION_COOKIE_NAME: Joi.string().default('connect.sid'),

--- a/apps/api/src/config/config.types.ts
+++ b/apps/api/src/config/config.types.ts
@@ -15,6 +15,7 @@ export interface EnvironmentVariables {
   GITHUB_APP_PRIVATE_KEY: string;
   GITLAB_CLIENT_ID: string;
   GITLAB_CLIENT_SECRET: string;
+  GITLAB_API_BASE_URL: string;
   APP_URL: string;
   FRONTEND_URL: string;
   SESSION_COOKIE_NAME: string;

--- a/apps/api/src/control-plane/control-plane.module.ts
+++ b/apps/api/src/control-plane/control-plane.module.ts
@@ -6,6 +6,7 @@ import { ControlPlaneService } from "./control-plane.service";
 import { GithubAppInstallationClient } from "./github-app-installation.client";
 import { GithubAppInstallationStateService } from "./github-app-installation-state.service";
 import { GithubWebhooksController } from "./github-webhooks.controller";
+import { GitlabCloudIntegrationClient } from "./gitlab-cloud-integration.client";
 import { IntegrationsController } from "./integrations.controller";
 import { RepositoryBindingsController } from "./repository-bindings.controller";
 import { ScanRequestsController } from "./scan-requests.controller";
@@ -21,12 +22,14 @@ import { ScanRequestsController } from "./scan-requests.controller";
   providers: [
     ControlPlaneService,
     GithubAppInstallationClient,
-    GithubAppInstallationStateService
+    GithubAppInstallationStateService,
+    GitlabCloudIntegrationClient
   ],
   exports: [
     ControlPlaneService,
     GithubAppInstallationClient,
-    GithubAppInstallationStateService
+    GithubAppInstallationStateService,
+    GitlabCloudIntegrationClient
   ]
 })
 export class ControlPlaneModule {}

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -19,6 +19,7 @@ import type {
 } from "./control-plane.types";
 import { GithubAppInstallationClient } from "./github-app-installation.client";
 import { GithubAppInstallationStateService } from "./github-app-installation-state.service";
+import { GitlabCloudIntegrationClient } from "./gitlab-cloud-integration.client";
 
 @Injectable()
 export class ControlPlaneService {
@@ -32,7 +33,8 @@ export class ControlPlaneService {
 
   constructor(
     private readonly githubAppInstallationClient: GithubAppInstallationClient,
-    private readonly githubAppInstallationState: GithubAppInstallationStateService
+    private readonly githubAppInstallationState: GithubAppInstallationStateService,
+    private readonly gitlabCloudIntegrationClient: GitlabCloudIntegrationClient
   ) {}
 
   async installGithubAppIntegration(input: InstallIntegrationInput): Promise<ControlPlaneIntegration> {
@@ -54,6 +56,27 @@ export class ControlPlaneService {
     await this.githubAppInstallationState.persistInstallation(integration, repositories);
 
     return integration;
+  }
+
+  async installGitlabCloudIntegration(input: InstallIntegrationInput): Promise<ControlPlaneIntegration> {
+    const repositories =
+      input.repositories ??
+      (await this.gitlabCloudIntegrationClient.listIntegrationRepositories(
+        input.externalInstallationId,
+        input.runtimeAccessToken
+      ));
+
+    return this.installIntegration(
+      {
+        ...input,
+        repositories,
+        runtimeAccessToken: undefined
+      },
+      {
+        provider: "GITLAB",
+        integrationType: "GITLAB_CLOUD_INTEGRATION"
+      }
+    );
   }
 
   installIntegration(

--- a/apps/api/src/control-plane/control-plane.types.ts
+++ b/apps/api/src/control-plane/control-plane.types.ts
@@ -53,6 +53,7 @@ export interface InstallIntegrationInput {
   commentWritePrincipalId?: string;
   integrationAdminPrincipalId?: string;
   repositories?: InstallRepositoryInput[];
+  runtimeAccessToken?: string;
 }
 
 export interface CreateScanRequestInput {

--- a/apps/api/src/control-plane/gitlab-cloud-integration.client.ts
+++ b/apps/api/src/control-plane/gitlab-cloud-integration.client.ts
@@ -1,0 +1,77 @@
+import { HttpService } from "@nestjs/axios";
+import { Injectable, ServiceUnavailableException } from "@nestjs/common";
+import { firstValueFrom } from "rxjs";
+
+import { ConfigService } from "../config/config.service";
+import type { InstallRepositoryInput } from "./control-plane.types";
+
+interface GitlabProjectResponse {
+  id: number;
+  path_with_namespace: string;
+  default_branch: string | null;
+  visibility: string;
+}
+
+@Injectable()
+export class GitlabCloudIntegrationClient {
+  constructor(
+    private readonly http: HttpService,
+    private readonly config: ConfigService
+  ) {}
+
+  async listIntegrationRepositories(
+    externalInstallationId: string,
+    runtimeAccessToken: string | undefined
+  ): Promise<InstallRepositoryInput[]> {
+    const response = await firstValueFrom(
+      this.http.get<GitlabProjectResponse[]>(`${this.baseUrl}/projects`, {
+        headers: this.buildHeaders(
+          this.requireString(runtimeAccessToken, "GitLab runtime access token is required")
+        ),
+        params: {
+          membership: true,
+          order_by: "updated_at",
+          sort: "desc",
+          per_page: 100,
+          ...this.scopeParams(externalInstallationId)
+        }
+      })
+    );
+
+    return response.data.map((project) => ({
+      providerRepoId: String(project.id),
+      fullName: project.path_with_namespace,
+      defaultBranch: this.requireString(
+        project.default_branch,
+        `GitLab project ${project.path_with_namespace} is missing a default branch`
+      ),
+      isPrivate: project.visibility !== "public"
+    }));
+  }
+
+  private get baseUrl(): string {
+    return this.config.get("GITLAB_API_BASE_URL").replace(/\/$/, "");
+  }
+
+  private buildHeaders(runtimeAccessToken: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${runtimeAccessToken}`
+    };
+  }
+
+  private scopeParams(externalInstallationId: string): Record<string, string> {
+    if (externalInstallationId.startsWith("group:")) {
+      return { namespace: externalInstallationId.slice("group:".length) };
+    }
+
+    return {};
+  }
+
+  private requireString(value: string | null | undefined, message: string): string {
+    if (!value) {
+      throw new ServiceUnavailableException(message);
+    }
+
+    return value;
+  }
+}

--- a/apps/api/src/control-plane/integrations.controller.ts
+++ b/apps/api/src/control-plane/integrations.controller.ts
@@ -14,10 +14,7 @@ export class IntegrationsController {
 
   @Post("gitlab/install")
   installGitlab(@Body() body: InstallIntegrationInput) {
-    return this.controlPlaneService.installIntegration(body, {
-      provider: "GITLAB",
-      integrationType: "GITLAB_CLOUD_INTEGRATION"
-    });
+    return this.controlPlaneService.installGitlabCloudIntegration(body);
   }
 
   @Get()

--- a/apps/api/test/control-plane/control-plane.e2e-spec.ts
+++ b/apps/api/test/control-plane/control-plane.e2e-spec.ts
@@ -15,6 +15,9 @@ describe("Control Plane skeleton (e2e)", () => {
     repositoryBinding: { upsert: jest.Mock; deleteMany: jest.Mock };
     auditEvent: { create: jest.Mock };
   };
+  let gitlabCloudIntegrationClientMock: {
+    listIntegrationRepositories: jest.Mock;
+  };
 
   beforeAll(async () => {
     process.env.NODE_ENV = "test";
@@ -32,9 +35,15 @@ describe("Control Plane skeleton (e2e)", () => {
     process.env.TOKEN_ENCRYPTION_KEY =
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-    const [{ AppModule }, { GithubAppInstallationClient }, { PrismaService }] = await Promise.all([
+    const [
+      { AppModule },
+      { GithubAppInstallationClient },
+      { GitlabCloudIntegrationClient },
+      { PrismaService }
+    ] = await Promise.all([
       import("../../src/app.module"),
       import("../../src/control-plane/github-app-installation.client"),
+      import("../../src/control-plane/gitlab-cloud-integration.client"),
       import("../../src/prisma/prisma.service")
     ]);
 
@@ -51,6 +60,16 @@ describe("Control Plane skeleton (e2e)", () => {
         deleteMany: jest.fn().mockResolvedValue({ count: 1 })
       },
       auditEvent: { create: jest.fn().mockResolvedValue({}) }
+    };
+    gitlabCloudIntegrationClientMock = {
+      listIntegrationRepositories: jest.fn().mockResolvedValue([
+        {
+          providerRepoId: "7007",
+          fullName: "acme/gitlab-runtime",
+          defaultBranch: "main",
+          isPrivate: true
+        }
+      ])
     };
 
     const moduleRef = await Test.createTestingModule({
@@ -69,6 +88,8 @@ describe("Control Plane skeleton (e2e)", () => {
           }
         ])
       })
+      .overrideProvider(GitlabCloudIntegrationClient)
+      .useValue(gitlabCloudIntegrationClientMock)
       .compile();
 
     app = moduleRef.createNestApplication();
@@ -97,6 +118,7 @@ describe("Control Plane skeleton (e2e)", () => {
     prismaMock.repositoryBinding.upsert.mockClear();
     prismaMock.repositoryBinding.deleteMany.mockClear();
     prismaMock.auditEvent.create.mockClear();
+    gitlabCloudIntegrationClientMock.listIntegrationRepositories.mockClear();
   });
 
   it("installs a GitHub App integration and exposes tenant-scoped repository bindings", async () => {
@@ -333,6 +355,51 @@ describe("Control Plane skeleton (e2e)", () => {
       })
     );
     expect(JSON.stringify(webhook.body)).not.toMatch(/accessToken|installation-token|secretValue|tokenValue/i);
+  });
+
+  it("loads GitLab Cloud integration repositories when install payload omits repository bindings", async () => {
+    const install = await request(app.getHttpServer())
+      .post("/api/integrations/gitlab/install")
+      .send({
+        tenantId: "tenant_gitlab_cloud",
+        externalInstallationId: "group:acme",
+        repoReadPrincipalId: "gitlab-cloud:group:acme:repo-read",
+        commentWritePrincipalId: "gitlab-cloud:group:acme:comment-write",
+        runtimeAccessToken: "gitlab-runtime-token"
+      })
+      .expect(201);
+
+    const installData = dataOf<Record<string, unknown>>(install.body);
+
+    expect(gitlabCloudIntegrationClientMock.listIntegrationRepositories).toHaveBeenCalledWith(
+      "group:acme",
+      "gitlab-runtime-token"
+    );
+    expect(installData).toMatchObject({
+      provider: "GITLAB",
+      integrationType: "GITLAB_CLOUD_INTEGRATION",
+      tenantId: "tenant_gitlab_cloud",
+      externalInstallationId: "group:acme",
+      status: "ACTIVE"
+    });
+    expect(JSON.stringify(installData)).not.toMatch(/runtimeAccessToken|gitlab-runtime-token|tokenValue|secretValue/i);
+
+    const repositories = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_gitlab_cloud" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(repositories.body)).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant_gitlab_cloud",
+        scmIntegrationId: installData.id,
+        providerRepoId: "7007",
+        fullName: "acme/gitlab-runtime",
+        defaultBranch: "main",
+        isPrivate: true
+      })
+    ]);
+    expect(JSON.stringify(repositories.body)).not.toMatch(/runtimeAccessToken|gitlab-runtime-token|tokenValue|secretValue/i);
   });
 
   it("creates scan requests with canonical keys and risk-based isolation escalation", async () => {

--- a/apps/api/test/control-plane/gitlab-cloud-integration.client.e2e-spec.ts
+++ b/apps/api/test/control-plane/gitlab-cloud-integration.client.e2e-spec.ts
@@ -1,0 +1,92 @@
+import { HttpService } from "@nestjs/axios";
+import { ServiceUnavailableException } from "@nestjs/common";
+import type { AxiosResponse } from "axios";
+import { of } from "rxjs";
+
+import { GitlabCloudIntegrationClient } from "../../src/control-plane/gitlab-cloud-integration.client";
+
+describe("GitlabCloudIntegrationClient", () => {
+  it("lists GitLab Cloud integration repositories with a runtime-only token", async () => {
+    const http = createHttpService();
+    http.get.mockReturnValueOnce(
+      of(
+        createAxiosResponse([
+          {
+            id: 7007,
+            path_with_namespace: "acme/gitlab-runtime",
+            default_branch: "main",
+            visibility: "private"
+          }
+        ])
+      )
+    );
+    const client = new GitlabCloudIntegrationClient(
+      http as never,
+      createConfigService("https://gitlab.example/api/v4") as never
+    );
+
+    await expect(client.listIntegrationRepositories("group:acme", "gitlab-runtime-token")).resolves.toEqual([
+      {
+        providerRepoId: "7007",
+        fullName: "acme/gitlab-runtime",
+        defaultBranch: "main",
+        isPrivate: true
+      }
+    ]);
+
+    expect(http.get).toHaveBeenCalledWith(
+      "https://gitlab.example/api/v4/projects",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer gitlab-runtime-token"
+        },
+        params: expect.objectContaining({
+          membership: true,
+          namespace: "acme",
+          per_page: 100
+        })
+      })
+    );
+  });
+
+  it("rejects repository listing when the runtime access token is absent", async () => {
+    const client = new GitlabCloudIntegrationClient(
+      createHttpService() as never,
+      createConfigService("https://gitlab.example/api/v4") as never
+    );
+
+    await expect(client.listIntegrationRepositories("group:acme", undefined)).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+  });
+});
+
+function createHttpService(): Pick<HttpService, "get"> & {
+  get: jest.Mock;
+} {
+  return {
+    get: jest.fn()
+  };
+}
+
+function createConfigService(baseUrl: string) {
+  return {
+    get: (key: string) => {
+      if (key === "GITLAB_API_BASE_URL") {
+        return baseUrl;
+      }
+
+      throw new Error(`Unexpected config key: ${key}`);
+    }
+  };
+}
+
+function createAxiosResponse<T>(data: T): AxiosResponse<T> {
+  return {
+    data,
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: { headers: undefined as never }
+  };
+}

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -59,6 +59,14 @@ records. The Control Plane may acknowledge GitHub `installation_repositories` we
 reconcile repository additions/removals into repository bindings. Webhook acknowledgements
 must not include or persist GitHub App installation token values.
 
+## GitLab Cloud Integration Runtime
+
+GitLab Cloud repository access is modeled through project/group integration metadata and
+webhook flows. The Control Plane may use a runtime-only GitLab access token to list
+accessible projects and create repository bindings for a tenant-scoped
+`GITLAB_CLOUD_INTEGRATION`. GitLab runtime token values must not be returned by public APIs,
+stored in integration records, repository bindings, or logs.
+
 ## Scan Plane Boundary
 
 Scan Plane accepts scan-scoped repository access and emits scanner runs, raw artifact

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -62,9 +62,15 @@
 - [x] T034 Reconcile GitHub installation repository added/removed events into repository bindings
 - [x] T035 Add e2e coverage for installation persistence, webhook reconciliation, and token leakage guardrails
 
+## Phase 10: GitLab Cloud Integration Runtime Slice
+
+- [x] T036 Add GitLab Cloud integration client for runtime token repository listing
+- [x] T037 Allow GitLab install endpoint to build repository bindings from GitLab project metadata
+- [x] T038 Add GitLab runtime configuration placeholder without persisting runtime token values
+- [x] T039 Add e2e coverage for GitLab repository binding and runtime token leakage guardrails
+
 ## Deferred
 
-- [ ] Implement GitLab Cloud integration runtime
 - [ ] Implement Token Broker credential issuance
 - [ ] Implement Opengrep/Trivy/Syft sandbox execution
 - [ ] Implement evidence object storage and TTL deletion


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/135-gitlab-cloud-integration-runtime`
- 이슈: #135

## 주요 변경 사항

- GitLab Cloud integration runtime client를 추가해 runtime-only token으로 project metadata를 조회합니다.
- GitLab install endpoint가 repositories를 생략하면 GitLab project metadata로 repository binding을 생성합니다.
- `GITLAB_API_BASE_URL` configuration placeholder와 env example을 추가했습니다.
- GitLab runtime token이 public API response나 repository binding에 노출되지 않도록 e2e guardrail을 추가했습니다.
- `specs/002-production-scan-architecture` contract/tasks 문서를 Phase 10 상태로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명은 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지는 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab Cloud integration installation support, enabling users to install GitLab Cloud integrations and automatically enumerate accessible repositories for binding.
  * Implemented secure runtime token handling that ensures access tokens are never persisted or exposed in API responses.

* **Tests**
  * Added end-to-end tests for GitLab Cloud integration installation and repository enumeration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->