### PR TITLE
feat: 댓글 디스패치 대기열 터미널 상태 최종성 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -471,6 +471,10 @@ export class ControlPlaneService {
       return outboxItem;
     }
 
+    if (outboxItem.status === "FAILED" || outboxItem.status === "CANCELED") {
+      throw new BadRequestException("Terminal comment dispatch outbox statuses cannot be rewritten.");
+    }
+
     const updatedOutboxItem: CommentDispatchOutboxItem = {
       ...outboxItem,
       status: input.status,

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -779,6 +779,105 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("keeps terminal outbox failure states immutable except for exact idempotent retries", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_status_finality",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-status-finality"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_status_finality",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_status_finality", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_status_finality",
+        workerId: "comment-dispatch-worker-finality",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    const failedPayload = {
+      tenantId: "tenant_comment_outbox_status_finality",
+      workerId: "comment-dispatch-worker-finality",
+      status: "FAILED",
+      statusReason: "SCM_RATE_LIMIT"
+    };
+    const firstFailedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send(failedPayload)
+      .expect(200);
+    const retryFailedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send(failedPayload)
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(retryFailedResponse.body)).toEqual(
+      dataOf<Record<string, unknown>>(firstFailedResponse.body)
+    );
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status_finality",
+        workerId: "comment-dispatch-worker-finality",
+        status: "FAILED",
+        statusReason: "DIFFERENT_FAILURE_REASON"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_status_finality",
+        workerId: "comment-dispatch-worker-finality",
+        status: "CANCELED",
+        statusReason: "MANUAL_CANCEL_AFTER_FAILURE"
+      })
+      .expect(400);
+
+    const outboxResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_status_finality" })
+      .expect(200);
+
+    expect(dataOf<Array<Record<string, unknown>>>(outboxResponse.body)).toEqual([
+      dataOf<Record<string, unknown>>(firstFailedResponse.body)
+    ]);
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_status_finality" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed",
+      "comment_dispatch.outbox_status_updated"
+    ]);
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -214,6 +214,11 @@ rejected. Status update audit metadata may include the claiming worker ID, but m
 include SCM token values, repo-read principals, integration-admin principals, external
 comment IDs, full repository content, source archives, or raw scanner payloads.
 
+`FAILED` and `CANCELED` are terminal metadata states for this milestone. Exact retries with
+the same status and reason return the existing outbox item and do not create duplicate audit
+events, but attempts to rewrite a terminal item with a different status or reason are
+rejected.
+
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns
 metadata only: repository binding ID, provider, provider repository ID, policy decision ID,

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -189,6 +189,13 @@
 - [x] T107 Include only the claiming worker ID in status update audit metadata
 - [x] T108 Add e2e coverage for status ownership and credential/source leakage guardrails
 
+## Phase 28: Comment Dispatch Outbox Terminal Status Finality Boundary Slice
+
+- [x] T109 Treat `FAILED` and `CANCELED` as terminal outbox metadata states
+- [x] T110 Allow exact idempotent retries for terminal status updates without duplicate audit events
+- [x] T111 Reject attempts to rewrite terminal status or status reason metadata
+- [x] T112 Add e2e coverage for terminal finality and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/171-comment-dispatch-status-finality`
- 이슈: Closes #171

## 주요 변경 사항

- `FAILED`/`CANCELED` outbox 상태를 이번 milestone의 terminal metadata state로 고정했습니다.
- 같은 worker의 동일 상태/사유 재시도는 기존 item을 반환하고 감사 이벤트를 중복 생성하지 않도록 유지했습니다.
- terminal item을 다른 상태나 다른 사유로 재작성하려는 요청은 400으로 거절합니다.
- 002 contracts/tasks 문서를 Phase 28 기준으로 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Outbox items in terminal states (failed/canceled) are now immutable—repeated updates with identical details are idempotently accepted, while attempts to change the status or reason are rejected.

* **Documentation**
  * Updated architecture contracts and task tracking to document terminal state finality and idempotent retry behavior for outbox processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->