### PR TITLE
feat: 댓글 디스패치 대기열 작업 클레임 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Patch, Post, Query } from "@nestjs/common
 
 import type {
   CommentDispatchEnqueueRequest,
+  CommentDispatchOutboxClaimRequest,
   CommentDispatchOutboxStatusUpdateRequest,
   CommentDispatchPlanRequest
 } from "../../../../packages/shared/src";
@@ -29,6 +30,11 @@ export class CommentDispatchesController {
   @Get("outbox")
   listOutbox(@Query("tenantId") tenantId: string) {
     return this.controlPlaneService.listCommentDispatchOutbox(tenantId);
+  }
+
+  @Post("outbox/claim")
+  claimOutbox(@Body() body: CommentDispatchOutboxClaimRequest) {
+    return this.controlPlaneService.claimCommentDispatchOutbox(body);
   }
 
   @Patch("outbox/:outboxItemId/status")

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -5,6 +5,7 @@ import {
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
   type CommentDispatchEnqueueRequest,
+  type CommentDispatchOutboxClaimRequest,
   type CommentDispatchOutboxItem,
   type CommentDispatchOutboxStatusUpdateRequest,
   type CommentDispatchPlan,
@@ -370,6 +371,69 @@ export class ControlPlaneService {
 
   listCommentDispatchOutbox(tenantId: string): CommentDispatchOutboxItem[] {
     return Array.from(this.commentDispatchOutboxItems.values()).filter((item) => item.tenantId === tenantId);
+  }
+
+  claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {
+    this.assertSafeCommentDispatchPayload(input);
+
+    if (!input.workerId || !Number.isFinite(input.leaseSeconds) || input.leaseSeconds <= 0) {
+      throw new BadRequestException("Comment dispatch outbox claim requires a worker id and positive lease seconds.");
+    }
+
+    const claimedAt = new Date(0).toISOString();
+    const leaseExpiresAt = new Date(input.leaseSeconds * 1000).toISOString();
+    const existingWorkerClaim = Array.from(this.commentDispatchOutboxItems.values()).find(
+      (item) =>
+        item.tenantId === input.tenantId &&
+        item.status === "PENDING" &&
+        item.claimedBy === input.workerId &&
+        item.leaseExpiresAt !== undefined &&
+        item.leaseExpiresAt > claimedAt
+    );
+    if (existingWorkerClaim) {
+      return existingWorkerClaim;
+    }
+
+    const claimableOutboxItem = Array.from(this.commentDispatchOutboxItems.values()).find(
+      (item) =>
+        item.tenantId === input.tenantId &&
+        item.status === "PENDING" &&
+        (item.leaseExpiresAt === undefined || item.leaseExpiresAt <= claimedAt)
+    );
+    if (!claimableOutboxItem) {
+      return null;
+    }
+
+    const claimedOutboxItem: CommentDispatchOutboxItem = {
+      ...claimableOutboxItem,
+      claimedBy: input.workerId,
+      claimedAt,
+      leaseExpiresAt
+    };
+
+    this.commentDispatchOutboxItems.set(claimedOutboxItem.planId, claimedOutboxItem);
+    this.commentDispatchAuditEvents.push({
+      id: `audit_event_${++this.commentDispatchAuditSequence}`,
+      tenantId: input.tenantId,
+      eventType: "comment_dispatch.outbox_claimed",
+      actor: "comment-dispatcher",
+      targetType: "comment_dispatch_outbox_item",
+      targetId: claimedOutboxItem.id,
+      occurredAt: claimedAt,
+      metadata: {
+        outboxItemId: claimedOutboxItem.id,
+        planId: claimedOutboxItem.planId,
+        workerId: input.workerId,
+        claimedAt,
+        leaseExpiresAt,
+        repositoryBindingId: claimedOutboxItem.repositoryBindingId,
+        provider: claimedOutboxItem.provider,
+        findingId: claimedOutboxItem.findingId,
+        commitSha: claimedOutboxItem.commitSha
+      }
+    });
+
+    return claimedOutboxItem;
   }
 
   updateCommentDispatchOutboxStatus(

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -535,6 +535,120 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("claims one pending outbox item for a dispatcher worker without publishing external comments", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_claim",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-claim"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_claim",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_claim", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    const claimPayload = {
+      tenantId: "tenant_comment_outbox_claim",
+      workerId: "comment-dispatch-worker-1",
+      leaseSeconds: 300
+    };
+    const firstClaimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send(claimPayload)
+      .expect(201);
+    const secondClaimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send(claimPayload)
+      .expect(201);
+    const otherWorkerClaimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_claim",
+        workerId: "comment-dispatch-worker-2",
+        leaseSeconds: 300
+      })
+      .expect(201);
+    const otherTenantClaimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_claim_other",
+        workerId: "comment-dispatch-worker-1",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(firstClaimResponse.body)).toEqual({
+      ...outboxItem,
+      claimedBy: "comment-dispatch-worker-1",
+      claimedAt: "1970-01-01T00:00:00.000Z",
+      leaseExpiresAt: "1970-01-01T00:05:00.000Z"
+    });
+    expect(dataOf<Record<string, unknown>>(secondClaimResponse.body)).toEqual(
+      dataOf<Record<string, unknown>>(firstClaimResponse.body)
+    );
+    expect(dataOf<unknown>(otherWorkerClaimResponse.body)).toBeNull();
+    expect(dataOf<unknown>(otherTenantClaimResponse.body)).toBeNull();
+    expect(JSON.stringify(firstClaimResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_claim" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents).toHaveLength(3);
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed"
+    ]);
+    expect(auditEvents[2]).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^audit_event_\d+$/),
+        tenantId: "tenant_comment_outbox_claim",
+        eventType: "comment_dispatch.outbox_claimed",
+        actor: "comment-dispatcher",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id,
+        occurredAt: "1970-01-01T00:00:00.000Z",
+        metadata: {
+          outboxItemId: outboxItem.id,
+          planId: plan.id,
+          workerId: "comment-dispatch-worker-1",
+          claimedAt: "1970-01-01T00:00:00.000Z",
+          leaseExpiresAt: "1970-01-01T00:05:00.000Z",
+          repositoryBindingId: repositoryBinding.id,
+          provider: "GITHUB",
+          findingId: "finding_comment_1",
+          commitSha: "abc123comment"
+        }
+      })
+    );
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({ ...claimPayload, accessToken: "ghs_secret" })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -207,8 +207,17 @@ export interface CommentDispatchOutboxItem {
   commitSha: string;
   status: 'PENDING' | 'PUBLISHED' | 'FAILED' | 'CANCELED';
   enqueuedAt: string;
+  claimedBy?: string;
+  claimedAt?: string;
+  leaseExpiresAt?: string;
   statusReason?: string;
   statusUpdatedAt?: string;
+}
+
+export interface CommentDispatchOutboxClaimRequest {
+  tenantId: string;
+  workerId: string;
+  leaseSeconds: number;
 }
 
 export interface CommentDispatchOutboxStatusUpdateRequest {
@@ -273,6 +282,7 @@ export interface CommentDispatchAuditEvent extends AuditEvent {
   eventType:
     | 'comment_dispatch.planned'
     | 'comment_dispatch.enqueued'
+    | 'comment_dispatch.outbox_claimed'
     | 'comment_dispatch.outbox_status_updated';
   actor: 'comment-dispatcher';
   targetType: 'comment_dispatch_plan' | 'comment_dispatch_outbox_item';
@@ -292,6 +302,9 @@ export interface CommentDispatchAuditEvent extends AuditEvent {
     nextStatus?: CommentDispatchOutboxItem['status'];
     statusReason?: string;
     statusUpdatedAt?: string;
+    workerId?: string;
+    claimedAt?: string;
+    leaseExpiresAt?: string;
   };
 }
 

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -28,6 +28,7 @@ sandbox, or AI runtime implementation.
 - `POST /api/comment-dispatches/plan`
 - `POST /api/comment-dispatches/enqueue`
 - `GET /api/comment-dispatches/outbox`
+- `POST /api/comment-dispatches/outbox/claim`
 - `PATCH /api/comment-dispatches/outbox/:outboxItemId/status`
 - `GET /api/comment-dispatches/audit-events`
 - `POST /api/waivers`
@@ -185,6 +186,22 @@ metadata-only `PENDING` outbox item. Repeated enqueue requests for the same plan
 existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped outbox
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
+
+`POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
+`PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window
+returns the same claimed item. Other workers and other tenants do not receive an item while
+the lease is active. Claim metadata is limited to worker ID, claim timestamp, and lease
+expiration timestamp; it does not publish comments, persist external comment IDs, or expose
+SCM token values, repo-read principals, integration-admin principals, full repository content,
+source archives, or raw scanner payloads.
+
+Every first successful outbox claim records one tenant-scoped
+`comment_dispatch.outbox_claimed` audit event. Same-worker retries inside the active lease
+return the existing claimed item and do not create duplicate claim audit events. Claim audit
+metadata is limited to outbox item ID, plan ID, worker ID, claim timestamp, lease expiration
+timestamp, repository binding ID, provider, finding ID, and commit SHA. It must not include
+external comment IDs, SCM token values, repo-read principals, integration-admin principals,
+full repository content, source archives, or raw scanner payloads.
 
 `PATCH /api/comment-dispatches/outbox/:outboxItemId/status` may update a tenant-scoped
 outbox item to `FAILED` or `CANCELED` with a reason and timestamp. `PUBLISHED` transitions,

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -174,6 +174,14 @@
 - [x] T098 Avoid duplicate status audit events for idempotent status update retries
 - [x] T099 Add e2e coverage for status audit metadata and credential/source leakage guardrails
 
+## Phase 26: Comment Dispatch Outbox Claim Boundary Slice
+
+- [x] T100 Add shared comment dispatch outbox claim request and lease metadata contract
+- [x] T101 Add tenant-scoped metadata-only outbox claim endpoint
+- [x] T102 Return the same claim for same-worker retries while withholding active leases from other workers
+- [x] T103 Record one tenant-scoped `comment_dispatch.outbox_claimed` audit event per first claim
+- [x] T104 Add e2e coverage for tenant scoping, lease metadata, audit idempotency, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/167-comment-dispatch-outbox-claim`
- 이슈: Closes #167

## 주요 변경 사항

- `POST /api/comment-dispatches/outbox/claim` 경계를 추가해 dispatcher worker가 tenant-scoped `PENDING` outbox item 하나를 metadata-only로 claim할 수 있게 했습니다.
- active lease 안에서 같은 worker 재시도는 같은 claim을 반환하고, 다른 worker/tenant에는 claim된 항목을 반환하지 않도록 했습니다.
- 최초 claim에 대해 `comment_dispatch.outbox_claimed` 감사 이벤트를 한 번만 기록하고, 응답/감사 이벤트에서 SCM 토큰, external comment ID, repo-read/admin principal, source/raw payload가 노출되지 않도록 e2e로 고정했습니다.
- 공유 계약 타입과 002 contracts/tasks 문서를 함께 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint enabling workers to claim pending comment dispatch outbox items with lease-based expiration and tenant scoping.
  * Implemented audit event tracking for all claim operations.

* **Tests**
  * Added end-to-end tests verifying claim isolation, security, and idempotent behavior.

* **Documentation**
  * Updated API contract specifications and architecture documentation with new claim endpoint details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->