### PR TITLE
feat: 댓글 디스패치 대기열 감사 이벤트 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -342,6 +342,27 @@ export class ControlPlaneService {
     };
 
     this.commentDispatchOutboxItems.set(plan.id, outboxItem);
+    this.commentDispatchAuditEvents.push({
+      id: `audit_event_${++this.commentDispatchAuditSequence}`,
+      tenantId: plan.tenantId,
+      eventType: "comment_dispatch.enqueued",
+      actor: "comment-dispatcher",
+      targetType: "comment_dispatch_outbox_item",
+      targetId: outboxItem.id,
+      occurredAt: new Date(0).toISOString(),
+      metadata: {
+        outboxItemId: outboxItem.id,
+        planId: plan.id,
+        idempotencyKey: plan.idempotencyKey,
+        repositoryBindingId: plan.repositoryBindingId,
+        provider: plan.provider,
+        policyDecisionId: plan.policyDecisionId,
+        findingId: plan.findingId,
+        targetRef: plan.targetRef,
+        commitSha: plan.commitSha,
+        commentWritePrincipalId: plan.commentWritePrincipalId
+      }
+    });
 
     return outboxItem;
   }

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -315,6 +315,74 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("records one metadata-only audit event when a dispatch plan is enqueued", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_audit",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-audit"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_audit",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const firstEnqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_audit", planId: plan.id })
+      .expect(201);
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_audit", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(firstEnqueueResponse.body);
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_audit" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents).toHaveLength(2);
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued"
+    ]);
+    expect(auditEvents[1]).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^audit_event_\d+$/),
+        tenantId: "tenant_comment_outbox_audit",
+        eventType: "comment_dispatch.enqueued",
+        actor: "comment-dispatcher",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id,
+        occurredAt: "1970-01-01T00:00:00.000Z",
+        metadata: {
+          outboxItemId: outboxItem.id,
+          planId: plan.id,
+          idempotencyKey: plan.idempotencyKey,
+          repositoryBindingId: repositoryBinding.id,
+          provider: "GITHUB",
+          policyDecisionId: "policy_decision_comment_1",
+          findingId: "finding_comment_1",
+          targetRef: "refs/pull/42/head",
+          commitSha: "abc123comment",
+          commentWritePrincipalId: "github-app-installation:comment-write-outbox-audit"
+        }
+      })
+    );
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -262,18 +262,21 @@ export interface AuditEvent {
 }
 
 export interface CommentDispatchAuditEvent extends AuditEvent {
-  eventType: 'comment_dispatch.planned';
+  eventType: 'comment_dispatch.planned' | 'comment_dispatch.enqueued';
   actor: 'comment-dispatcher';
-  targetType: 'comment_dispatch_plan';
+  targetType: 'comment_dispatch_plan' | 'comment_dispatch_outbox_item';
   metadata: {
     repositoryBindingId: string;
     provider: ScmProvider;
-    providerRepoId: string;
+    providerRepoId?: string;
     policyDecisionId: string;
     findingId: string;
     targetRef: string;
     commitSha: string;
     commentWritePrincipalId: string;
+    outboxItemId?: string;
+    planId?: string;
+    idempotencyKey?: string;
   };
 }
 

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -191,3 +191,12 @@ metadata only: repository binding ID, provider, provider repository ID, policy d
 finding ID, target ref, commit SHA, and comment-write principal ID. Audit events must not
 include SCM token values, repo-read principals, integration-admin principals, full
 repository content, source archives, or raw scanner payloads.
+
+Every first successful outbox enqueue records one tenant-scoped
+`comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return
+the existing outbox item and do not create duplicate enqueue audit events. Enqueue audit
+metadata is limited to outbox item ID, plan ID, idempotency key, repository binding ID,
+provider, policy decision ID, finding ID, target ref, commit SHA, and comment-write
+principal ID. It must not include SCM token values, repo-read principals,
+integration-admin principals, external comment IDs, full repository content, source
+archives, or raw scanner payloads.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -153,6 +153,13 @@
 - [x] T086 Add tenant-scoped outbox read endpoint
 - [x] T087 Add e2e coverage for enqueue idempotency, tenant scoping, and credential/source leakage guardrails
 
+## Phase 23: Comment Dispatch Outbox Audit Event Boundary Slice
+
+- [x] T088 Extend comment dispatch audit event contract for outbox enqueue events
+- [x] T089 Record one tenant-scoped `comment_dispatch.enqueued` audit event per outbox item
+- [x] T090 Avoid duplicate enqueue audit events for idempotent enqueue retries
+- [x] T091 Add e2e coverage for enqueue audit metadata and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/161-comment-dispatch-outbox-audit-boundary`
- 이슈: Closes #161

## 주요 변경 사항

- 댓글 디스패치 audit event 계약을 `comment_dispatch.enqueued` 이벤트까지 확장했습니다.
- outbox enqueue 최초 성공 시 tenant-scoped enqueue audit event를 기록합니다.
- 같은 plan enqueue 재시도는 기존 outbox item을 반환하고 enqueue audit event를 중복 기록하지 않습니다.
- audit metadata를 outbox item, plan, idempotency key, repository/policy/finding/target/comment-write principal metadata로 제한했습니다.
- SCM token, repo-read/integration-admin principal, source archive, full repository, raw scanner payload, externalCommentId 누출 방지 e2e를 추가했습니다.
- 002 contract/tasks 문서를 Phase 23까지 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**합니다.

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit events are now recorded when comment dispatches are enqueued, enabling full tracking of dispatch operations.

* **Tests**
  * Added comprehensive end-to-end test coverage for audit event recording during comment dispatch processing.

* **Documentation**
  * Updated architecture documentation with audit event requirements and specifications for comment dispatch operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->