### PR TITLE
feat: 댓글 디스패치 대기열 조회 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -3,6 +3,7 @@ import { Body, Controller, Get, Param, Patch, Post, Query } from "@nestjs/common
 import type {
   CommentDispatchEnqueueRequest,
   CommentDispatchOutboxClaimRequest,
+  CommentDispatchOutboxListQuery,
   CommentDispatchOutboxLeaseRenewalRequest,
   CommentDispatchOutboxStatusUpdateRequest,
   CommentDispatchPlanRequest
@@ -29,8 +30,8 @@ export class CommentDispatchesController {
   }
 
   @Get("outbox")
-  listOutbox(@Query("tenantId") tenantId: string) {
-    return this.controlPlaneService.listCommentDispatchOutbox(tenantId);
+  listOutbox(@Query() query: CommentDispatchOutboxListQuery) {
+    return this.controlPlaneService.listCommentDispatchOutbox(query);
   }
 
   @Post("outbox/claim")

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -8,6 +8,7 @@ import {
   type CommentDispatchEnqueueRequest,
   type CommentDispatchOutboxClaimRequest,
   type CommentDispatchOutboxItem,
+  type CommentDispatchOutboxListQuery,
   type CommentDispatchOutboxLeaseRenewalRequest,
   type CommentDispatchOutboxStatusUpdateRequest,
   type CommentDispatchPlan,
@@ -371,8 +372,29 @@ export class ControlPlaneService {
     return outboxItem;
   }
 
-  listCommentDispatchOutbox(tenantId: string): CommentDispatchOutboxItem[] {
-    return Array.from(this.commentDispatchOutboxItems.values()).filter((item) => item.tenantId === tenantId);
+  listCommentDispatchOutbox(query: CommentDispatchOutboxListQuery): CommentDispatchOutboxItem[] {
+    this.assertSafeCommentDispatchPayload(query);
+
+    if (!query.tenantId) {
+      throw new BadRequestException("Comment dispatch outbox reads require a tenant id.");
+    }
+
+    if (
+      query.status !== undefined &&
+      query.status !== "PENDING" &&
+      query.status !== "PUBLISHED" &&
+      query.status !== "FAILED" &&
+      query.status !== "CANCELED"
+    ) {
+      throw new BadRequestException("Comment dispatch outbox status filter is invalid.");
+    }
+
+    return Array.from(this.commentDispatchOutboxItems.values()).filter(
+      (item) =>
+        item.tenantId === query.tenantId &&
+        (query.status === undefined || item.status === query.status) &&
+        (query.workerId === undefined || item.claimedBy === query.workerId)
+    );
   }
 
   claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1050,6 +1050,110 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     );
   });
 
+  it("filters outbox reads by status and claiming worker without crossing tenant or sensitive boundaries", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_filters",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-filters"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_outbox_filters",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_filters", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters", status: "FAILED" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    const claimResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_filters",
+        workerId: "comment-dispatch-worker-filter",
+        leaseSeconds: 300
+      })
+      .expect(201);
+    const claimedOutboxItem = dataOf<Record<string, unknown>>(claimResponse.body);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters", workerId: "comment-dispatch-worker-filter" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([claimedOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters", workerId: "comment-dispatch-worker-other" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    const failedResponse = await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${outboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_filters",
+        workerId: "comment-dispatch-worker-filter",
+        status: "FAILED",
+        statusReason: "SCM_RATE_LIMIT"
+      })
+      .expect(200);
+    const failedOutboxItem = dataOf<Record<string, unknown>>(failedResponse.body);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters", status: "PENDING" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters", status: "FAILED" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([failedOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_filters_other", status: "FAILED" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_filters",
+        status: "FAILED",
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -216,6 +216,12 @@ export interface CommentDispatchOutboxItem {
   statusUpdatedAt?: string;
 }
 
+export interface CommentDispatchOutboxListQuery {
+  tenantId: string;
+  status?: CommentDispatchOutboxItem['status'];
+  workerId?: string;
+}
+
 export interface CommentDispatchOutboxClaimRequest {
   tenantId: string;
   workerId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -188,6 +188,12 @@ existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
+Outbox reads accept metadata-only `status` and `workerId` filters after tenant scoping is
+applied. Invalid status values and sensitive query fields are rejected. Filters must not
+expand visibility across tenants and must not accept SCM token values, repo-read principals,
+integration-admin principals, external comment IDs, full repository content, source
+archives, raw scanner payloads, or SCM write-result metadata.
+
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window
 returns the same claimed item. Other workers and other tenants do not receive an item while

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -211,6 +211,13 @@
 - [x] T120 Record tenant-scoped `comment_dispatch.outbox_lease_renewed` audit events
 - [x] T121 Add e2e coverage for renewal ownership, duration limits, and credential/source leakage guardrails
 
+## Phase 31: Comment Dispatch Outbox Read Filter Boundary Slice
+
+- [x] T122 Add shared comment dispatch outbox list query contract
+- [x] T123 Add tenant-scoped metadata-only `status` and `workerId` outbox read filters
+- [x] T124 Reject invalid status filters and sensitive outbox read query fields
+- [x] T125 Add e2e coverage for filter behavior, tenant scoping, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/177-comment-dispatch-outbox-filters`
- 이슈: Closes #177

## 주요 변경 사항

- 댓글 디스패치 outbox 조회 query 공유 계약(`CommentDispatchOutboxListQuery`)을 추가했습니다.
- `GET /api/comment-dispatches/outbox`에 tenant-scoped `status`, `workerId` 필터를 연결했습니다.
- invalid status와 query 내 민감/권한 필드(`accessToken` 등)를 400으로 거절하도록 했습니다.
- 필터 동작, tenant 격리, 민감정보 차단 e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 31로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
