### PR TITLE
feat: 댓글 디스패치 대기열 클레임 임대 시간 제한 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import {
   buildCanonicalScanKey,
   buildCommentDispatchIdempotencyKey,
+  COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
   type CommentDispatchEnqueueRequest,
@@ -376,8 +377,13 @@ export class ControlPlaneService {
   claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {
     this.assertSafeCommentDispatchPayload(input);
 
-    if (!input.workerId || !Number.isFinite(input.leaseSeconds) || input.leaseSeconds <= 0) {
-      throw new BadRequestException("Comment dispatch outbox claim requires a worker id and positive lease seconds.");
+    if (
+      !input.workerId ||
+      !Number.isInteger(input.leaseSeconds) ||
+      input.leaseSeconds <= 0 ||
+      input.leaseSeconds > COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS
+    ) {
+      throw new BadRequestException("Comment dispatch outbox claim requires a worker id and 1-900 lease seconds.");
     }
 
     const claimedAt = new Date(0).toISOString();

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -672,6 +672,63 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("rejects invalid or excessive outbox claim lease durations", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_claim_lease",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-claim-lease"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_claim_lease",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_claim_lease", planId: plan.id })
+      .expect(201);
+
+    for (const leaseSeconds of [0, -1, 0.5, 901]) {
+      await request(app.getHttpServer())
+        .post("/api/comment-dispatches/outbox/claim")
+        .send({
+          tenantId: "tenant_comment_outbox_claim_lease",
+          workerId: "comment-dispatch-worker-lease",
+          leaseSeconds
+        })
+        .expect(400);
+    }
+
+    const claimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_claim_lease",
+        workerId: "comment-dispatch-worker-lease",
+        leaseSeconds: 900
+      })
+      .expect(201);
+
+    expect(dataOf<Record<string, unknown>>(claimResponse.body)).toEqual(
+      expect.objectContaining({
+        tenantId: "tenant_comment_outbox_claim_lease",
+        claimedBy: "comment-dispatch-worker-lease",
+        claimedAt: "1970-01-01T00:00:00.000Z",
+        leaseExpiresAt: "1970-01-01T00:15:00.000Z"
+      })
+    );
+    expect(JSON.stringify(claimResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+  });
+
   it("requires the active claim owner when a dispatcher worker updates outbox status", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_outbox_status_owner",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -192,6 +192,8 @@ export interface CommentDispatchEnqueueRequest {
   planId: string;
 }
 
+export const COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS = 900;
+
 export interface CommentDispatchOutboxItem {
   id: string;
   tenantId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -190,10 +190,11 @@ GitLab comments, does not persist external comment IDs, and does not call SCM wr
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window
 returns the same claimed item. Other workers and other tenants do not receive an item while
-the lease is active. Claim metadata is limited to worker ID, claim timestamp, and lease
-expiration timestamp; it does not publish comments, persist external comment IDs, or expose
-SCM token values, repo-read principals, integration-admin principals, full repository content,
-source archives, or raw scanner payloads.
+the lease is active. `leaseSeconds` must be an integer from 1 through 900 seconds. Claim
+metadata is limited to worker ID, claim timestamp, and lease expiration timestamp; it does
+not publish comments, persist external comment IDs, or expose SCM token values, repo-read
+principals, integration-admin principals, full repository content, source archives, or raw
+scanner payloads.
 
 Every first successful outbox claim records one tenant-scoped
 `comment_dispatch.outbox_claimed` audit event. Same-worker retries inside the active lease

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -196,6 +196,13 @@
 - [x] T111 Reject attempts to rewrite terminal status or status reason metadata
 - [x] T112 Add e2e coverage for terminal finality and credential/source leakage guardrails
 
+## Phase 29: Comment Dispatch Outbox Claim Lease Duration Boundary Slice
+
+- [x] T113 Add shared maximum claim lease duration contract
+- [x] T114 Require outbox claim lease duration to be a positive integer no greater than 900 seconds
+- [x] T115 Reject zero, negative, fractional, and excessive claim lease durations
+- [x] T116 Add e2e coverage for lease duration limits and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/173-comment-dispatch-lease-duration`
- 이슈: Closes #173

## 주요 변경 사항

- outbox claim lease duration 계약에 최대 900초 상수를 추가했습니다.
- `leaseSeconds`를 양의 정수, 1-900초 범위로 제한하고 0/음수/소수/초과 요청을 400으로 거절합니다.
- 정상 claim 응답과 감사 이벤트는 기존 metadata-only 경계를 유지합니다.
- 002 contracts/tasks 문서를 Phase 29 기준으로 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`