### PR TITLE
feat: 댓글 디스패치 대기열 상태 감사 이벤트 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -390,14 +390,40 @@ export class ControlPlaneService {
     }
 
     const [planId, outboxItem] = outboxEntry;
+    if (outboxItem.status === input.status && outboxItem.statusReason === input.statusReason) {
+      return outboxItem;
+    }
+
+    const statusUpdatedAt = new Date(0).toISOString();
     const updatedOutboxItem: CommentDispatchOutboxItem = {
       ...outboxItem,
       status: input.status,
       statusReason: input.statusReason,
-      statusUpdatedAt: new Date(0).toISOString()
+      statusUpdatedAt
     };
 
     this.commentDispatchOutboxItems.set(planId, updatedOutboxItem);
+    this.commentDispatchAuditEvents.push({
+      id: `audit_event_${++this.commentDispatchAuditSequence}`,
+      tenantId: input.tenantId,
+      eventType: "comment_dispatch.outbox_status_updated",
+      actor: "comment-dispatcher",
+      targetType: "comment_dispatch_outbox_item",
+      targetId: outboxItem.id,
+      occurredAt: statusUpdatedAt,
+      metadata: {
+        outboxItemId: outboxItem.id,
+        planId: outboxItem.planId,
+        previousStatus: outboxItem.status,
+        nextStatus: updatedOutboxItem.status,
+        statusReason: updatedOutboxItem.statusReason,
+        statusUpdatedAt: updatedOutboxItem.statusUpdatedAt,
+        repositoryBindingId: outboxItem.repositoryBindingId,
+        provider: outboxItem.provider,
+        findingId: outboxItem.findingId,
+        commitSha: outboxItem.commitSha
+      }
+    });
 
     return updatedOutboxItem;
   }

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -455,6 +455,86 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(404);
   });
 
+  it("records one metadata-only audit event when an outbox item enters a failure state", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_status_audit",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-status-audit"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_status_audit",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_status_audit", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    const failedPayload = {
+      tenantId: "tenant_comment_outbox_status_audit",
+      status: "FAILED",
+      statusReason: "SCM_RATE_LIMIT"
+    };
+    const firstFailedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send(failedPayload)
+      .expect(200);
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send(failedPayload)
+      .expect(200);
+    const failedOutboxItem = dataOf<Record<string, unknown>>(firstFailedResponse.body);
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_status_audit" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents).toHaveLength(3);
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_status_updated"
+    ]);
+    expect(auditEvents[2]).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^audit_event_\d+$/),
+        tenantId: "tenant_comment_outbox_status_audit",
+        eventType: "comment_dispatch.outbox_status_updated",
+        actor: "comment-dispatcher",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id,
+        occurredAt: "1970-01-01T00:00:00.000Z",
+        metadata: {
+          outboxItemId: outboxItem.id,
+          planId: plan.id,
+          previousStatus: "PENDING",
+          nextStatus: "FAILED",
+          statusReason: "SCM_RATE_LIMIT",
+          statusUpdatedAt: failedOutboxItem.statusUpdatedAt,
+          repositoryBindingId: repositoryBinding.id,
+          provider: "GITHUB",
+          findingId: "finding_comment_1",
+          commitSha: "abc123comment"
+        }
+      })
+    );
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -270,21 +270,28 @@ export interface AuditEvent {
 }
 
 export interface CommentDispatchAuditEvent extends AuditEvent {
-  eventType: 'comment_dispatch.planned' | 'comment_dispatch.enqueued';
+  eventType:
+    | 'comment_dispatch.planned'
+    | 'comment_dispatch.enqueued'
+    | 'comment_dispatch.outbox_status_updated';
   actor: 'comment-dispatcher';
   targetType: 'comment_dispatch_plan' | 'comment_dispatch_outbox_item';
   metadata: {
     repositoryBindingId: string;
     provider: ScmProvider;
     providerRepoId?: string;
-    policyDecisionId: string;
+    policyDecisionId?: string;
     findingId: string;
-    targetRef: string;
+    targetRef?: string;
     commitSha: string;
-    commentWritePrincipalId: string;
+    commentWritePrincipalId?: string;
     outboxItemId?: string;
     planId?: string;
     idempotencyKey?: string;
+    previousStatus?: CommentDispatchOutboxItem['status'];
+    nextStatus?: CommentDispatchOutboxItem['status'];
+    statusReason?: string;
+    statusUpdatedAt?: string;
   };
 }
 

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -206,3 +206,12 @@ provider, policy decision ID, finding ID, target ref, commit SHA, and comment-wr
 principal ID. It must not include SCM token values, repo-read principals,
 integration-admin principals, external comment IDs, full repository content, source
 archives, or raw scanner payloads.
+
+Every first successful outbox failure/cancel status transition records one tenant-scoped
+`comment_dispatch.outbox_status_updated` audit event. Repeated requests with the same
+status and reason return the existing outbox item and do not create duplicate status audit
+events. Status audit metadata is limited to outbox item ID, plan ID, previous status, next
+status, status reason, status update timestamp, repository binding ID, provider, finding
+ID, and commit SHA. It must not include `PUBLISHED` write-result metadata, external comment
+IDs, SCM token values, repo-read principals, integration-admin principals, full repository
+content, source archives, or raw scanner payloads.

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -167,6 +167,13 @@
 - [x] T094 Allow `FAILED` and `CANCELED` metadata transitions while deferring `PUBLISHED`
 - [x] T095 Add e2e coverage for tenant scoping, publish deferral, and credential/source leakage guardrails
 
+## Phase 25: Comment Dispatch Outbox Status Audit Event Boundary Slice
+
+- [x] T096 Extend comment dispatch audit event contract for outbox status updates
+- [x] T097 Record one tenant-scoped `comment_dispatch.outbox_status_updated` audit event per status transition
+- [x] T098 Avoid duplicate status audit events for idempotent status update retries
+- [x] T099 Add e2e coverage for status audit metadata and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/165-comment-dispatch-outbox-status-audit`
- 이슈: Closes #165

## 주요 변경 사항

- 댓글 디스패치 대기열 항목이 `FAILED`/`CANCELED` 상태로 전이될 때 tenant-scoped `comment_dispatch.outbox_status_updated` 감사 이벤트를 기록합니다.
- 같은 상태와 사유로 재시도되는 상태 업데이트는 기존 outbox 항목을 반환하고 감사 이벤트를 중복 생성하지 않도록 했습니다.
- 공유 계약 타입, 계약 문서, 002 태스크 목록, e2e 누출 방지 검증을 함께 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit events are now recorded when comment dispatch outbox items transition to failed or canceled states, including status history and related metadata.

* **Bug Fixes**
  * Added idempotency checks to prevent duplicate audit events when the same status update is retried.

* **Tests**
  * New end-to-end test coverage verifies audit event recording during outbox status transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->