### PR TITLE
feat: 댓글 디스패치 대기열 클레임 임대 갱신 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -3,6 +3,7 @@ import { Body, Controller, Get, Param, Patch, Post, Query } from "@nestjs/common
 import type {
   CommentDispatchEnqueueRequest,
   CommentDispatchOutboxClaimRequest,
+  CommentDispatchOutboxLeaseRenewalRequest,
   CommentDispatchOutboxStatusUpdateRequest,
   CommentDispatchPlanRequest
 } from "../../../../packages/shared/src";
@@ -35,6 +36,14 @@ export class CommentDispatchesController {
   @Post("outbox/claim")
   claimOutbox(@Body() body: CommentDispatchOutboxClaimRequest) {
     return this.controlPlaneService.claimCommentDispatchOutbox(body);
+  }
+
+  @Patch("outbox/:outboxItemId/lease")
+  renewOutboxLease(
+    @Param("outboxItemId") outboxItemId: string,
+    @Body() body: CommentDispatchOutboxLeaseRenewalRequest
+  ) {
+    return this.controlPlaneService.renewCommentDispatchOutboxLease(outboxItemId, body);
   }
 
   @Patch("outbox/:outboxItemId/status")

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -8,6 +8,7 @@ import {
   type CommentDispatchEnqueueRequest,
   type CommentDispatchOutboxClaimRequest,
   type CommentDispatchOutboxItem,
+  type CommentDispatchOutboxLeaseRenewalRequest,
   type CommentDispatchOutboxStatusUpdateRequest,
   type CommentDispatchPlan,
   type CommentDispatchPlanRequest,
@@ -377,14 +378,7 @@ export class ControlPlaneService {
   claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {
     this.assertSafeCommentDispatchPayload(input);
 
-    if (
-      !input.workerId ||
-      !Number.isInteger(input.leaseSeconds) ||
-      input.leaseSeconds <= 0 ||
-      input.leaseSeconds > COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS
-    ) {
-      throw new BadRequestException("Comment dispatch outbox claim requires a worker id and 1-900 lease seconds.");
-    }
+    this.assertValidCommentDispatchLease(input.workerId, input.leaseSeconds);
 
     const claimedAt = new Date(0).toISOString();
     const leaseExpiresAt = new Date(input.leaseSeconds * 1000).toISOString();
@@ -440,6 +434,63 @@ export class ControlPlaneService {
     });
 
     return claimedOutboxItem;
+  }
+
+  renewCommentDispatchOutboxLease(
+    outboxItemId: string,
+    input: CommentDispatchOutboxLeaseRenewalRequest
+  ): CommentDispatchOutboxItem {
+    this.assertSafeCommentDispatchPayload(input);
+    this.assertValidCommentDispatchLease(input.workerId, input.leaseSeconds);
+
+    const renewedAt = new Date(0).toISOString();
+    const outboxEntry = Array.from(this.commentDispatchOutboxItems.entries()).find(
+      ([, item]) => item.id === outboxItemId && item.tenantId === input.tenantId
+    );
+    if (!outboxEntry) {
+      throw new NotFoundException("Comment dispatch outbox item not found for tenant");
+    }
+
+    const [planId, outboxItem] = outboxEntry;
+    if (
+      outboxItem.status !== "PENDING" ||
+      outboxItem.claimedBy !== input.workerId ||
+      outboxItem.claimedAt === undefined ||
+      outboxItem.leaseExpiresAt === undefined ||
+      outboxItem.leaseExpiresAt <= renewedAt
+    ) {
+      throw new BadRequestException("Comment dispatch outbox lease renewal requires an active worker claim.");
+    }
+
+    const leaseExpiresAt = new Date(input.leaseSeconds * 1000).toISOString();
+    const renewedOutboxItem: CommentDispatchOutboxItem = {
+      ...outboxItem,
+      leaseExpiresAt
+    };
+
+    this.commentDispatchOutboxItems.set(planId, renewedOutboxItem);
+    this.commentDispatchAuditEvents.push({
+      id: `audit_event_${++this.commentDispatchAuditSequence}`,
+      tenantId: input.tenantId,
+      eventType: "comment_dispatch.outbox_lease_renewed",
+      actor: "comment-dispatcher",
+      targetType: "comment_dispatch_outbox_item",
+      targetId: outboxItem.id,
+      occurredAt: renewedAt,
+      metadata: {
+        outboxItemId: outboxItem.id,
+        planId: outboxItem.planId,
+        workerId: input.workerId,
+        claimedAt: outboxItem.claimedAt,
+        leaseExpiresAt,
+        repositoryBindingId: outboxItem.repositoryBindingId,
+        provider: outboxItem.provider,
+        findingId: outboxItem.findingId,
+        commitSha: outboxItem.commitSha
+      }
+    });
+
+    return renewedOutboxItem;
   }
 
   updateCommentDispatchOutboxStatus(
@@ -615,6 +666,17 @@ export class ControlPlaneService {
       if (new RegExp(forbiddenKey, "i").test(serialized)) {
         throw new BadRequestException("Comment dispatch payload contains forbidden sensitive or authority content.");
       }
+    }
+  }
+
+  private assertValidCommentDispatchLease(workerId: string, leaseSeconds: number): void {
+    if (
+      !workerId ||
+      !Number.isInteger(leaseSeconds) ||
+      leaseSeconds <= 0 ||
+      leaseSeconds > COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS
+    ) {
+      throw new BadRequestException("Comment dispatch outbox lease requires a worker id and 1-900 lease seconds.");
     }
   }
 }

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -729,6 +729,121 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("renews an active outbox claim lease only for the claiming dispatcher worker", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_lease_renewal",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-lease-renewal"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_lease_renewal",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_lease_renewal", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/lease`)
+      .send({
+        tenantId: "tenant_comment_outbox_lease_renewal",
+        workerId: "comment-dispatch-worker-lease-renewal",
+        leaseSeconds: 300
+      })
+      .expect(400);
+
+    const claimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_lease_renewal",
+        workerId: "comment-dispatch-worker-lease-renewal",
+        leaseSeconds: 300
+      })
+      .expect(201);
+    const claimedOutboxItem = dataOf<Record<string, unknown>>(claimResponse.body);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/lease`)
+      .send({
+        tenantId: "tenant_comment_outbox_lease_renewal",
+        workerId: "comment-dispatch-worker-other",
+        leaseSeconds: 600
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/lease`)
+      .send({
+        tenantId: "tenant_comment_outbox_lease_renewal",
+        workerId: "comment-dispatch-worker-lease-renewal",
+        leaseSeconds: 901
+      })
+      .expect(400);
+
+    const renewalResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/lease`)
+      .send({
+        tenantId: "tenant_comment_outbox_lease_renewal",
+        workerId: "comment-dispatch-worker-lease-renewal",
+        leaseSeconds: 600
+      })
+      .expect(200);
+
+    expect(dataOf<Record<string, unknown>>(renewalResponse.body)).toEqual({
+      ...claimedOutboxItem,
+      leaseExpiresAt: "1970-01-01T00:10:00.000Z"
+    });
+    expect(JSON.stringify(renewalResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+
+    const auditEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_outbox_lease_renewal" })
+      .expect(200);
+    const auditEvents = dataOf<Array<Record<string, unknown>>>(auditEventsResponse.body);
+
+    expect(auditEvents.map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed",
+      "comment_dispatch.outbox_lease_renewed"
+    ]);
+    expect(auditEvents[3]).toEqual(
+      expect.objectContaining({
+        eventType: "comment_dispatch.outbox_lease_renewed",
+        actor: "comment-dispatcher",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id,
+        metadata: {
+          outboxItemId: outboxItem.id,
+          planId: plan.id,
+          workerId: "comment-dispatch-worker-lease-renewal",
+          claimedAt: "1970-01-01T00:00:00.000Z",
+          leaseExpiresAt: "1970-01-01T00:10:00.000Z",
+          repositoryBindingId: repositoryBinding.id,
+          provider: "GITHUB",
+          findingId: "finding_comment_1",
+          commitSha: "abc123comment"
+        }
+      })
+    );
+    expect(JSON.stringify(auditEventsResponse.body)).not.toMatch(
+      /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload|repoReadPrincipalId|integrationAdminPrincipalId|externalCommentId/i
+    );
+  });
+
   it("requires the active claim owner when a dispatcher worker updates outbox status", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_outbox_status_owner",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -222,6 +222,12 @@ export interface CommentDispatchOutboxClaimRequest {
   leaseSeconds: number;
 }
 
+export interface CommentDispatchOutboxLeaseRenewalRequest {
+  tenantId: string;
+  workerId: string;
+  leaseSeconds: number;
+}
+
 export interface CommentDispatchOutboxStatusUpdateRequest {
   tenantId: string;
   workerId: string;
@@ -286,6 +292,7 @@ export interface CommentDispatchAuditEvent extends AuditEvent {
     | 'comment_dispatch.planned'
     | 'comment_dispatch.enqueued'
     | 'comment_dispatch.outbox_claimed'
+    | 'comment_dispatch.outbox_lease_renewed'
     | 'comment_dispatch.outbox_status_updated';
   actor: 'comment-dispatcher';
   targetType: 'comment_dispatch_plan' | 'comment_dispatch_outbox_item';

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -29,6 +29,7 @@ sandbox, or AI runtime implementation.
 - `POST /api/comment-dispatches/enqueue`
 - `GET /api/comment-dispatches/outbox`
 - `POST /api/comment-dispatches/outbox/claim`
+- `PATCH /api/comment-dispatches/outbox/:outboxItemId/lease`
 - `PATCH /api/comment-dispatches/outbox/:outboxItemId/status`
 - `GET /api/comment-dispatches/audit-events`
 - `POST /api/waivers`
@@ -203,6 +204,17 @@ metadata is limited to outbox item ID, plan ID, worker ID, claim timestamp, leas
 timestamp, repository binding ID, provider, finding ID, and commit SHA. It must not include
 external comment IDs, SCM token values, repo-read principals, integration-admin principals,
 full repository content, source archives, or raw scanner payloads.
+
+`PATCH /api/comment-dispatches/outbox/:outboxItemId/lease` lets the active claim owner renew
+the lease for a tenant-scoped `PENDING` outbox item. Renewal uses the same 1 through 900
+second integer duration limit as claim creation. Unclaimed items, terminal items, tenant
+mismatches, different workers, expired leases, and invalid durations are rejected. Every
+successful renewal records one tenant-scoped `comment_dispatch.outbox_lease_renewed` audit
+event with metadata limited to outbox item ID, plan ID, worker ID, claim timestamp, renewed
+lease expiration timestamp, repository binding ID, provider, finding ID, and commit SHA. It
+must not include external comment IDs, SCM token values, repo-read principals,
+integration-admin principals, full repository content, source archives, or raw scanner
+payloads.
 
 `PATCH /api/comment-dispatches/outbox/:outboxItemId/status` may update a tenant-scoped
 outbox item to `FAILED` or `CANCELED` with a reason and timestamp. `PUBLISHED` transitions,

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -203,6 +203,14 @@
 - [x] T115 Reject zero, negative, fractional, and excessive claim lease durations
 - [x] T116 Add e2e coverage for lease duration limits and credential/source leakage guardrails
 
+## Phase 30: Comment Dispatch Outbox Lease Renewal Boundary Slice
+
+- [x] T117 Add shared comment dispatch outbox lease renewal request contract
+- [x] T118 Add tenant-scoped metadata-only outbox lease renewal endpoint
+- [x] T119 Restrict renewal to active claim owners with valid 1-900 second lease duration
+- [x] T120 Record tenant-scoped `comment_dispatch.outbox_lease_renewed` audit events
+- [x] T121 Add e2e coverage for renewal ownership, duration limits, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/175-comment-dispatch-lease-renewal`
- 이슈: Closes #175

## 주요 변경 사항

- `PATCH /api/comment-dispatches/outbox/:outboxItemId/lease` endpoint를 추가했습니다.
- active claim owner만 `PENDING` outbox item의 lease를 1-900초 범위로 갱신할 수 있게 했습니다.
- 미클레임, 다른 worker, tenant mismatch, terminal status, invalid lease duration은 거절합니다.
- `comment_dispatch.outbox_lease_renewed` 감사 이벤트를 metadata-only로 기록하고 credential/source/write-result metadata 노출을 차단했습니다.
- 002 contracts/tasks 문서를 Phase 30 기준으로 갱신했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 했습니다.
- [x] **라벨(Label)** 등록을 했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인합니다.

## 검증

- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`