### PR TITLE
feat: issue short-lived Token Broker credentials

### DIFF
--- a/apps/api/src/token-broker/token-broker.module.ts
+++ b/apps/api/src/token-broker/token-broker.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
 
 import { AuditEventsController } from "./audit-events.controller";
+import { TokenCredentialIssuerService } from "./token-credential-issuer.service";
 import { TokenBrokerController } from "./token-broker.controller";
 import { TokenBrokerService } from "./token-broker.service";
 
 @Module({
   controllers: [TokenBrokerController, AuditEventsController],
-  providers: [TokenBrokerService]
+  providers: [TokenBrokerService, TokenCredentialIssuerService]
 })
 export class TokenBrokerModule {}

--- a/apps/api/src/token-broker/token-broker.service.ts
+++ b/apps/api/src/token-broker/token-broker.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import type { TokenBrokerIssueRequest } from "../../../../packages/shared/src";
 
+import { TokenCredentialIssuerService } from "./token-credential-issuer.service";
 import type { TokenBrokerAuditEvent, TokenBrokerIssueResponse } from "./token-broker.types";
 
 @Injectable()
@@ -9,10 +10,14 @@ export class TokenBrokerService {
   private credentialSequence = 0;
   private auditSequence = 0;
 
+  constructor(private readonly tokenCredentialIssuer: TokenCredentialIssuerService) {}
+
   issue(input: TokenBrokerIssueRequest): TokenBrokerIssueResponse {
+    const issuedCredential = this.tokenCredentialIssuer.issue(input);
     const response: TokenBrokerIssueResponse = {
       ...input,
       credentialId: `credential_${++this.credentialSequence}`,
+      ...issuedCredential,
       expiresInSeconds: input.ttlSeconds,
       auditEventType: "token.issued"
     };

--- a/apps/api/src/token-broker/token-broker.types.ts
+++ b/apps/api/src/token-broker/token-broker.types.ts
@@ -2,6 +2,10 @@ import type { AuditEvent, ScmPrincipal, TokenBrokerIssueRequest } from "../../..
 
 export interface TokenBrokerIssueResponse extends TokenBrokerIssueRequest {
   credentialId: string;
+  credentialType: "SCM_REPOSITORY_ACCESS";
+  credentialValue: string;
+  issuedAt: string;
+  expiresAt: string;
   expiresInSeconds: number;
   auditEventType: "token.issued";
 }

--- a/apps/api/src/token-broker/token-credential-issuer.service.ts
+++ b/apps/api/src/token-broker/token-credential-issuer.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@nestjs/common";
+import { randomBytes } from "node:crypto";
+import type { TokenBrokerIssueRequest } from "../../../../packages/shared/src";
+
+export interface IssuedTokenCredential {
+  credentialType: "SCM_REPOSITORY_ACCESS";
+  credentialValue: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+@Injectable()
+export class TokenCredentialIssuerService {
+  issue(input: TokenBrokerIssueRequest): IssuedTokenCredential {
+    const issuedAt = new Date();
+    const expiresAt = new Date(issuedAt.getTime() + input.ttlSeconds * 1000);
+
+    return {
+      credentialType: "SCM_REPOSITORY_ACCESS",
+      credentialValue: this.buildCredentialValue(input),
+      issuedAt: issuedAt.toISOString(),
+      expiresAt: expiresAt.toISOString()
+    };
+  }
+
+  private buildCredentialValue(input: TokenBrokerIssueRequest): string {
+    const randomPart = randomBytes(24).toString("base64url");
+    const scopePart = Buffer.from(
+      [
+        input.tenantId,
+        input.repositoryBindingId,
+        input.scanRequestId,
+        input.commitSha,
+        input.principal
+      ].join(":")
+    ).toString("base64url");
+
+    return `aegis_tb_${scopePart}.${randomPart}`;
+  }
+}

--- a/apps/api/test/token-broker/token-broker.e2e-spec.ts
+++ b/apps/api/test/token-broker/token-broker.e2e-spec.ts
@@ -59,7 +59,7 @@ describe("Token Broker and audit skeleton (e2e)", () => {
     return body as T;
   };
 
-  it("issues scan-scoped credential metadata without returning token values", async () => {
+  it("issues scan-scoped short-lived credential values without persisting them", async () => {
     const response = await request(app.getHttpServer())
       .post("/api/token-broker/issue")
       .send({
@@ -83,10 +83,32 @@ describe("Token Broker and audit skeleton (e2e)", () => {
       commitSha: "abc123",
       ttlSeconds: 600,
       expiresInSeconds: 600,
-      auditEventType: "token.issued"
+      auditEventType: "token.issued",
+      credentialType: "SCM_REPOSITORY_ACCESS"
     });
     expect(responseData.credentialId).toMatch(/^credential_/);
-    expect(JSON.stringify(responseData)).not.toMatch(/tokenValue|secretValue|accessToken|refreshToken/i);
+    expect(responseData.credentialValue).toMatch(/^aegis_tb_/);
+    expect(new Date(responseData.issuedAt as string).toISOString()).toBe(responseData.issuedAt);
+    expect(new Date(responseData.expiresAt as string).getTime()).toBeGreaterThan(
+      new Date(responseData.issuedAt as string).getTime()
+    );
+
+    const secondResponse = await request(app.getHttpServer())
+      .post("/api/token-broker/issue")
+      .send({
+        tenantId: "tenant_gamma",
+        repositoryBindingId: "repository_binding_1",
+        scanRequestId: "scan_request_1",
+        principal: "REPO_READ",
+        commitSha: "abc123",
+        ttlSeconds: 600,
+        auditReason: "scan-fetch"
+      })
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(secondResponse.body).credentialValue).not.toBe(
+      responseData.credentialValue
+    );
   });
 
   it("records tenant-scoped audit events for token issuance", async () => {
@@ -126,6 +148,8 @@ describe("Token Broker and audit skeleton (e2e)", () => {
         })
       })
     ]);
-    expect(JSON.stringify(auditData)).not.toMatch(/tokenValue|secretValue|accessToken|refreshToken/i);
+    expect(JSON.stringify(auditData)).not.toMatch(
+      /credentialValue|aegis_tb_|tokenValue|secretValue|accessToken|refreshToken/i
+    );
   });
 });

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -47,6 +47,11 @@ Token Broker issue requests are tenant, repository, and scan scoped. The request
 include a principal, fixed commit SHA, TTL, and audit reason. The token value itself must
 not be persisted or logged.
 
+Token Broker issue responses may include a short-lived `SCM_REPOSITORY_ACCESS` credential
+value for the immediate caller. Credential values are tenant/repository/scan/commit scoped,
+expire according to the requested TTL, and must never appear in audit events or persisted
+records.
+
 ## GitHub App Installation Runtime
 
 GitHub Cloud repository access is modeled through a GitHub App installation principal.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -69,9 +69,15 @@
 - [x] T038 Add GitLab runtime configuration placeholder without persisting runtime token values
 - [x] T039 Add e2e coverage for GitLab repository binding and runtime token leakage guardrails
 
+## Phase 11: Token Broker Credential Issuance Slice
+
+- [x] T040 Add scan-scoped short-lived credential value issuance
+- [x] T041 Return credential value only to the Token Broker issue caller with explicit expiration metadata
+- [x] T042 Keep token values out of tenant-scoped audit events
+- [x] T043 Add e2e coverage for unique credential values and audit leakage guardrails
+
 ## Deferred
 
-- [ ] Implement Token Broker credential issuance
 - [ ] Implement Opengrep/Trivy/Syft sandbox execution
 - [ ] Implement evidence object storage and TTL deletion
 - [ ] Implement policy-as-code engine


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/137-token-broker-credential-issuance`
- 이슈: #137

## 주요 변경 사항

- Token Broker가 scan-scoped short-lived `SCM_REPOSITORY_ACCESS` credential value를 발급합니다.
- credential response에 `issuedAt`, `expiresAt`, `expiresInSeconds`, `credentialType` metadata를 추가했습니다.
- credential value는 caller 응답에만 포함되고 audit event에는 저장되지 않도록 guardrail을 유지했습니다.
- `specs/002-production-scan-architecture` contract/tasks 문서를 Phase 11 상태로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명은 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지는 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`