### PR TITLE
feat: 댓글 디스패치 감사 이벤트 조회 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/comment-dispatches.controller.ts
+++ b/apps/api/src/control-plane/comment-dispatches.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, Param, Patch, Post, Query } from "@nestjs/common";
 
 import type {
+  CommentDispatchAuditEventListQuery,
   CommentDispatchEnqueueRequest,
   CommentDispatchOutboxClaimRequest,
   CommentDispatchOutboxListQuery,
@@ -25,8 +26,8 @@ export class CommentDispatchesController {
   }
 
   @Get("audit-events")
-  listAuditEvents(@Query("tenantId") tenantId: string) {
-    return this.controlPlaneService.listCommentDispatchAuditEvents(tenantId);
+  listAuditEvents(@Query() query: CommentDispatchAuditEventListQuery) {
+    return this.controlPlaneService.listCommentDispatchAuditEvents(query);
   }
 
   @Get("outbox")

--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -5,6 +5,7 @@ import {
   COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
+  type CommentDispatchAuditEventListQuery,
   type CommentDispatchEnqueueRequest,
   type CommentDispatchOutboxClaimRequest,
   type CommentDispatchOutboxItem,
@@ -310,8 +311,32 @@ export class ControlPlaneService {
     return plan;
   }
 
-  listCommentDispatchAuditEvents(tenantId: string): CommentDispatchAuditEvent[] {
-    return this.commentDispatchAuditEvents.filter((event) => event.tenantId === tenantId);
+  listCommentDispatchAuditEvents(query: CommentDispatchAuditEventListQuery): CommentDispatchAuditEvent[] {
+    this.assertSafeCommentDispatchPayload(query);
+
+    if (!query.tenantId) {
+      throw new BadRequestException("Comment dispatch audit event reads require a tenant id.");
+    }
+
+    if (query.eventType !== undefined && !this.isCommentDispatchAuditEventType(query.eventType)) {
+      throw new BadRequestException("Comment dispatch audit event type filter is invalid.");
+    }
+
+    if (
+      query.targetType !== undefined &&
+      query.targetType !== "comment_dispatch_plan" &&
+      query.targetType !== "comment_dispatch_outbox_item"
+    ) {
+      throw new BadRequestException("Comment dispatch audit target type filter is invalid.");
+    }
+
+    return this.commentDispatchAuditEvents.filter(
+      (event) =>
+        event.tenantId === query.tenantId &&
+        (query.eventType === undefined || event.eventType === query.eventType) &&
+        (query.targetType === undefined || event.targetType === query.targetType) &&
+        (query.targetId === undefined || event.targetId === query.targetId)
+    );
   }
 
   enqueueCommentDispatch(input: CommentDispatchEnqueueRequest): CommentDispatchOutboxItem {
@@ -689,6 +714,16 @@ export class ControlPlaneService {
         throw new BadRequestException("Comment dispatch payload contains forbidden sensitive or authority content.");
       }
     }
+  }
+
+  private isCommentDispatchAuditEventType(eventType: string): eventType is CommentDispatchAuditEvent["eventType"] {
+    return (
+      eventType === "comment_dispatch.planned" ||
+      eventType === "comment_dispatch.enqueued" ||
+      eventType === "comment_dispatch.outbox_claimed" ||
+      eventType === "comment_dispatch.outbox_lease_renewed" ||
+      eventType === "comment_dispatch.outbox_status_updated"
+    );
   }
 
   private assertValidCommentDispatchLease(workerId: string, leaseSeconds: number): void {

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1154,6 +1154,99 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_filters",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-filters"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_audit_filters",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_filters", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_audit_filters",
+        workerId: "comment-dispatch-worker-audit-filter",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    const plannedEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_filters",
+        eventType: "comment_dispatch.planned"
+      })
+      .expect(200);
+    expect(dataOf<Array<Record<string, unknown>>>(plannedEventsResponse.body)).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant_comment_audit_filters",
+        eventType: "comment_dispatch.planned",
+        targetType: "comment_dispatch_plan",
+        targetId: plan.id
+      })
+    ]);
+
+    const outboxTargetEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_filters",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id
+      })
+      .expect(200);
+    expect(dataOf<Array<Record<string, unknown>>>(outboxTargetEventsResponse.body).map((event) => event.eventType)).toEqual([
+      "comment_dispatch.enqueued",
+      "comment_dispatch.outbox_claimed"
+    ]);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_filters_other",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_filters",
+        eventType: "comment_dispatch.unknown"
+      })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_filters",
+        targetType: "comment_dispatch_outbox_item",
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -324,6 +324,13 @@ export interface CommentDispatchAuditEvent extends AuditEvent {
   };
 }
 
+export interface CommentDispatchAuditEventListQuery {
+  tenantId: string;
+  eventType?: CommentDispatchAuditEvent['eventType'];
+  targetType?: CommentDispatchAuditEvent['targetType'];
+  targetId?: string;
+}
+
 export interface TokenBrokerIssueRequest {
   tenantId: string;
   repositoryBindingId: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -245,6 +245,13 @@ finding ID, target ref, commit SHA, and comment-write principal ID. Audit events
 include SCM token values, repo-read principals, integration-admin principals, full
 repository content, source archives, or raw scanner payloads.
 
+Audit event reads accept metadata-only `eventType`, `targetType`, and `targetId` filters
+after tenant scoping is applied. Invalid event or target type filters and sensitive query
+fields are rejected. Filters must not expand visibility across tenants and must not accept
+SCM token values, repo-read principals, integration-admin principals, external comment IDs,
+full repository content, source archives, raw scanner payloads, or SCM write-result
+metadata.
+
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return
 the existing outbox item and do not create duplicate enqueue audit events. Enqueue audit

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -218,6 +218,13 @@
 - [x] T124 Reject invalid status filters and sensitive outbox read query fields
 - [x] T125 Add e2e coverage for filter behavior, tenant scoping, and credential/source leakage guardrails
 
+## Phase 32: Comment Dispatch Audit Event Read Filter Boundary Slice
+
+- [x] T126 Add shared comment dispatch audit event list query contract
+- [x] T127 Add tenant-scoped metadata-only `eventType`, `targetType`, and `targetId` audit filters
+- [x] T128 Reject invalid audit filters and sensitive audit read query fields
+- [x] T129 Add e2e coverage for audit filter behavior, tenant scoping, and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/179-comment-dispatch-audit-filters`
- 이슈: Closes #179

## 주요 변경 사항

- 댓글 디스패치 감사 이벤트 조회 query 공유 계약(`CommentDispatchAuditEventListQuery`)을 추가했습니다.
- `GET /api/comment-dispatches/audit-events`에 tenant-scoped `eventType`, `targetType`, `targetId` 필터를 연결했습니다.
- invalid event/target filter와 query 내 민감/권한 필드(`accessToken` 등)를 400으로 거절하도록 했습니다.
- 감사 이벤트 필터 동작, tenant 격리, 민감정보 차단 e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 32로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded audit events API with metadata-only filtering by event type, target type, and target ID.
  * Enhanced input validation to reject invalid filter values and sensitive credentials.

* **Tests**
  * Added end-to-end test coverage verifying filter behavior, tenant isolation, and security guardrails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->