### PR TITLE
feat: 댓글 디스패치 대기열 상태 변경 소유권 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -446,6 +446,10 @@ export class ControlPlaneService {
       throw new BadRequestException("Only FAILED or CANCELED outbox status updates are accepted in this milestone.");
     }
 
+    if (!input.workerId) {
+      throw new BadRequestException("Comment dispatch outbox status updates require the claiming worker id.");
+    }
+
     const outboxEntry = Array.from(this.commentDispatchOutboxItems.entries()).find(
       ([, item]) => item.id === outboxItemId && item.tenantId === input.tenantId
     );
@@ -454,11 +458,19 @@ export class ControlPlaneService {
     }
 
     const [planId, outboxItem] = outboxEntry;
+    const statusUpdatedAt = new Date(0).toISOString();
+    if (
+      outboxItem.claimedBy !== input.workerId ||
+      outboxItem.leaseExpiresAt === undefined ||
+      outboxItem.leaseExpiresAt <= statusUpdatedAt
+    ) {
+      throw new BadRequestException("Comment dispatch outbox status updates require an active worker claim.");
+    }
+
     if (outboxItem.status === input.status && outboxItem.statusReason === input.statusReason) {
       return outboxItem;
     }
 
-    const statusUpdatedAt = new Date(0).toISOString();
     const updatedOutboxItem: CommentDispatchOutboxItem = {
       ...outboxItem,
       status: input.status,
@@ -482,6 +494,7 @@ export class ControlPlaneService {
         nextStatus: updatedOutboxItem.status,
         statusReason: updatedOutboxItem.statusReason,
         statusUpdatedAt: updatedOutboxItem.statusUpdatedAt,
+        workerId: input.workerId,
         repositoryBindingId: outboxItem.repositoryBindingId,
         provider: outboxItem.provider,
         findingId: outboxItem.findingId,

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -407,18 +407,28 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .send({ tenantId: "tenant_comment_outbox_status", planId: plan.id })
       .expect(201);
     const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+    const claimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_status",
+        workerId: "comment-dispatch-worker-status",
+        leaseSeconds: 300
+      })
+      .expect(201);
+    const claimedOutboxItem = dataOf<Record<string, unknown>>(claimResponse.body);
 
     const failedResponse = await request(app.getHttpServer())
       .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
       .send({
         tenantId: "tenant_comment_outbox_status",
+        workerId: "comment-dispatch-worker-status",
         status: "FAILED",
         statusReason: "SCM_RATE_LIMIT"
       })
       .expect(200);
 
     expect(dataOf<Record<string, unknown>>(failedResponse.body)).toEqual({
-      ...outboxItem,
+      ...claimedOutboxItem,
       status: "FAILED",
       statusReason: "SCM_RATE_LIMIT",
       statusUpdatedAt: "1970-01-01T00:00:00.000Z"
@@ -440,6 +450,7 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
       .send({
         tenantId: "tenant_comment_outbox_status",
+        workerId: "comment-dispatch-worker-status",
         status: "PUBLISHED",
         externalCommentId: "github-comment-1"
       })
@@ -449,6 +460,7 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
       .send({
         tenantId: "tenant_comment_outbox_other",
+        workerId: "comment-dispatch-worker-status",
         status: "CANCELED",
         statusReason: "TENANT_MISMATCH"
       })
@@ -479,9 +491,18 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .send({ tenantId: "tenant_comment_outbox_status_audit", planId: plan.id })
       .expect(201);
     const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_status_audit",
+        workerId: "comment-dispatch-worker-status-audit",
+        leaseSeconds: 300
+      })
+      .expect(201);
 
     const failedPayload = {
       tenantId: "tenant_comment_outbox_status_audit",
+      workerId: "comment-dispatch-worker-status-audit",
       status: "FAILED",
       statusReason: "SCM_RATE_LIMIT"
     };
@@ -501,13 +522,14 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(200);
     const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
 
-    expect(auditEvents).toHaveLength(3);
+    expect(auditEvents).toHaveLength(4);
     expect(auditEvents.map((event) => event.eventType)).toEqual([
       "comment_dispatch.planned",
       "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed",
       "comment_dispatch.outbox_status_updated"
     ]);
-    expect(auditEvents[2]).toEqual(
+    expect(auditEvents[3]).toEqual(
       expect.objectContaining({
         id: expect.stringMatching(/^audit_event_\d+$/),
         tenantId: "tenant_comment_outbox_status_audit",
@@ -523,6 +545,7 @@ describe("Comment dispatcher boundary API (e2e)", () => {
           nextStatus: "FAILED",
           statusReason: "SCM_RATE_LIMIT",
           statusUpdatedAt: failedOutboxItem.statusUpdatedAt,
+          workerId: "comment-dispatch-worker-status-audit",
           repositoryBindingId: repositoryBinding.id,
           provider: "GITHUB",
           findingId: "finding_comment_1",
@@ -647,6 +670,113 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .post("/api/comment-dispatches/outbox/claim")
       .send({ ...claimPayload, accessToken: "ghs_secret" })
       .expect(400);
+  });
+
+  it("requires the active claim owner when a dispatcher worker updates outbox status", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_status_owner",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-status-owner"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_status_owner",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_status_owner", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status_owner",
+        workerId: "comment-dispatch-worker-1",
+        status: "FAILED",
+        statusReason: "UNCLAIMED_STATUS_UPDATE"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_status_owner",
+        workerId: "comment-dispatch-worker-1",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status_owner",
+        workerId: "comment-dispatch-worker-2",
+        status: "FAILED",
+        statusReason: "WRONG_WORKER"
+      })
+      .expect(400);
+
+    const failedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status_owner",
+        workerId: "comment-dispatch-worker-1",
+        status: "FAILED",
+        statusReason: "SCM_RATE_LIMIT"
+      })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(failedResponse.body)).toEqual(
+      expect.objectContaining({
+        id: outboxItem.id,
+        tenantId: "tenant_comment_outbox_status_owner",
+        claimedBy: "comment-dispatch-worker-1",
+        status: "FAILED",
+        statusReason: "SCM_RATE_LIMIT",
+        statusUpdatedAt: "1970-01-01T00:00:00.000Z"
+      })
+    );
+    expect(JSON.stringify(failedResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_status_owner" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed",
+      "comment_dispatch.outbox_status_updated"
+    ]);
+    expect(auditEvents[3]).toEqual(
+      expect.objectContaining({
+        eventType: "comment_dispatch.outbox_status_updated",
+        metadata: expect.objectContaining({
+          outboxItemId: outboxItem.id,
+          workerId: "comment-dispatch-worker-1",
+          previousStatus: "PENDING",
+          nextStatus: "FAILED",
+          statusReason: "SCM_RATE_LIMIT"
+        })
+      })
+    );
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
   });
 
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -222,6 +222,7 @@ export interface CommentDispatchOutboxClaimRequest {
 
 export interface CommentDispatchOutboxStatusUpdateRequest {
   tenantId: string;
+  workerId: string;
   status: Extract<CommentDispatchOutboxItem['status'], 'FAILED' | 'CANCELED'>;
   statusReason: string;
 }

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -208,6 +208,12 @@ outbox item to `FAILED` or `CANCELED` with a reason and timestamp. `PUBLISHED` t
 external comment IDs, and SCM write-result metadata remain deferred until a real dispatcher
 runtime exists.
 
+Outbox status updates require the active claim owner's worker ID. Unclaimed items, requests
+from a different worker, tenant mismatches, and missing or expired lease metadata are
+rejected. Status update audit metadata may include the claiming worker ID, but must not
+include SCM token values, repo-read principals, integration-admin principals, external
+comment IDs, full repository content, source archives, or raw scanner payloads.
+
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns
 metadata only: repository binding ID, provider, provider repository ID, policy decision ID,

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -182,6 +182,13 @@
 - [x] T103 Record one tenant-scoped `comment_dispatch.outbox_claimed` audit event per first claim
 - [x] T104 Add e2e coverage for tenant scoping, lease metadata, audit idempotency, and credential/source leakage guardrails
 
+## Phase 27: Comment Dispatch Outbox Status Ownership Boundary Slice
+
+- [x] T105 Require worker ownership metadata for outbox status update requests
+- [x] T106 Reject unclaimed, cross-worker, cross-tenant, and inactive-lease status updates
+- [x] T107 Include only the claiming worker ID in status update audit metadata
+- [x] T108 Add e2e coverage for status ownership and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/169-comment-dispatch-status-ownership`
- 이슈: Closes #169

## 주요 변경 사항

- outbox 상태 업데이트 요청에 `workerId` ownership metadata를 추가했습니다.
- `FAILED`/`CANCELED` 상태 전이를 active claim lease를 가진 동일 worker에게만 허용하고, 미클레임/다른 worker/tenant mismatch/비활성 lease 요청은 거절합니다.
- `comment_dispatch.outbox_status_updated` 감사 이벤트에는 claiming worker ID만 추가하고, SCM 토큰, external comment ID, repo-read/admin principal, source/raw payload는 계속 차단합니다.
- 002 contracts/tasks 문서를 Phase 27 기준으로 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`