### PR TITLE
feat: 정책 엔진 결정 골격 구현

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { DashboardModule } from './dashboard/dashboard.module';
 import { HealthModule } from './health/health.module';
 import { LanguageModule } from './language/language.module';
 import { ObservabilityModule } from './observability/observability.module';
+import { PolicyModule } from './policy/policy.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { ReportModule } from './report/report.module';
 import { RepoModule } from './repo/repo.module';
@@ -58,6 +59,7 @@ const runtimeFeatureModules = [ScanModule, HealthModule, ReportModule];
     ControlPlaneModule,
     TokenBrokerModule,
     ScanPlaneModule,
+    PolicyModule,
     GitClientModule,
     LanguageModule,
     AnalysisApiModule,

--- a/apps/api/src/policy/policy-decisions.controller.ts
+++ b/apps/api/src/policy/policy-decisions.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+
+import type { PolicyEvaluationInput } from "../../../../packages/shared/src";
+import { PolicyEngineService } from "./policy-engine.service";
+
+@Controller("policy-decisions")
+export class PolicyDecisionsController {
+  constructor(private readonly policyEngineService: PolicyEngineService) {}
+
+  @Post("evaluate")
+  evaluate(@Body() body: PolicyEvaluationInput) {
+    return this.policyEngineService.evaluate(body);
+  }
+
+  @Get(":policyDecisionId")
+  read(@Param("policyDecisionId") policyDecisionId: string, @Query("tenantId") tenantId: string) {
+    return this.policyEngineService.getPolicyDecision(tenantId, policyDecisionId);
+  }
+}

--- a/apps/api/src/policy/policy-engine.service.ts
+++ b/apps/api/src/policy/policy-engine.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+
+import type {
+  PolicyDecision,
+  PolicyEvaluationInput,
+  ScannerKind
+} from "../../../../packages/shared/src";
+
+const REQUIRED_SCANNER_COVERAGE: ScannerKind[] = ["OPENGREP", "TRIVY", "SYFT"];
+
+@Injectable()
+export class PolicyEngineService {
+  private readonly policyDecisions: PolicyDecision[] = [];
+  private decisionSequence = 0;
+
+  evaluate(input: PolicyEvaluationInput): PolicyDecision {
+    const reasonCodes = this.reasonCodesFor(input);
+    const enforcementAction = this.enforcementActionFor(input);
+    const decision: PolicyDecision = {
+      id: `policy_decision_${++this.decisionSequence}`,
+      tenantId: input.tenantId,
+      scanRequestId: input.scanRequestId,
+      findingId: input.finding.id,
+      enforcementAction,
+      commentAllowed: enforcementAction !== "DASHBOARD_ONLY",
+      dashboardVisible: true,
+      ticketRequested: enforcementAction === "BLOCK",
+      blockRequested: enforcementAction === "BLOCK",
+      reasonCodes,
+      requiredCoverage: REQUIRED_SCANNER_COVERAGE,
+      waiverApplied: false,
+      staleSuppressed: false,
+      aiAdvisoryVisible: input.aiAdvisory?.visible === true
+    };
+
+    this.policyDecisions.push(decision);
+
+    return decision;
+  }
+
+  getPolicyDecision(tenantId: string, policyDecisionId: string): PolicyDecision {
+    const decision = this.policyDecisions.find(
+      (policyDecision) =>
+        policyDecision.id === policyDecisionId && policyDecision.tenantId === tenantId
+    );
+
+    if (!decision) {
+      throw new NotFoundException("Policy decision was not found for tenant.");
+    }
+
+    return decision;
+  }
+
+  private enforcementActionFor(input: PolicyEvaluationInput): PolicyDecision["enforcementAction"] {
+    if (input.finding.severity === "CRITICAL") {
+      return "BLOCK";
+    }
+
+    if (input.finding.severity === "HIGH") {
+      return "WARN";
+    }
+
+    if (input.finding.severity === "MEDIUM") {
+      return "COMMENT";
+    }
+
+    return "DASHBOARD_ONLY";
+  }
+
+  private reasonCodesFor(input: PolicyEvaluationInput): string[] {
+    const reasonCodes = [`SEVERITY_${input.finding.severity}`];
+    const hasRequiredCoverage = REQUIRED_SCANNER_COVERAGE.every((scanner) =>
+      input.scannerCoverage.includes(scanner)
+    );
+
+    if (input.scanLane === "DEEP" && !hasRequiredCoverage) {
+      reasonCodes.push("MISSING_REQUIRED_SCANNER_COVERAGE");
+    }
+
+    return reasonCodes;
+  }
+}

--- a/apps/api/src/policy/policy.module.ts
+++ b/apps/api/src/policy/policy.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+
+import { PolicyDecisionsController } from "./policy-decisions.controller";
+import { PolicyEngineService } from "./policy-engine.service";
+
+@Module({
+  controllers: [PolicyDecisionsController],
+  providers: [PolicyEngineService],
+  exports: [PolicyEngineService]
+})
+export class PolicyModule {}

--- a/apps/api/test/policy/policy-decisions.e2e-spec.ts
+++ b/apps/api/test/policy/policy-decisions.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+
+describe("Policy decision API (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.PORT = "3000";
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/aegisai";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env.SESSION_SECRET = "test-session-secret-value";
+    process.env.CSRF_SECRET = "test-csrf-secret-value";
+    process.env.GITHUB_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_CLIENT_SECRET = "github-client-secret";
+    process.env.GITLAB_CLIENT_ID = "gitlab-client-id";
+    process.env.GITLAB_CLIENT_SECRET = "gitlab-client-secret";
+    process.env.APP_URL = "http://localhost:3000";
+    process.env.FRONTEND_URL = "http://localhost:5173";
+    process.env.TOKEN_ENCRYPTION_KEY =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    const [{ AppModule }, { PrismaService }] = await Promise.all([
+      import("../../src/app.module"),
+      import("../../src/prisma/prisma.service")
+    ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix("api");
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  const dataOf = <T>(body: { data?: T } | T): T => {
+    if (body && typeof body === "object" && "data" in body) {
+      return (body as { data: T }).data;
+    }
+
+    return body as T;
+  };
+
+  it("evaluates and reads tenant-scoped policy decisions without credential or AI override leakage", async () => {
+    const evaluate = await request(app.getHttpServer())
+      .post("/api/policy-decisions/evaluate")
+      .send({
+        tenantId: "tenant_policy_api",
+        scanRequestId: "scan_request_api_1",
+        scanLane: "DEEP",
+        scannerCoverage: ["OPENGREP"],
+        finding: {
+          id: "finding_api_1",
+          tenantId: "tenant_policy_api",
+          scanRequestId: "scan_request_api_1",
+          scannerRunId: "scanner_run_api_1",
+          title: "Unsafe deserialization",
+          severity: "HIGH",
+          scannerProvenance: "OPENGREP",
+          filePath: "src/App.java",
+          lineStart: 42,
+          status: "OPEN"
+        },
+        aiAdvisory: {
+          visible: true,
+          suggestedAction: "BLOCK",
+          summary: "Advisory context only"
+        }
+      })
+      .expect(201);
+
+    const decision = dataOf<Record<string, unknown>>(evaluate.body);
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant_policy_api",
+        scanRequestId: "scan_request_api_1",
+        findingId: "finding_api_1",
+        enforcementAction: "WARN",
+        aiAdvisoryVisible: true
+      })
+    );
+
+    const read = await request(app.getHttpServer())
+      .get(`/api/policy-decisions/${decision.id}`)
+      .query({ tenantId: "tenant_policy_api" })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(read.body)).toEqual(decision);
+    expect(JSON.stringify({ decision, read: read.body })).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|aiOverride|policyOverride/i
+    );
+  });
+});

--- a/apps/api/test/policy/policy-engine.service.e2e-spec.ts
+++ b/apps/api/test/policy/policy-engine.service.e2e-spec.ts
@@ -1,0 +1,80 @@
+import { PolicyEngineService } from "../../src/policy/policy-engine.service";
+
+import type { NormalizedFinding } from "../../../../packages/shared/src";
+
+describe("PolicyEngineService", () => {
+  const highFinding: NormalizedFinding = {
+    id: "finding_high",
+    tenantId: "tenant_policy",
+    scanRequestId: "scan_request_1",
+    scannerRunId: "scanner_run_1",
+    title: "Unsafe deserialization",
+    severity: "HIGH",
+    scannerProvenance: "OPENGREP",
+    filePath: "src/App.java",
+    lineStart: 42,
+    status: "OPEN"
+  };
+
+  it("creates deterministic policy decisions from scanner findings and coverage", () => {
+    const service = new PolicyEngineService();
+
+    const decision = service.evaluate({
+      tenantId: "tenant_policy",
+      scanRequestId: "scan_request_1",
+      finding: highFinding,
+      scanLane: "DEEP",
+      scannerCoverage: ["OPENGREP"],
+      aiAdvisory: {
+        visible: true,
+        suggestedAction: "BLOCK"
+      }
+    });
+
+    expect(decision).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant_policy",
+        scanRequestId: "scan_request_1",
+        findingId: "finding_high",
+        enforcementAction: "WARN",
+        commentAllowed: true,
+        dashboardVisible: true,
+        ticketRequested: false,
+        blockRequested: false,
+        waiverApplied: false,
+        staleSuppressed: false,
+        aiAdvisoryVisible: true,
+        requiredCoverage: ["OPENGREP", "TRIVY", "SYFT"]
+      })
+    );
+    expect(decision.reasonCodes).toEqual(
+      expect.arrayContaining(["SEVERITY_HIGH", "MISSING_REQUIRED_SCANNER_COVERAGE"])
+    );
+  });
+
+  it("blocks critical scanner findings without using AI as the policy authority", () => {
+    const service = new PolicyEngineService();
+
+    const decision = service.evaluate({
+      tenantId: "tenant_policy",
+      scanRequestId: "scan_request_2",
+      finding: {
+        ...highFinding,
+        id: "finding_critical",
+        scanRequestId: "scan_request_2",
+        severity: "CRITICAL"
+      },
+      scanLane: "FAST",
+      scannerCoverage: ["OPENGREP", "TRIVY", "SYFT"],
+      aiAdvisory: {
+        visible: true,
+        suggestedAction: "DASHBOARD_ONLY"
+      }
+    });
+
+    expect(decision.enforcementAction).toBe("BLOCK");
+    expect(decision.blockRequested).toBe(true);
+    expect(decision.aiAdvisoryVisible).toBe(true);
+    expect(decision.reasonCodes).toEqual(expect.arrayContaining(["SEVERITY_CRITICAL"]));
+  });
+});

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -150,6 +150,19 @@ export interface PolicyDecision {
   aiAdvisoryVisible: boolean;
 }
 
+export interface PolicyEvaluationInput {
+  tenantId: string;
+  scanRequestId: string;
+  finding: NormalizedFinding;
+  scanLane: ScanLane;
+  scannerCoverage: ScannerKind[];
+  aiAdvisory?: {
+    visible: boolean;
+    suggestedAction?: PolicyAction;
+    summary?: string;
+  };
+}
+
 export interface Waiver {
   id: string;
   tenantId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -21,6 +21,7 @@ sandbox, or AI runtime implementation.
 - `GET /api/findings/:findingId`
 - `GET /api/evidence/:evidencePackId`
 - `POST /api/evidence/:evidencePackId/access-requests`
+- `POST /api/policy-decisions/evaluate`
 - `GET /api/policy-decisions/:policyDecisionId`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
@@ -111,3 +112,9 @@ storage and KMS integration remain deferred.
 PolicyDecision is structured. It includes enforcement action, comment allowance, dashboard
 visibility, ticket/block requests, reason codes, required coverage set, waiver application,
 stale suppression, and AI advisory visibility.
+
+Policy evaluation in this milestone is deterministic and scanner-first. It accepts normalized
+finding metadata, scan lane, scanner coverage metadata, and optional AI advisory visibility
+metadata. AI advisory input may be surfaced through `aiAdvisoryVisible`, but suggested AI
+actions must not select or override enforcement action, ticket request, block request, waiver
+state, or stale suppression.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -90,7 +90,13 @@
 - [x] T050 Add TTL deletion task for expired evidence objects
 - [x] T051 Add e2e coverage for evidence storage, TTL deletion, and credential/source leakage guardrails
 
+## Phase 14: Policy Engine Decision Skeleton Slice
+
+- [x] T052 Add deterministic policy engine evaluator for scanner-first findings
+- [x] T053 Add policy decision evaluate and tenant-scoped read endpoints
+- [x] T054 Keep AI advisory metadata visible but non-authoritative for enforcement decisions
+- [x] T055 Add e2e coverage for policy decision shape, coverage requirements, and leakage guardrails
+
 ## Deferred
 
-- [ ] Implement policy-as-code engine
 - [ ] Implement AI detector/planner inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/143-policy-engine-decision-skeleton`
- 이슈: #143

## 주요 변경 사항

- deterministic policy engine evaluator를 추가했습니다.
- `POST /api/policy-decisions/evaluate`와 `GET /api/policy-decisions/:policyDecisionId`를 추가했습니다.
- HIGH/CRITICAL severity와 scanner coverage 기반 PolicyDecision shape를 고정했습니다.
- AI advisory는 표시 metadata로만 반영하고 enforcement override를 하지 않도록 테스트했습니다.
- Phase 14 tasks와 scan architecture contract를 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목이 동일합니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **Label** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 작동하는지 확인하겠습니다.

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`