### PR TITLE
feat: 댓글 디스패치 대기열 실패 상태 전이 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -1,6 +1,10 @@
-import { Body, Controller, Get, Post, Query } from "@nestjs/common";
+import { Body, Controller, Get, Param, Patch, Post, Query } from "@nestjs/common";
 
-import type { CommentDispatchEnqueueRequest, CommentDispatchPlanRequest } from "../../../../packages/shared/src";
+import type {
+  CommentDispatchEnqueueRequest,
+  CommentDispatchOutboxStatusUpdateRequest,
+  CommentDispatchPlanRequest
+} from "../../../../packages/shared/src";
 import { ControlPlaneService } from "./control-plane.service";
 
 @Controller("comment-dispatches")
@@ -25,5 +29,13 @@ export class CommentDispatchesController {
   @Get("outbox")
   listOutbox(@Query("tenantId") tenantId: string) {
     return this.controlPlaneService.listCommentDispatchOutbox(tenantId);
+  }
+
+  @Patch("outbox/:outboxItemId/status")
+  updateOutboxStatus(
+    @Param("outboxItemId") outboxItemId: string,
+    @Body() body: CommentDispatchOutboxStatusUpdateRequest
+  ) {
+    return this.controlPlaneService.updateCommentDispatchOutboxStatus(outboxItemId, body);
   }
 }

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -6,6 +6,7 @@ import {
   type CommentDispatchAuditEvent,
   type CommentDispatchEnqueueRequest,
   type CommentDispatchOutboxItem,
+  type CommentDispatchOutboxStatusUpdateRequest,
   type CommentDispatchPlan,
   type CommentDispatchPlanRequest,
   type IsolationClass
@@ -371,6 +372,36 @@ export class ControlPlaneService {
     return Array.from(this.commentDispatchOutboxItems.values()).filter((item) => item.tenantId === tenantId);
   }
 
+  updateCommentDispatchOutboxStatus(
+    outboxItemId: string,
+    input: CommentDispatchOutboxStatusUpdateRequest
+  ): CommentDispatchOutboxItem {
+    this.assertSafeCommentDispatchPayload(input);
+
+    if (input.status !== "FAILED" && input.status !== "CANCELED") {
+      throw new BadRequestException("Only FAILED or CANCELED outbox status updates are accepted in this milestone.");
+    }
+
+    const outboxEntry = Array.from(this.commentDispatchOutboxItems.entries()).find(
+      ([, item]) => item.id === outboxItemId && item.tenantId === input.tenantId
+    );
+    if (!outboxEntry) {
+      throw new NotFoundException("Comment dispatch outbox item not found for tenant");
+    }
+
+    const [planId, outboxItem] = outboxEntry;
+    const updatedOutboxItem: CommentDispatchOutboxItem = {
+      ...outboxItem,
+      status: input.status,
+      statusReason: input.statusReason,
+      statusUpdatedAt: new Date(0).toISOString()
+    };
+
+    this.commentDispatchOutboxItems.set(planId, updatedOutboxItem);
+
+    return updatedOutboxItem;
+  }
+
   private findGithubAppIntegration(
     externalInstallationId: string,
     tenantId?: string
@@ -462,6 +493,7 @@ export class ControlPlaneService {
       "rawScannerPayload",
       "repoReadPrincipalId",
       "integrationAdminPrincipalId",
+      "externalCommentId",
       "policyOverride",
       "findingOverride"
     ];

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -383,6 +383,78 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("updates outbox items to failure states without accepting publish or external comment authority", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_status",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-status"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_status",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_status", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    const failedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status",
+        status: "FAILED",
+        statusReason: "SCM_RATE_LIMIT"
+      })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(failedResponse.body)).toEqual({
+      ...outboxItem,
+      status: "FAILED",
+      statusReason: "SCM_RATE_LIMIT",
+      statusUpdatedAt: "1970-01-01T00:00:00.000Z"
+    });
+    expect(JSON.stringify(failedResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    const outboxResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_status" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(outboxResponse.body)).toEqual([
+      dataOf<Record<string, unknown>>(failedResponse.body)
+    ]);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status",
+        status: "PUBLISHED",
+        externalCommentId: "github-comment-1"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_other",
+        status: "CANCELED",
+        statusReason: "TENANT_MISMATCH"
+      })
+      .expect(404);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -207,6 +207,14 @@ export interface CommentDispatchOutboxItem {
   commitSha: string;
   status: 'PENDING' | 'PUBLISHED' | 'FAILED' | 'CANCELED';
   enqueuedAt: string;
+  statusReason?: string;
+  statusUpdatedAt?: string;
+}
+
+export interface CommentDispatchOutboxStatusUpdateRequest {
+  tenantId: string;
+  status: Extract<CommentDispatchOutboxItem['status'], 'FAILED' | 'CANCELED'>;
+  statusReason: string;
 }
 
 export interface Waiver {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -28,6 +28,7 @@ sandbox, or AI runtime implementation.
 - `POST /api/comment-dispatches/plan`
 - `POST /api/comment-dispatches/enqueue`
 - `GET /api/comment-dispatches/outbox`
+- `PATCH /api/comment-dispatches/outbox/:outboxItemId/status`
 - `GET /api/comment-dispatches/audit-events`
 - `POST /api/waivers`
 - `PATCH /api/waivers/:waiverId`
@@ -184,6 +185,11 @@ metadata-only `PENDING` outbox item. Repeated enqueue requests for the same plan
 existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped outbox
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
+
+`PATCH /api/comment-dispatches/outbox/:outboxItemId/status` may update a tenant-scoped
+outbox item to `FAILED` or `CANCELED` with a reason and timestamp. `PUBLISHED` transitions,
+external comment IDs, and SCM write-result metadata remain deferred until a real dispatcher
+runtime exists.
 
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -160,6 +160,13 @@
 - [x] T090 Avoid duplicate enqueue audit events for idempotent enqueue retries
 - [x] T091 Add e2e coverage for enqueue audit metadata and credential/source leakage guardrails
 
+## Phase 24: Comment Dispatch Outbox Failure Status Boundary Slice
+
+- [x] T092 Add comment dispatch outbox failure status update contract
+- [x] T093 Add tenant-scoped outbox status update endpoint
+- [x] T094 Allow `FAILED` and `CANCELED` metadata transitions while deferring `PUBLISHED`
+- [x] T095 Add e2e coverage for tenant scoping, publish deferral, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/163-comment-dispatch-outbox-failure-status`
- 이슈: Closes #163

## 주요 변경 사항

- 댓글 디스패치 outbox failure/cancel status update shared 계약을 추가했습니다.
- `PATCH /api/comment-dispatches/outbox/:outboxItemId/status` endpoint를 추가했습니다.
- tenant-scoped outbox item만 `FAILED` 또는 `CANCELED`로 metadata 전이할 수 있게 했습니다.
- `statusReason`, `statusUpdatedAt` metadata를 outbox item에 반영합니다.
- `PUBLISHED`, externalCommentId, SCM token/source/raw scanner payload 입력은 거부합니다.
- 실제 GitHub/GitLab 댓글 발행, external comment ID 저장, SCM write API 호출은 계속 deferred로 유지했습니다.
- 002 contract/tasks 문서를 Phase 24까지 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR merge 전 반드시 **CI가 정상적으로 작동하는지 확인**합니다.

## 검증

- [x] `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`