### PR TITLE
feat: 댓글 디스패처 결정 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -1,0 +1,14 @@
+import { Body, Controller, Post } from "@nestjs/common";
+
+import type { CommentDispatchPlanRequest } from "../../../../packages/shared/src";
+import { ControlPlaneService } from "./control-plane.service";
+
+@Controller("comment-dispatches")
+export class CommentDispatchesController {
+  constructor(private readonly controlPlaneService: ControlPlaneService) {}
+
+  @Post("plan")
+  plan(@Body() body: CommentDispatchPlanRequest) {
+    return this.controlPlaneService.planCommentDispatch(body);
+  }
+}

--- a/apps/api/src/control-plane/control-plane.module.ts
+++ b/apps/api/src/control-plane/control-plane.module.ts
@@ -1,6 +1,7 @@
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 
+import { CommentDispatchesController } from "./comment-dispatches.controller";
 import { ConfigModule } from "../config/config.module";
 import { ControlPlaneService } from "./control-plane.service";
 import { GithubAppInstallationClient } from "./github-app-installation.client";
@@ -17,7 +18,8 @@ import { ScanRequestsController } from "./scan-requests.controller";
     IntegrationsController,
     RepositoryBindingsController,
     ScanRequestsController,
-    GithubWebhooksController
+    GithubWebhooksController,
+    CommentDispatchesController
   ],
   providers: [
     ControlPlaneService,

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -2,6 +2,8 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import {
   buildCanonicalScanKey,
   shouldEscalateIsolation,
+  type CommentDispatchPlan,
+  type CommentDispatchPlanRequest,
   type IsolationClass
 } from "../../../../packages/shared/src";
 
@@ -30,6 +32,7 @@ export class ControlPlaneService {
   private integrationSequence = 0;
   private repositorySequence = 0;
   private scanSequence = 0;
+  private commentDispatchSequence = 0;
 
   constructor(
     private readonly githubAppInstallationClient: GithubAppInstallationClient,
@@ -218,6 +221,50 @@ export class ControlPlaneService {
     return scanRequest;
   }
 
+  planCommentDispatch(input: CommentDispatchPlanRequest): CommentDispatchPlan {
+    this.assertSafeCommentDispatchPayload(input);
+
+    const repositoryBinding = this.repositoryBindings.get(input.repositoryBindingId);
+    if (!repositoryBinding || repositoryBinding.tenantId !== input.tenantId) {
+      throw new NotFoundException("Repository binding not found for tenant");
+    }
+
+    const integration = this.integrations.get(repositoryBinding.scmIntegrationId);
+    if (!integration || integration.tenantId !== input.tenantId) {
+      throw new NotFoundException("SCM integration not found for tenant");
+    }
+
+    if (!integration.commentWritePrincipalId) {
+      throw new BadRequestException("Repository binding does not have a comment-write principal.");
+    }
+
+    if (!input.policyDecision.commentAllowed) {
+      throw new BadRequestException("Policy decision does not allow comment dispatch.");
+    }
+
+    if (
+      input.policyDecision.tenantId !== input.tenantId ||
+      input.finding.tenantId !== input.tenantId ||
+      input.policyDecision.findingId !== input.finding.id
+    ) {
+      throw new BadRequestException("Comment dispatch input is not tenant or finding aligned.");
+    }
+
+    return {
+      id: `comment_dispatch_plan_${++this.commentDispatchSequence}`,
+      tenantId: input.tenantId,
+      repositoryBindingId: repositoryBinding.id,
+      provider: integration.provider,
+      providerRepoId: repositoryBinding.providerRepoId,
+      commentWritePrincipalId: integration.commentWritePrincipalId,
+      policyDecisionId: input.policyDecision.id,
+      findingId: input.finding.id,
+      targetRef: input.targetRef,
+      commitSha: input.commitSha,
+      dispatchAllowed: true
+    };
+  }
+
   private findGithubAppIntegration(
     externalInstallationId: string,
     tenantId?: string
@@ -295,5 +342,28 @@ export class ControlPlaneService {
         isPrivate: repository.isPrivate ?? repository.private ?? true
       };
     });
+  }
+
+  private assertSafeCommentDispatchPayload(input: unknown): void {
+    const serialized = JSON.stringify(input);
+    const forbiddenKeys = [
+      "accessToken",
+      "refreshToken",
+      "tokenValue",
+      "secretValue",
+      "sourceArchive",
+      "fullRepository",
+      "rawScannerPayload",
+      "repoReadPrincipalId",
+      "integrationAdminPrincipalId",
+      "policyOverride",
+      "findingOverride"
+    ];
+
+    for (const forbiddenKey of forbiddenKeys) {
+      if (new RegExp(forbiddenKey, "i").test(serialized)) {
+        throw new BadRequestException("Comment dispatch payload contains forbidden sensitive or authority content.");
+      }
+    }
   }
 }

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1,0 +1,258 @@
+import { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+
+describe("Comment dispatcher boundary API (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = "test";
+    process.env.PORT = "3000";
+    process.env.DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/aegisai";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    process.env.SESSION_SECRET = "test-session-secret-value";
+    process.env.CSRF_SECRET = "test-csrf-secret-value";
+    process.env.GITHUB_CLIENT_ID = "github-client-id";
+    process.env.GITHUB_CLIENT_SECRET = "github-client-secret";
+    process.env.GITLAB_CLIENT_ID = "gitlab-client-id";
+    process.env.GITLAB_CLIENT_SECRET = "gitlab-client-secret";
+    process.env.APP_URL = "http://localhost:3000";
+    process.env.FRONTEND_URL = "http://localhost:5173";
+    process.env.TOKEN_ENCRYPTION_KEY =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    const [
+      { AppModule },
+      { GithubAppInstallationClient },
+      { GitlabCloudIntegrationClient },
+      { PrismaService }
+    ] = await Promise.all([
+      import("../../src/app.module"),
+      import("../../src/control-plane/github-app-installation.client"),
+      import("../../src/control-plane/gitlab-cloud-integration.client"),
+      import("../../src/prisma/prisma.service")
+    ]);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule]
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn().mockResolvedValue(undefined),
+        $disconnect: jest.fn().mockResolvedValue(undefined),
+        onModuleInit: jest.fn().mockResolvedValue(undefined),
+        onModuleDestroy: jest.fn().mockResolvedValue(undefined),
+        $queryRawUnsafe: jest.fn().mockResolvedValue([{ result: 1 }]),
+        tenant: { upsert: jest.fn().mockResolvedValue({}) },
+        scmIntegration: { upsert: jest.fn().mockResolvedValue({}) },
+        repositoryBinding: {
+          upsert: jest.fn().mockResolvedValue({}),
+          deleteMany: jest.fn().mockResolvedValue({ count: 1 })
+        },
+        auditEvent: { create: jest.fn().mockResolvedValue({}) }
+      })
+      .overrideProvider(GithubAppInstallationClient)
+      .useValue({
+        listInstallationRepositories: jest.fn().mockResolvedValue([])
+      })
+      .overrideProvider(GitlabCloudIntegrationClient)
+      .useValue({
+        listIntegrationRepositories: jest.fn().mockResolvedValue([])
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix("api");
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  const dataOf = <T>(body: { data?: T } | T): T => {
+    if (body && typeof body === "object" && "data" in body) {
+      return (body as { data: T }).data;
+    }
+
+    return body as T;
+  };
+
+  async function installRepositoryBinding(input: {
+    tenantId: string;
+    provider: "github" | "gitlab";
+    commentWritePrincipalId?: string;
+  }): Promise<Record<string, unknown>> {
+    await request(app.getHttpServer())
+      .post(`/api/integrations/${input.provider}/install`)
+      .send({
+        tenantId: input.tenantId,
+        externalInstallationId: `${input.provider}-comment-installation`,
+        repoReadPrincipalId: `${input.provider}:repo-read`,
+        commentWritePrincipalId: input.commentWritePrincipalId,
+        repositories: [
+          {
+            providerRepoId: `${input.provider}-repo-1`,
+            fullName: `acme/${input.provider}-comment-target`,
+            defaultBranch: "main",
+            isPrivate: true
+          }
+        ]
+      })
+      .expect(201);
+
+    const repositories = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: input.tenantId })
+      .expect(200);
+
+    return dataOf<Array<Record<string, unknown>>>(repositories.body)[0];
+  }
+
+  function dispatchRequest(input: {
+    tenantId: string;
+    repositoryBindingId: unknown;
+    policyCommentAllowed: boolean;
+  }) {
+    return {
+      tenantId: input.tenantId,
+      repositoryBindingId: input.repositoryBindingId,
+      targetRef: "refs/pull/42/head",
+      commitSha: "abc123comment",
+      policyDecision: {
+        id: "policy_decision_comment_1",
+        tenantId: input.tenantId,
+        scanRequestId: "scan_request_comment_1",
+        findingId: "finding_comment_1",
+        enforcementAction: input.policyCommentAllowed ? "WARN" : "DASHBOARD_ONLY",
+        commentAllowed: input.policyCommentAllowed,
+        dashboardVisible: true,
+        ticketRequested: false,
+        blockRequested: false,
+        reasonCodes: ["SEVERITY_HIGH"],
+        requiredCoverage: ["OPENGREP", "TRIVY", "SYFT"],
+        waiverApplied: false,
+        staleSuppressed: false,
+        aiAdvisoryVisible: false
+      },
+      finding: {
+        id: "finding_comment_1",
+        tenantId: input.tenantId,
+        scanRequestId: "scan_request_comment_1",
+        scannerRunId: "scanner_run_comment_1",
+        title: "Unsafe template injection",
+        severity: "HIGH",
+        scannerProvenance: "OPENGREP",
+        filePath: "src/template.ts",
+        lineStart: 42,
+        status: "OPEN"
+      }
+    };
+  }
+
+  it("creates a metadata-only dispatch plan through the Control Plane comment-write principal", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_dispatch",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write"
+    });
+
+    const response = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_dispatch",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(response.body)).toEqual({
+      id: "comment_dispatch_plan_1",
+      tenantId: "tenant_comment_dispatch",
+      repositoryBindingId: repositoryBinding.id,
+      provider: "GITHUB",
+      providerRepoId: "github-repo-1",
+      commentWritePrincipalId: "github-app-installation:comment-write",
+      policyDecisionId: "policy_decision_comment_1",
+      findingId: "finding_comment_1",
+      targetRef: "refs/pull/42/head",
+      commitSha: "abc123comment",
+      dispatchAllowed: true
+    });
+    expect(JSON.stringify(response.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId/i
+    );
+  });
+
+  it("rejects dispatch when policy forbids comments or no comment-write principal exists", async () => {
+    const allowedBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_policy_denied",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-denied"
+    });
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_policy_denied",
+          repositoryBindingId: allowedBinding.id,
+          policyCommentAllowed: false
+        })
+      )
+      .expect(400);
+
+    const missingPrincipalBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_missing_principal",
+      provider: "gitlab"
+    });
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_missing_principal",
+          repositoryBindingId: missingPrincipalBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(400);
+  });
+
+  it("rejects dispatch payloads that include source, credentials, or policy override authority", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_sensitive",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-sensitive"
+    });
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send({
+        ...dispatchRequest({
+          tenantId: "tenant_comment_sensitive",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        }),
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send({
+        ...dispatchRequest({
+          tenantId: "tenant_comment_sensitive",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        }),
+        fullRepository: "all source"
+      })
+      .expect(400);
+  });
+});

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -163,6 +163,29 @@ export interface PolicyEvaluationInput {
   };
 }
 
+export interface CommentDispatchPlanRequest {
+  tenantId: string;
+  repositoryBindingId: string;
+  targetRef: string;
+  commitSha: string;
+  policyDecision: PolicyDecision;
+  finding: NormalizedFinding;
+}
+
+export interface CommentDispatchPlan {
+  id: string;
+  tenantId: string;
+  repositoryBindingId: string;
+  provider: ScmProvider;
+  providerRepoId: string;
+  commentWritePrincipalId: string;
+  policyDecisionId: string;
+  findingId: string;
+  targetRef: string;
+  commitSha: string;
+  dispatchAllowed: true;
+}
+
 export interface Waiver {
   id: string;
   tenantId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -25,6 +25,7 @@ sandbox, or AI runtime implementation.
 - `GET /api/policy-decisions/:policyDecisionId`
 - `POST /api/ai-advisories`
 - `GET /api/ai-advisories/:advisoryId`
+- `POST /api/comment-dispatches/plan`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
 - `POST /api/suppressions`
@@ -155,3 +156,16 @@ source archives, raw scanner payloads, AI override fields, finding override fiel
 authority such as enforcement action or block requests. Lifecycle APIs record exception
 metadata; they do not execute scans, make deterministic policy decisions, or grant SCM
 principals.
+
+## Comment Dispatcher Boundary
+
+Comment dispatch planning is a Control Plane boundary. `POST /api/comment-dispatches/plan`
+accepts tenant, repository binding, target ref, commit SHA, policy decision metadata, and a
+normalized finding. It returns metadata for a planned comment dispatch only when the policy
+decision allows comments and the repository binding's SCM integration has a comment-write
+principal.
+
+Comment dispatch planning must not receive or return repo-read credentials, integration-admin
+authority, SCM token values, full repository content, source archives, or raw scanner payloads.
+This milestone does not publish GitHub/GitLab comments; it only validates the comment-write
+principal boundary and produces deterministic dispatch metadata.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -125,6 +125,13 @@
 - [x] T070 Add tenant-scoped suppression create endpoint
 - [x] T071 Add e2e coverage for lifecycle metadata, tenant scoping, and leakage guardrails
 
+## Phase 19: Comment Dispatcher Boundary Slice
+
+- [x] T072 Add shared comment dispatch plan request/result contracts
+- [x] T073 Add Control Plane comment dispatch plan endpoint
+- [x] T074 Require policy `commentAllowed` and SCM comment-write principal metadata
+- [x] T075 Add e2e coverage for dispatch metadata and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/153-comment-dispatcher-boundary`
- 이슈: Closes #153

## 주요 변경 사항

- `POST /api/comment-dispatches/plan` Control Plane dispatch planning endpoint 추가
- shared `CommentDispatchPlanRequest` / `CommentDispatchPlan` contract 추가
- policy `commentAllowed` 및 SCM comment-write principal metadata 검증 추가
- repo-read/integration-admin 권한, SCM token, source archive, full repository, raw scanner payload 차단 guardrail 추가
- 002 production scan architecture contracts/tasks 문서 갱신

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 했나요?
- [x] **라벨(Label)** 등록을 했나요?
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- --runTestsByPath test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

## 참고

- 첫 `corepack pnpm test`에서 기존 web `ScanPage` 테스트가 1회 타이밍 실패했지만, 동일 테스트 단독 재실행과 전체 재실행에서는 통과했습니다. 이번 PR 변경 범위는 API/control-plane입니다.