### PR TITLE
feat: 예외 승인과 억제 수명주기 API 구현

### DIFF
--- a/apps/api/src/policy/policy-lifecycle.service.ts
+++ b/apps/api/src/policy/policy-lifecycle.service.ts
@@ -1,0 +1,132 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+
+import type {
+  Suppression,
+  SuppressionCreateInput,
+  Waiver,
+  WaiverCreateInput,
+  WaiverUpdateInput
+} from "../../../../packages/shared/src";
+
+const FORBIDDEN_LIFECYCLE_KEYS = [
+  "accessToken",
+  "refreshToken",
+  "tokenValue",
+  "secretValue",
+  "sourceArchive",
+  "fullRepository",
+  "rawScannerPayload",
+  "aiOverride",
+  "policyOverride",
+  "findingOverride",
+  "enforcementAction",
+  "blockRequested"
+];
+
+@Injectable()
+export class PolicyLifecycleService {
+  private readonly waivers: Waiver[] = [];
+  private readonly suppressions: Suppression[] = [];
+  private waiverSequence = 0;
+  private suppressionSequence = 0;
+
+  createWaiver(input: WaiverCreateInput): Waiver {
+    this.assertSafeLifecyclePayload(input);
+    this.assertRequiredString(input.tenantId, "tenantId");
+    this.assertRequiredString(input.owner, "owner");
+    this.assertRequiredString(input.reason, "reason");
+    this.assertRequiredString(input.scope, "scope");
+    this.assertRequiredString(input.expiresAt, "expiresAt");
+
+    const waiver: Waiver = {
+      id: `waiver_${++this.waiverSequence}`,
+      tenantId: input.tenantId,
+      owner: input.owner,
+      reason: input.reason,
+      scope: input.scope,
+      expiresAt: input.expiresAt
+    };
+
+    this.waivers.push(waiver);
+
+    return waiver;
+  }
+
+  updateWaiver(waiverId: string, input: WaiverUpdateInput): Waiver {
+    this.assertSafeLifecyclePayload(input);
+    this.assertRequiredString(input.tenantId, "tenantId");
+
+    const waiver = this.waivers.find(
+      (candidate) => candidate.id === waiverId && candidate.tenantId === input.tenantId
+    );
+
+    if (!waiver) {
+      throw new NotFoundException("Waiver was not found for tenant.");
+    }
+
+    if (input.owner !== undefined) {
+      this.assertRequiredString(input.owner, "owner");
+      waiver.owner = input.owner;
+    }
+
+    if (input.reason !== undefined) {
+      this.assertRequiredString(input.reason, "reason");
+      waiver.reason = input.reason;
+    }
+
+    if (input.scope !== undefined) {
+      this.assertRequiredString(input.scope, "scope");
+      waiver.scope = input.scope;
+    }
+
+    if (input.expiresAt !== undefined) {
+      this.assertRequiredString(input.expiresAt, "expiresAt");
+      waiver.expiresAt = input.expiresAt;
+    }
+
+    if (input.lastReviewedAt !== undefined) {
+      this.assertRequiredString(input.lastReviewedAt, "lastReviewedAt");
+      waiver.lastReviewedAt = input.lastReviewedAt;
+    }
+
+    return waiver;
+  }
+
+  createSuppression(input: SuppressionCreateInput): Suppression {
+    this.assertSafeLifecyclePayload(input);
+    this.assertRequiredString(input.tenantId, "tenantId");
+    this.assertRequiredString(input.scanRequestId, "scanRequestId");
+
+    if (!["STALE_RESULT", "DUPLICATE", "POLICY"].includes(input.reason)) {
+      throw new BadRequestException("Suppression reason is invalid.");
+    }
+
+    const suppression: Suppression = {
+      id: `suppression_${++this.suppressionSequence}`,
+      tenantId: input.tenantId,
+      scanRequestId: input.scanRequestId,
+      findingId: input.findingId,
+      reason: input.reason
+    };
+
+    this.suppressions.push(suppression);
+
+    return suppression;
+  }
+
+  private assertSafeLifecyclePayload(input: unknown): void {
+    const serialized = JSON.stringify(input);
+
+    for (const forbiddenKey of FORBIDDEN_LIFECYCLE_KEYS) {
+      if (new RegExp(forbiddenKey, "i").test(serialized)) {
+        throw new BadRequestException("Lifecycle payload contains forbidden sensitive or authority content.");
+      }
+    }
+  }
+
+  private assertRequiredString(value: unknown, fieldName: string): asserts value is string {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new BadRequestException(`Lifecycle payload is missing required field: ${fieldName}.`);
+    }
+  }
+}

--- a/apps/api/src/policy/policy.module.ts
+++ b/apps/api/src/policy/policy.module.ts
@@ -2,10 +2,13 @@ import { Module } from "@nestjs/common";
 
 import { PolicyDecisionsController } from "./policy-decisions.controller";
 import { PolicyEngineService } from "./policy-engine.service";
+import { PolicyLifecycleService } from "./policy-lifecycle.service";
+import { SuppressionsController } from "./suppressions.controller";
+import { WaiversController } from "./waivers.controller";
 
 @Module({
-  controllers: [PolicyDecisionsController],
-  providers: [PolicyEngineService],
-  exports: [PolicyEngineService]
+  controllers: [PolicyDecisionsController, WaiversController, SuppressionsController],
+  providers: [PolicyEngineService, PolicyLifecycleService],
+  exports: [PolicyEngineService, PolicyLifecycleService]
 })
 export class PolicyModule {}

--- a/apps/api/src/policy/suppressions.controller.ts
+++ b/apps/api/src/policy/suppressions.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from "@nestjs/common";
+
+import type { SuppressionCreateInput } from "../../../../packages/shared/src";
+import { PolicyLifecycleService } from "./policy-lifecycle.service";
+
+@Controller("suppressions")
+export class SuppressionsController {
+  constructor(private readonly policyLifecycleService: PolicyLifecycleService) {}
+
+  @Post()
+  create(@Body() body: SuppressionCreateInput) {
+    return this.policyLifecycleService.createSuppression(body);
+  }
+}

--- a/apps/api/src/policy/waivers.controller.ts
+++ b/apps/api/src/policy/waivers.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Param, Patch, Post } from "@nestjs/common";
+
+import type { WaiverCreateInput, WaiverUpdateInput } from "../../../../packages/shared/src";
+import { PolicyLifecycleService } from "./policy-lifecycle.service";
+
+@Controller("waivers")
+export class WaiversController {
+  constructor(private readonly policyLifecycleService: PolicyLifecycleService) {}
+
+  @Post()
+  create(@Body() body: WaiverCreateInput) {
+    return this.policyLifecycleService.createWaiver(body);
+  }
+
+  @Patch(":waiverId")
+  update(@Param("waiverId") waiverId: string, @Body() body: WaiverUpdateInput) {
+    return this.policyLifecycleService.updateWaiver(waiverId, body);
+  }
+}

--- a/apps/api/test/policy/waiver-suppression-lifecycle.e2e-spec.ts
+++ b/apps/api/test/policy/waiver-suppression-lifecycle.e2e-spec.ts
@@ -1,0 +1,157 @@
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+
+describe("Waiver and suppression lifecycle API (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.PORT = "3000";
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/aegisai";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env.SESSION_SECRET = "test-session-secret-value";
+    process.env.CSRF_SECRET = "test-csrf-secret-value";
+    process.env.GITHUB_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_CLIENT_SECRET = "github-client-secret";
+    process.env.GITLAB_CLIENT_ID = "gitlab-client-id";
+    process.env.GITLAB_CLIENT_SECRET = "gitlab-client-secret";
+    process.env.APP_URL = "http://localhost:3000";
+    process.env.FRONTEND_URL = "http://localhost:5173";
+    process.env.TOKEN_ENCRYPTION_KEY =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    const [{ AppModule }, { PrismaService }] = await Promise.all([
+      import("../../src/app.module"),
+      import("../../src/prisma/prisma.service")
+    ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }])
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix("api");
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  const dataOf = <T>(body: { data?: T } | T): T => {
+    if (body && typeof body === "object" && "data" in body) {
+      return (body as { data: T }).data;
+    }
+
+    return body as T;
+  };
+
+  it("creates and updates tenant-scoped waivers without credential or policy override leakage", async () => {
+    const create = await request(app.getHttpServer())
+      .post("/api/waivers")
+      .send({
+        tenantId: "tenant_waiver_api",
+        owner: "security-reviewer@example.com",
+        reason: "Compensating control approved for one sprint.",
+        scope: "finding:finding_waiver_1",
+        expiresAt: "2026-06-01T00:00:00.000Z"
+      })
+      .expect(201);
+
+    const waiver = dataOf<Record<string, unknown>>(create.body);
+
+    expect(waiver).toEqual(
+      expect.objectContaining({
+        id: "waiver_1",
+        tenantId: "tenant_waiver_api",
+        owner: "security-reviewer@example.com",
+        reason: "Compensating control approved for one sprint.",
+        scope: "finding:finding_waiver_1",
+        expiresAt: "2026-06-01T00:00:00.000Z"
+      })
+    );
+
+    const update = await request(app.getHttpServer())
+      .patch(`/api/waivers/${waiver.id}`)
+      .send({
+        tenantId: "tenant_waiver_api",
+        reason: "Compensating control reviewed and extended.",
+        expiresAt: "2026-06-15T00:00:00.000Z",
+        lastReviewedAt: "2026-05-10T00:00:00.000Z"
+      })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(update.body)).toEqual(
+      expect.objectContaining({
+        id: waiver.id,
+        tenantId: "tenant_waiver_api",
+        reason: "Compensating control reviewed and extended.",
+        expiresAt: "2026-06-15T00:00:00.000Z",
+        lastReviewedAt: "2026-05-10T00:00:00.000Z"
+      })
+    );
+    expect(JSON.stringify({ create: create.body, update: update.body })).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|aiOverride|policyOverride/i
+    );
+  });
+
+  it("creates tenant-scoped suppressions without accepting source or credential material", async () => {
+    const create = await request(app.getHttpServer())
+      .post("/api/suppressions")
+      .send({
+        tenantId: "tenant_suppression_api",
+        scanRequestId: "scan_request_suppression_1",
+        findingId: "finding_suppression_1",
+        reason: "STALE_RESULT"
+      })
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(create.body)).toEqual({
+      id: "suppression_1",
+      tenantId: "tenant_suppression_api",
+      scanRequestId: "scan_request_suppression_1",
+      findingId: "finding_suppression_1",
+      reason: "STALE_RESULT"
+    });
+    expect(JSON.stringify(create.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|policyOverride|findingOverride/i
+    );
+  });
+
+  it("rejects lifecycle payloads that include credentials, full repository content, or policy authority", async () => {
+    await request(app.getHttpServer())
+      .post("/api/waivers")
+      .send({
+        tenantId: "tenant_waiver_api",
+        owner: "security-reviewer@example.com",
+        reason: "Do not accept this payload.",
+        scope: "finding:finding_waiver_2",
+        expiresAt: "2026-06-01T00:00:00.000Z",
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .post("/api/suppressions")
+      .send({
+        tenantId: "tenant_suppression_api",
+        scanRequestId: "scan_request_suppression_2",
+        reason: "POLICY",
+        fullRepository: "all source"
+      })
+      .expect(400);
+  });
+});

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -173,12 +173,36 @@ export interface Waiver {
   lastReviewedAt?: string;
 }
 
+export interface WaiverCreateInput {
+  tenantId: string;
+  owner: string;
+  reason: string;
+  scope: string;
+  expiresAt: string;
+}
+
+export interface WaiverUpdateInput {
+  tenantId: string;
+  owner?: string;
+  reason?: string;
+  scope?: string;
+  expiresAt?: string;
+  lastReviewedAt?: string;
+}
+
 export interface Suppression {
   id: string;
   tenantId: string;
   scanRequestId: string;
   findingId?: string;
   reason: 'STALE_RESULT' | 'DUPLICATE' | 'POLICY';
+}
+
+export interface SuppressionCreateInput {
+  tenantId: string;
+  scanRequestId: string;
+  findingId?: string;
+  reason: Suppression['reason'];
 }
 
 export interface AuditEvent {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -136,3 +136,22 @@ finding metadata, scan lane, scanner coverage metadata, and optional AI advisory
 metadata. AI advisory input may be surfaced through `aiAdvisoryVisible`, but suggested AI
 actions must not select or override enforcement action, ticket request, block request, waiver
 state, or stale suppression.
+
+## Waiver and Suppression Lifecycle
+
+Waiver lifecycle endpoints accept tenant-scoped metadata only:
+
+- `POST /api/waivers` creates a waiver with owner, reason, scope, and expiration metadata.
+- `PATCH /api/waivers/:waiverId` updates an existing waiver for the same tenant and may
+  record `lastReviewedAt`.
+
+Suppression lifecycle endpoints accept tenant and scan scoped metadata only:
+
+- `POST /api/suppressions` creates a stale-result, duplicate, or policy suppression for a
+  scan request and optional finding.
+
+Waiver and suppression payloads must not include SCM credentials, full repository content,
+source archives, raw scanner payloads, AI override fields, finding override fields, or policy
+authority such as enforcement action or block requests. Lifecycle APIs record exception
+metadata; they do not execute scans, make deterministic policy decisions, or grant SCM
+principals.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -118,6 +118,13 @@
 - [x] T066 Reject credentials, full repository content, source archives, raw scanner payloads, and policy/finding authority fields
 - [x] T067 Add dev/demo Docker image, Oracle Compose service, env examples, and runtime tests
 
+## Phase 18: Waiver and Suppression Lifecycle API Slice
+
+- [x] T068 Add shared create/update input contracts for waivers and suppressions
+- [x] T069 Add tenant-scoped waiver create and update endpoints
+- [x] T070 Add tenant-scoped suppression create endpoint
+- [x] T071 Add e2e coverage for lifecycle metadata, tenant scoping, and leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/151-waiver-suppression-lifecycle`
- 이슈: Closes #151

## 주요 변경 사항

- waiver 생성 및 tenant-scoped update API 추가
- suppression 생성 API 추가
- waiver/suppression create/update shared input contract 추가
- credential, full repository, source archive, raw scanner payload, AI/policy/finding override 차단 guardrail 추가
- 002 production scan architecture contracts/tasks 문서 갱신

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 했나요?
- [x] **라벨(Label)** 등록을 했나요?
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- --runTestsByPath test/policy/waiver-suppression-lifecycle.e2e-spec.ts`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints for creating and updating policy waivers with tenant scoping
  * Added API endpoint for creating policy suppressions with validation against predefined suppression reasons
  * Implemented payload validation to prevent submission of sensitive credentials and policy authority data

* **Tests**
  * Added end-to-end tests covering waiver and suppression lifecycle operations

* **Documentation**
  * Updated architecture specifications with waiver and suppression lifecycle API contracts and expectations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->