### PR TITLE
feat: AI 자문 감지 계획 골격 구현

### DIFF
--- a/apps/api/src/ai-plane/ai-advisory.controller.ts
+++ b/apps/api/src/ai-plane/ai-advisory.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+
+import type { AiAdvisoryRequest } from "../../../../packages/shared/src";
+import { AiAdvisoryService } from "./ai-advisory.service";
+
+@Controller("ai-advisories")
+export class AiAdvisoryController {
+  constructor(private readonly aiAdvisoryService: AiAdvisoryService) {}
+
+  @Post()
+  create(@Body() body: AiAdvisoryRequest) {
+    return this.aiAdvisoryService.createAdvisory(body);
+  }
+
+  @Get(":advisoryId")
+  read(@Param("advisoryId") advisoryId: string, @Query("tenantId") tenantId: string) {
+    return this.aiAdvisoryService.getAdvisory(tenantId, advisoryId);
+  }
+}

--- a/apps/api/src/ai-plane/ai-advisory.service.ts
+++ b/apps/api/src/ai-plane/ai-advisory.service.ts
@@ -1,0 +1,101 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+
+import type { AiAdvisoryRequest, AiAdvisoryResult } from "../../../../packages/shared/src";
+
+const FORBIDDEN_AI_INPUT_KEYS = [
+  "accessToken",
+  "refreshToken",
+  "tokenValue",
+  "secretValue",
+  "sourceArchive",
+  "fullRepository",
+  "rawScannerPayload",
+  "policyOverride",
+  "findingOverride"
+];
+
+@Injectable()
+export class AiAdvisoryService {
+  private readonly advisories: AiAdvisoryResult[] = [];
+  private advisorySequence = 0;
+
+  createAdvisory(input: AiAdvisoryRequest): AiAdvisoryResult {
+    this.assertReducedInput(input);
+
+    const advisory: AiAdvisoryResult = {
+      id: `ai_advisory_${++this.advisorySequence}`,
+      tenantId: input.tenantId,
+      scanRequestId: input.scanRequestId,
+      findingId: input.findingId,
+      modelVersion: input.modelVersion,
+      advisoryOnly: true,
+      redactedEvidenceOnly: true,
+      detectorSignals: this.detectorSignalsFor(input),
+      plannerSteps: this.plannerStepsFor(input),
+      confidence: this.confidenceFor(input),
+      createdAt: new Date().toISOString()
+    };
+
+    this.advisories.push(advisory);
+
+    return advisory;
+  }
+
+  getAdvisory(tenantId: string, advisoryId: string): AiAdvisoryResult {
+    const advisory = this.advisories.find(
+      (candidate) => candidate.id === advisoryId && candidate.tenantId === tenantId
+    );
+
+    if (!advisory) {
+      throw new NotFoundException("AI advisory was not found for tenant.");
+    }
+
+    return advisory;
+  }
+
+  private assertReducedInput(input: AiAdvisoryRequest): void {
+    if (!input.evidence.redacted) {
+      throw new BadRequestException("AI advisory input must use redacted evidence.");
+    }
+
+    const serialized = JSON.stringify(input);
+
+    for (const forbiddenKey of FORBIDDEN_AI_INPUT_KEYS) {
+      if (new RegExp(forbiddenKey, "i").test(serialized)) {
+        throw new BadRequestException("AI advisory input contains forbidden sensitive content.");
+      }
+    }
+  }
+
+  private detectorSignalsFor(input: AiAdvisoryRequest): string[] {
+    return [
+      "SCANNER_CONFIRMED",
+      `SEVERITY_${input.normalizedFinding.severity}`,
+      `PROVENANCE_${input.normalizedFinding.scannerProvenance}`
+    ];
+  }
+
+  private plannerStepsFor(input: AiAdvisoryRequest): string[] {
+    const steps = ["Review scanner evidence before remediation."];
+
+    if (input.normalizedFinding.severity === "CRITICAL" || input.normalizedFinding.severity === "HIGH") {
+      steps.push("Prioritize owner review before merging affected changes.");
+    }
+
+    steps.push("Apply remediation outside the AI advisory boundary.");
+
+    return steps;
+  }
+
+  private confidenceFor(input: AiAdvisoryRequest): number {
+    if (input.normalizedFinding.severity === "CRITICAL") {
+      return 0.82;
+    }
+
+    if (input.normalizedFinding.severity === "HIGH") {
+      return 0.74;
+    }
+
+    return 0.61;
+  }
+}

--- a/apps/api/src/ai-plane/ai-plane.module.ts
+++ b/apps/api/src/ai-plane/ai-plane.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+
+import { AiAdvisoryController } from "./ai-advisory.controller";
+import { AiAdvisoryService } from "./ai-advisory.service";
+
+@Module({
+  controllers: [AiAdvisoryController],
+  providers: [AiAdvisoryService],
+  exports: [AiAdvisoryService]
+})
+export class AiPlaneModule {}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { ThrottlerModule, seconds } from '@nestjs/throttler';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AiPlaneModule } from './ai-plane/ai-plane.module';
 import { AuthModule } from './auth/auth.module';
 import { AnalysisApiModule } from './client/analysis/analysis-api.module';
 import { GitClientModule } from './client/git/git-client.module';
@@ -60,6 +61,7 @@ const runtimeFeatureModules = [ScanModule, HealthModule, ReportModule];
     TokenBrokerModule,
     ScanPlaneModule,
     PolicyModule,
+    AiPlaneModule,
     GitClientModule,
     LanguageModule,
     AnalysisApiModule,

--- a/apps/api/test/ai-plane/ai-advisory.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory.e2e-spec.ts
@@ -1,0 +1,117 @@
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+
+describe("AI advisory API (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.PORT = "3000";
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/aegisai";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env.SESSION_SECRET = "test-session-secret-value";
+    process.env.CSRF_SECRET = "test-csrf-secret-value";
+    process.env.GITHUB_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_CLIENT_SECRET = "github-client-secret";
+    process.env.GITLAB_CLIENT_ID = "gitlab-client-id";
+    process.env.GITLAB_CLIENT_SECRET = "gitlab-client-secret";
+    process.env.APP_URL = "http://localhost:3000";
+    process.env.FRONTEND_URL = "http://localhost:5173";
+    process.env.TOKEN_ENCRYPTION_KEY =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    const [{ AppModule }, { PrismaService }] = await Promise.all([
+      import("../../src/app.module"),
+      import("../../src/prisma/prisma.service")
+    ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix("api");
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  const dataOf = <T>(body: { data?: T } | T): T => {
+    if (body && typeof body === "object" && "data" in body) {
+      return (body as { data: T }).data;
+    }
+
+    return body as T;
+  };
+
+  it("creates and reads advisory-only AI output without source, credential, finding, or policy authority", async () => {
+    const create = await request(app.getHttpServer())
+      .post("/api/ai-advisories")
+      .send({
+        tenantId: "tenant_ai_api",
+        scanRequestId: "scan_request_ai_1",
+        findingId: "finding_ai_1",
+        normalizedFinding: {
+          id: "finding_ai_1",
+          tenantId: "tenant_ai_api",
+          scanRequestId: "scan_request_ai_1",
+          scannerRunId: "scanner_run_ai_1",
+          title: "Unsafe deserialization",
+          severity: "HIGH",
+          scannerProvenance: "OPENGREP",
+          filePath: "src/App.java",
+          lineStart: 42,
+          status: "OPEN"
+        },
+        evidence: {
+          id: "evidence_ai_1",
+          tenantId: "tenant_ai_api",
+          scanRequestId: "scan_request_ai_1",
+          classification: "SHORT_LIVED_EVIDENCE",
+          objectKey: "tenant_ai_api/scan_request_ai_1/evidence/evidence_ai_1.json",
+          expiresAt: "2026-04-19T00:00:00.000Z",
+          byteSize: 512,
+          redacted: true
+        },
+        modelVersion: "detector-planner-mock-v1"
+      })
+      .expect(201);
+
+    const advisory = dataOf<Record<string, unknown>>(create.body);
+
+    expect(advisory).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant_ai_api",
+        scanRequestId: "scan_request_ai_1",
+        findingId: "finding_ai_1",
+        advisoryOnly: true,
+        redactedEvidenceOnly: true
+      })
+    );
+
+    const read = await request(app.getHttpServer())
+      .get(`/api/ai-advisories/${advisory.id}`)
+      .query({ tenantId: "tenant_ai_api" })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(read.body)).toEqual(advisory);
+    expect(JSON.stringify({ advisory, read: read.body })).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload/i
+    );
+  });
+});

--- a/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
@@ -1,0 +1,81 @@
+import { AiAdvisoryService } from "../../src/ai-plane/ai-advisory.service";
+
+import type { AiAdvisoryRequest } from "../../../../packages/shared/src";
+
+describe("AiAdvisoryService", () => {
+  const request: AiAdvisoryRequest = {
+    tenantId: "tenant_ai",
+    scanRequestId: "scan_request_1",
+    findingId: "finding_1",
+    normalizedFinding: {
+      id: "finding_1",
+      tenantId: "tenant_ai",
+      scanRequestId: "scan_request_1",
+      scannerRunId: "scanner_run_1",
+      title: "Unsafe deserialization",
+      severity: "HIGH",
+      scannerProvenance: "OPENGREP",
+      filePath: "src/App.java",
+      lineStart: 42,
+      status: "OPEN"
+    },
+    evidence: {
+      id: "evidence_1",
+      tenantId: "tenant_ai",
+      scanRequestId: "scan_request_1",
+      classification: "SHORT_LIVED_EVIDENCE",
+      objectKey: "tenant_ai/scan_request_1/evidence/evidence_1.json",
+      expiresAt: "2026-04-19T00:00:00.000Z",
+      byteSize: 512,
+      redacted: true
+    },
+    modelVersion: "detector-planner-mock-v1"
+  };
+
+  it("creates advisory-only detector planner output from normalized findings and redacted evidence", () => {
+    const service = new AiAdvisoryService();
+
+    const advisory = service.createAdvisory(request);
+
+    expect(advisory).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant_ai",
+        scanRequestId: "scan_request_1",
+        findingId: "finding_1",
+        modelVersion: "detector-planner-mock-v1",
+        advisoryOnly: true,
+        redactedEvidenceOnly: true,
+        confidence: expect.any(Number)
+      })
+    );
+    expect(advisory.detectorSignals).toEqual(expect.arrayContaining(["SCANNER_CONFIRMED"]));
+    expect(advisory.plannerSteps).toEqual(expect.arrayContaining(["Review scanner evidence before remediation."]));
+    expect(JSON.stringify(advisory)).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|accessToken|refreshToken|tokenValue|secretValue|fullRepository|sourceArchive|rawScannerPayload/i
+    );
+  });
+
+  it("rejects unredacted evidence and forbidden repository or credential payloads", () => {
+    const service = new AiAdvisoryService();
+
+    expect(() =>
+      service.createAdvisory({
+        ...request,
+        evidence: {
+          ...request.evidence,
+          redacted: false
+        }
+      })
+    ).toThrow("AI advisory input must use redacted evidence.");
+
+    expect(() =>
+      service.createAdvisory({
+        ...request,
+        normalizedFinding: {
+          ...request.normalizedFinding,
+          title: "fullRepository payload was supplied"
+        }
+      })
+    ).toThrow("AI advisory input contains forbidden sensitive content.");
+  });
+});

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -210,6 +210,20 @@ export interface AiAdvisoryRequest {
   modelVersion: string;
 }
 
+export interface AiAdvisoryResult {
+  id: string;
+  tenantId: string;
+  scanRequestId: string;
+  findingId: string;
+  modelVersion: string;
+  advisoryOnly: true;
+  redactedEvidenceOnly: true;
+  detectorSignals: string[];
+  plannerSteps: string[];
+  confidence: number;
+  createdAt: string;
+}
+
 export interface IsolationEscalationInput {
   tenantAgeDays: number;
   repositorySizeMb: number;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -23,6 +23,8 @@ sandbox, or AI runtime implementation.
 - `POST /api/evidence/:evidencePackId/access-requests`
 - `POST /api/policy-decisions/evaluate`
 - `GET /api/policy-decisions/:policyDecisionId`
+- `POST /api/ai-advisories`
+- `GET /api/ai-advisories/:advisoryId`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
 - `POST /api/suppressions`
@@ -93,6 +95,12 @@ AI advisory requests contain a normalized finding, reduced redacted evidence, an
 version. They must not contain SCM credentials, full repository input, or raw unbounded
 scanner payloads. AI output is advisory metadata only and cannot override deterministic
 scanner findings or policy decisions.
+
+AI detector/planner output in this milestone is a mock runtime boundary that returns
+advisory-only detector signals, planner steps, confidence, model version, and tenant/scan
+attribution. It must not emit authoritative finding status, enforcement action, block
+request, waiver state, suppression state, credential values, full repository content, or raw
+scanner payloads.
 
 ## EvidencePack
 

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -97,6 +97,13 @@
 - [x] T054 Keep AI advisory metadata visible but non-authoritative for enforcement decisions
 - [x] T055 Add e2e coverage for policy decision shape, coverage requirements, and leakage guardrails
 
+## Phase 15: AI Advisory Detector Planner Skeleton Slice
+
+- [x] T056 Add AI advisory result contract for advisory-only detector/planner output
+- [x] T057 Add mock AI Plane advisory service over normalized findings and redacted evidence
+- [x] T058 Add AI advisory create and tenant-scoped read endpoints
+- [x] T059 Add e2e coverage for reduced evidence input and policy/finding non-authority guardrails
+
 ## Deferred
 
-- [ ] Implement AI detector/planner inference
+- [ ] Implement production AI detector/planner model runtime


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/145-ai-advisory-skeleton`
- 이슈: #145

## 주요 변경 사항

- AI Plane advisory-only result contract를 추가했습니다.
- mock detector/planner advisory service를 추가했습니다.
- `POST /api/ai-advisories`와 `GET /api/ai-advisories/:advisoryId`를 추가했습니다.
- normalized finding + redacted evidence + modelVersion 입력만 허용하는 guardrail을 테스트했습니다.
- finding/policy override, credential, full repository, raw scanner payload leakage를 차단하는 테스트를 추가했습니다.
- Phase 15 tasks와 scan architecture contract를 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목이 동일합니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **Label** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 작동하는지 확인하겠습니다.

## Validation

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched AI Advisory API with endpoints to create and retrieve AI-generated advisories, featuring detector signals and recommended planner actions derived from scan results.
  * Implemented comprehensive validation and data protection mechanisms that automatically redact sensitive information and prevent exposure of confidential data in advisory outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->