### PR TITLE
feat: 댓글 디스패치 중복 방지 키 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import {
   buildCanonicalScanKey,
+  buildCommentDispatchIdempotencyKey,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
   type CommentDispatchPlan,
@@ -29,6 +30,7 @@ export class ControlPlaneService {
   private readonly integrations = new Map<string, ControlPlaneIntegration>();
   private readonly repositoryBindings = new Map<string, ControlPlaneRepositoryBinding>();
   private readonly scanRequests = new Map<string, ControlPlaneScanRequest>();
+  private readonly commentDispatchPlans = new Map<string, CommentDispatchPlan>();
   private readonly commentDispatchAuditEvents: CommentDispatchAuditEvent[] = [];
 
   private integrationSequence = 0;
@@ -253,8 +255,15 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch input is not tenant or finding aligned.");
     }
 
+    const idempotencyKey = buildCommentDispatchIdempotencyKey(input);
+    const existingPlan = this.commentDispatchPlans.get(idempotencyKey);
+    if (existingPlan) {
+      return existingPlan;
+    }
+
     const plan: CommentDispatchPlan = {
       id: `comment_dispatch_plan_${++this.commentDispatchSequence}`,
+      idempotencyKey,
       tenantId: input.tenantId,
       repositoryBindingId: repositoryBinding.id,
       provider: integration.provider,
@@ -286,6 +295,8 @@ export class ControlPlaneService {
         commentWritePrincipalId: integration.commentWritePrincipalId
       }
     });
+
+    this.commentDispatchPlans.set(idempotencyKey, plan);
 
     return plan;
   }

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -173,6 +173,14 @@ describe("Comment dispatcher boundary API (e2e)", () => {
 
     expect(dataOf<Record<string, unknown>>(response.body)).toEqual({
       id: "comment_dispatch_plan_1",
+      idempotencyKey: [
+        "tenant_comment_dispatch",
+        repositoryBinding.id,
+        "policy_decision_comment_1",
+        "finding_comment_1",
+        "refs/pull/42/head",
+        "abc123comment"
+      ].join(":"),
       tenantId: "tenant_comment_dispatch",
       repositoryBindingId: repositoryBinding.id,
       provider: "GITHUB",
@@ -187,6 +195,49 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     expect(JSON.stringify(response.body)).not.toMatch(
       /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId/i
     );
+  });
+
+  it("returns the existing dispatch plan and avoids duplicate audit events for idempotent retries", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_idempotent",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-idempotent"
+    });
+    const body = dispatchRequest({
+      tenantId: "tenant_comment_idempotent",
+      repositoryBindingId: repositoryBinding.id,
+      policyCommentAllowed: true
+    });
+
+    const firstResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(body)
+      .expect(201);
+    const secondResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(body)
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(secondResponse.body)).toEqual(
+      dataOf<Record<string, unknown>>(firstResponse.body)
+    );
+    expect(dataOf<Record<string, unknown>>(firstResponse.body)).toMatchObject({
+      idempotencyKey: [
+        "tenant_comment_idempotent",
+        repositoryBinding.id,
+        "policy_decision_comment_1",
+        "finding_comment_1",
+        "refs/pull/42/head",
+        "abc123comment"
+      ].join(":")
+    });
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_idempotent" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body)).toHaveLength(1);
   });
 
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -174,6 +174,7 @@ export interface CommentDispatchPlanRequest {
 
 export interface CommentDispatchPlan {
   id: string;
+  idempotencyKey: string;
   tenantId: string;
   repositoryBindingId: string;
   provider: ScmProvider;
@@ -315,6 +316,17 @@ export function buildCanonicalScanKey(input: CanonicalScanKeyInput): CanonicalSc
     input.commitSha,
     input.policyVersion,
     input.scannerSetVersion
+  ].join(':');
+}
+
+export function buildCommentDispatchIdempotencyKey(input: CommentDispatchPlanRequest): string {
+  return [
+    input.tenantId,
+    input.repositoryBindingId,
+    input.policyDecision.id,
+    input.finding.id,
+    input.targetRef,
+    input.commitSha
   ].join(':');
 }
 

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -164,12 +164,18 @@ Comment dispatch planning is a Control Plane boundary. `POST /api/comment-dispat
 accepts tenant, repository binding, target ref, commit SHA, policy decision metadata, and a
 normalized finding. It returns metadata for a planned comment dispatch only when the policy
 decision allows comments and the repository binding's SCM integration has a comment-write
-principal.
+principal. The response includes a deterministic `idempotencyKey` built from tenant,
+repository binding, policy decision, finding, target ref, and commit SHA.
 
 Comment dispatch planning must not receive or return repo-read credentials, integration-admin
 authority, SCM token values, full repository content, source archives, or raw scanner payloads.
 This milestone does not publish GitHub/GitLab comments; it only validates the comment-write
 principal boundary and produces deterministic dispatch metadata.
+
+Repeated dispatch planning requests with the same `idempotencyKey` return the existing plan
+instead of creating a duplicate plan or duplicate `comment_dispatch.planned` audit event.
+Different finding, target, commit, policy decision, repository binding, or tenant inputs create
+separate plans.
 
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -139,6 +139,13 @@
 - [x] T078 Add comment dispatch audit event read endpoint
 - [x] T079 Add e2e coverage for tenant scoping and credential/source leakage guardrails
 
+## Phase 21: Comment Dispatch Idempotency Boundary Slice
+
+- [x] T080 Add deterministic comment dispatch idempotency key contract
+- [x] T081 Return existing plans for identical dispatch planning retries
+- [x] T082 Avoid duplicate `comment_dispatch.planned` audit events for idempotent retries
+- [x] T083 Add e2e coverage for retry safety and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/157-comment-dispatch-idempotency-boundary`
- 이슈: Closes #157

## 주요 변경 사항

- 댓글 디스패치 plan 응답에 deterministic `idempotencyKey` 계약을 추가했습니다.
- 동일 tenant/repositoryBindingId/policyDecisionId/findingId/targetRef/commitSha 요청은 기존 plan을 반환하도록 했습니다.
- idempotent retry에서 `comment_dispatch.planned` audit event가 중복 기록되지 않게 했습니다.
- retry safety e2e와 002 contract/tasks 문서를 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**합니다.

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`