### PR TITLE
feat: 댓글 디스패치 발행 대기열 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post, Query } from "@nestjs/common";
 
-import type { CommentDispatchPlanRequest } from "../../../../packages/shared/src";
+import type { CommentDispatchEnqueueRequest, CommentDispatchPlanRequest } from "../../../../packages/shared/src";
 import { ControlPlaneService } from "./control-plane.service";
 
 @Controller("comment-dispatches")
@@ -12,8 +12,18 @@ export class CommentDispatchesController {
     return this.controlPlaneService.planCommentDispatch(body);
   }
 
+  @Post("enqueue")
+  enqueue(@Body() body: CommentDispatchEnqueueRequest) {
+    return this.controlPlaneService.enqueueCommentDispatch(body);
+  }
+
   @Get("audit-events")
   listAuditEvents(@Query("tenantId") tenantId: string) {
     return this.controlPlaneService.listCommentDispatchAuditEvents(tenantId);
+  }
+
+  @Get("outbox")
+  listOutbox(@Query("tenantId") tenantId: string) {
+    return this.controlPlaneService.listCommentDispatchOutbox(tenantId);
   }
 }

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -4,6 +4,8 @@ import {
   buildCommentDispatchIdempotencyKey,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
+  type CommentDispatchEnqueueRequest,
+  type CommentDispatchOutboxItem,
   type CommentDispatchPlan,
   type CommentDispatchPlanRequest,
   type IsolationClass
@@ -31,12 +33,14 @@ export class ControlPlaneService {
   private readonly repositoryBindings = new Map<string, ControlPlaneRepositoryBinding>();
   private readonly scanRequests = new Map<string, ControlPlaneScanRequest>();
   private readonly commentDispatchPlans = new Map<string, CommentDispatchPlan>();
+  private readonly commentDispatchOutboxItems = new Map<string, CommentDispatchOutboxItem>();
   private readonly commentDispatchAuditEvents: CommentDispatchAuditEvent[] = [];
 
   private integrationSequence = 0;
   private repositorySequence = 0;
   private scanSequence = 0;
   private commentDispatchSequence = 0;
+  private commentDispatchOutboxSequence = 0;
   private commentDispatchAuditSequence = 0;
 
   constructor(
@@ -303,6 +307,47 @@ export class ControlPlaneService {
 
   listCommentDispatchAuditEvents(tenantId: string): CommentDispatchAuditEvent[] {
     return this.commentDispatchAuditEvents.filter((event) => event.tenantId === tenantId);
+  }
+
+  enqueueCommentDispatch(input: CommentDispatchEnqueueRequest): CommentDispatchOutboxItem {
+    this.assertSafeCommentDispatchPayload(input);
+
+    const plan = Array.from(this.commentDispatchPlans.values()).find(
+      (candidate) => candidate.id === input.planId && candidate.tenantId === input.tenantId
+    );
+    if (!plan) {
+      throw new NotFoundException("Comment dispatch plan not found for tenant");
+    }
+
+    const existingOutboxItem = this.commentDispatchOutboxItems.get(plan.id);
+    if (existingOutboxItem) {
+      return existingOutboxItem;
+    }
+
+    const outboxItem: CommentDispatchOutboxItem = {
+      id: `comment_dispatch_outbox_${++this.commentDispatchOutboxSequence}`,
+      tenantId: plan.tenantId,
+      planId: plan.id,
+      idempotencyKey: plan.idempotencyKey,
+      repositoryBindingId: plan.repositoryBindingId,
+      provider: plan.provider,
+      providerRepoId: plan.providerRepoId,
+      commentWritePrincipalId: plan.commentWritePrincipalId,
+      policyDecisionId: plan.policyDecisionId,
+      findingId: plan.findingId,
+      targetRef: plan.targetRef,
+      commitSha: plan.commitSha,
+      status: "PENDING",
+      enqueuedAt: new Date(0).toISOString()
+    };
+
+    this.commentDispatchOutboxItems.set(plan.id, outboxItem);
+
+    return outboxItem;
+  }
+
+  listCommentDispatchOutbox(tenantId: string): CommentDispatchOutboxItem[] {
+    return Array.from(this.commentDispatchOutboxItems.values()).filter((item) => item.tenantId === tenantId);
   }
 
   private findGithubAppIntegration(

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -240,6 +240,81 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     expect(dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body)).toHaveLength(1);
   });
 
+  it("enqueues dispatch plans into a tenant-scoped metadata outbox without publishing external comments", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const firstEnqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox", planId: plan.id })
+      .expect(201);
+    const secondEnqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox", planId: plan.id })
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(secondEnqueueResponse.body)).toEqual(
+      dataOf<Record<string, unknown>>(firstEnqueueResponse.body)
+    );
+    expect(dataOf<Record<string, unknown>>(firstEnqueueResponse.body)).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^comment_dispatch_outbox_\d+$/),
+        tenantId: "tenant_comment_outbox",
+        planId: plan.id,
+        idempotencyKey: plan.idempotencyKey,
+        repositoryBindingId: repositoryBinding.id,
+        provider: "GITHUB",
+        providerRepoId: "github-repo-1",
+        commentWritePrincipalId: "github-app-installation:comment-write-outbox",
+        policyDecisionId: "policy_decision_comment_1",
+        findingId: "finding_comment_1",
+        targetRef: "refs/pull/42/head",
+        commitSha: "abc123comment",
+        status: "PENDING",
+        enqueuedAt: "1970-01-01T00:00:00.000Z"
+      })
+    );
+    expect(JSON.stringify(firstEnqueueResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    const outboxResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(outboxResponse.body)).toEqual([
+      dataOf<Record<string, unknown>>(firstEnqueueResponse.body)
+    ]);
+
+    const otherTenantResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_other" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(otherTenantResponse.body)).toEqual([]);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox", planId: plan.id, accessToken: "ghs_secret" })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -187,6 +187,28 @@ export interface CommentDispatchPlan {
   dispatchAllowed: true;
 }
 
+export interface CommentDispatchEnqueueRequest {
+  tenantId: string;
+  planId: string;
+}
+
+export interface CommentDispatchOutboxItem {
+  id: string;
+  tenantId: string;
+  planId: string;
+  idempotencyKey: string;
+  repositoryBindingId: string;
+  provider: ScmProvider;
+  providerRepoId: string;
+  commentWritePrincipalId: string;
+  policyDecisionId: string;
+  findingId: string;
+  targetRef: string;
+  commitSha: string;
+  status: 'PENDING' | 'PUBLISHED' | 'FAILED' | 'CANCELED';
+  enqueuedAt: string;
+}
+
 export interface Waiver {
   id: string;
   tenantId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -26,6 +26,8 @@ sandbox, or AI runtime implementation.
 - `POST /api/ai-advisories`
 - `GET /api/ai-advisories/:advisoryId`
 - `POST /api/comment-dispatches/plan`
+- `POST /api/comment-dispatches/enqueue`
+- `GET /api/comment-dispatches/outbox`
 - `GET /api/comment-dispatches/audit-events`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
@@ -176,6 +178,12 @@ Repeated dispatch planning requests with the same `idempotencyKey` return the ex
 instead of creating a duplicate plan or duplicate `comment_dispatch.planned` audit event.
 Different finding, target, commit, policy decision, repository binding, or tenant inputs create
 separate plans.
+
+`POST /api/comment-dispatches/enqueue` converts an existing tenant-scoped plan into a
+metadata-only `PENDING` outbox item. Repeated enqueue requests for the same plan return the
+existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped outbox
+metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
+GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -146,6 +146,13 @@
 - [x] T082 Avoid duplicate `comment_dispatch.planned` audit events for idempotent retries
 - [x] T083 Add e2e coverage for retry safety and credential/source leakage guardrails
 
+## Phase 22: Comment Dispatch Outbox Boundary Slice
+
+- [x] T084 Add comment dispatch enqueue request and outbox item contracts
+- [x] T085 Add metadata-only outbox enqueue endpoint
+- [x] T086 Add tenant-scoped outbox read endpoint
+- [x] T087 Add e2e coverage for enqueue idempotency, tenant scoping, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/159-comment-dispatch-outbox-boundary`
- 이슈: Closes #159

## 주요 변경 사항

- 댓글 디스패치 enqueue request/outbox item shared 계약을 추가했습니다.
- `POST /api/comment-dispatches/enqueue` endpoint로 기존 plan을 `PENDING` outbox metadata로 전환합니다.
- `GET /api/comment-dispatches/outbox` tenant-scoped 조회 endpoint를 추가했습니다.
- 같은 plan enqueue 재시도는 기존 outbox item을 반환하도록 했습니다.
- 외부 GitHub/GitLab 댓글 발행, external comment ID 저장, SCM write API 호출은 추가하지 않았습니다.
- credential/source leakage guardrail e2e와 002 contract/tasks 문서를 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**합니다.

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`