### PR TITLE
feat: 댓글 디스패치 감사 이벤트 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from "@nestjs/common";
+import { Body, Controller, Get, Post, Query } from "@nestjs/common";
 
 import type { CommentDispatchPlanRequest } from "../../../../packages/shared/src";
 import { ControlPlaneService } from "./control-plane.service";
@@ -10,5 +10,10 @@ export class CommentDispatchesController {
   @Post("plan")
   plan(@Body() body: CommentDispatchPlanRequest) {
     return this.controlPlaneService.planCommentDispatch(body);
+  }
+
+  @Get("audit-events")
+  listAuditEvents(@Query("tenantId") tenantId: string) {
+    return this.controlPlaneService.listCommentDispatchAuditEvents(tenantId);
   }
 }

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import {
   buildCanonicalScanKey,
   shouldEscalateIsolation,
+  type CommentDispatchAuditEvent,
   type CommentDispatchPlan,
   type CommentDispatchPlanRequest,
   type IsolationClass
@@ -28,11 +29,13 @@ export class ControlPlaneService {
   private readonly integrations = new Map<string, ControlPlaneIntegration>();
   private readonly repositoryBindings = new Map<string, ControlPlaneRepositoryBinding>();
   private readonly scanRequests = new Map<string, ControlPlaneScanRequest>();
+  private readonly commentDispatchAuditEvents: CommentDispatchAuditEvent[] = [];
 
   private integrationSequence = 0;
   private repositorySequence = 0;
   private scanSequence = 0;
   private commentDispatchSequence = 0;
+  private commentDispatchAuditSequence = 0;
 
   constructor(
     private readonly githubAppInstallationClient: GithubAppInstallationClient,
@@ -250,7 +253,7 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch input is not tenant or finding aligned.");
     }
 
-    return {
+    const plan: CommentDispatchPlan = {
       id: `comment_dispatch_plan_${++this.commentDispatchSequence}`,
       tenantId: input.tenantId,
       repositoryBindingId: repositoryBinding.id,
@@ -263,6 +266,32 @@ export class ControlPlaneService {
       commitSha: input.commitSha,
       dispatchAllowed: true
     };
+
+    this.commentDispatchAuditEvents.push({
+      id: `audit_event_${++this.commentDispatchAuditSequence}`,
+      tenantId: input.tenantId,
+      eventType: "comment_dispatch.planned",
+      actor: "comment-dispatcher",
+      targetType: "comment_dispatch_plan",
+      targetId: plan.id,
+      occurredAt: new Date(0).toISOString(),
+      metadata: {
+        repositoryBindingId: repositoryBinding.id,
+        provider: integration.provider,
+        providerRepoId: repositoryBinding.providerRepoId,
+        policyDecisionId: input.policyDecision.id,
+        findingId: input.finding.id,
+        targetRef: input.targetRef,
+        commitSha: input.commitSha,
+        commentWritePrincipalId: integration.commentWritePrincipalId
+      }
+    });
+
+    return plan;
+  }
+
+  listCommentDispatchAuditEvents(tenantId: string): CommentDispatchAuditEvent[] {
+    return this.commentDispatchAuditEvents.filter((event) => event.tenantId === tenantId);
   }
 
   private findGithubAppIntegration(

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -189,6 +189,63 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit"
+    });
+
+    const response = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_audit",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(response.body);
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body)).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(/^audit_event_\d+$/),
+        tenantId: "tenant_comment_audit",
+        eventType: "comment_dispatch.planned",
+        actor: "comment-dispatcher",
+        targetType: "comment_dispatch_plan",
+        targetId: plan.id,
+        occurredAt: "1970-01-01T00:00:00.000Z",
+        metadata: {
+          repositoryBindingId: repositoryBinding.id,
+          provider: "GITHUB",
+          providerRepoId: "github-repo-1",
+          policyDecisionId: "policy_decision_comment_1",
+          findingId: "finding_comment_1",
+          targetRef: "refs/pull/42/head",
+          commitSha: "abc123comment",
+          commentWritePrincipalId: "github-app-installation:comment-write-audit"
+        }
+      })
+    ]);
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId/i
+    );
+
+    const otherTenantResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_other" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(otherTenantResponse.body)).toEqual([]);
+  });
+
   it("rejects dispatch when policy forbids comments or no comment-write principal exists", async () => {
     const allowedBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_policy_denied",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -238,6 +238,22 @@ export interface AuditEvent {
   occurredAt: string;
 }
 
+export interface CommentDispatchAuditEvent extends AuditEvent {
+  eventType: 'comment_dispatch.planned';
+  actor: 'comment-dispatcher';
+  targetType: 'comment_dispatch_plan';
+  metadata: {
+    repositoryBindingId: string;
+    provider: ScmProvider;
+    providerRepoId: string;
+    policyDecisionId: string;
+    findingId: string;
+    targetRef: string;
+    commitSha: string;
+    commentWritePrincipalId: string;
+  };
+}
+
 export interface TokenBrokerIssueRequest {
   tenantId: string;
   repositoryBindingId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -26,6 +26,7 @@ sandbox, or AI runtime implementation.
 - `POST /api/ai-advisories`
 - `GET /api/ai-advisories/:advisoryId`
 - `POST /api/comment-dispatches/plan`
+- `GET /api/comment-dispatches/audit-events`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
 - `POST /api/suppressions`
@@ -169,3 +170,10 @@ Comment dispatch planning must not receive or return repo-read credentials, inte
 authority, SCM token values, full repository content, source archives, or raw scanner payloads.
 This milestone does not publish GitHub/GitLab comments; it only validates the comment-write
 principal boundary and produces deterministic dispatch metadata.
+
+Every successful dispatch planning operation records a tenant-scoped
+`comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns
+metadata only: repository binding ID, provider, provider repository ID, policy decision ID,
+finding ID, target ref, commit SHA, and comment-write principal ID. Audit events must not
+include SCM token values, repo-read principals, integration-admin principals, full
+repository content, source archives, or raw scanner payloads.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -132,6 +132,13 @@
 - [x] T074 Require policy `commentAllowed` and SCM comment-write principal metadata
 - [x] T075 Add e2e coverage for dispatch metadata and credential/source leakage guardrails
 
+## Phase 20: Comment Dispatch Audit Event Boundary Slice
+
+- [x] T076 Add shared comment dispatch audit event contract
+- [x] T077 Record tenant-scoped `comment_dispatch.planned` audit events
+- [x] T078 Add comment dispatch audit event read endpoint
+- [x] T079 Add e2e coverage for tenant scoping and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/155-comment-dispatch-audit-boundary`
- 이슈: Closes #155

## 주요 변경 사항

- 댓글 디스패치 plan 생성 시 tenant-scoped `comment_dispatch.planned` audit event를 기록합니다.
- `GET /api/comment-dispatches/audit-events` 조회 endpoint를 추가했습니다.
- 감사 이벤트 metadata를 repository/policy/finding/target/comment-write principal 정보로 제한했습니다.
- SCM token, repo-read/integration-admin principal, source archive, full repository, raw scanner payload 노출 방지 e2e를 추가했습니다.
- 002 계약 문서와 tasks.md를 Phase 20까지 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**합니다.

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`