### PR TITLE
feat: 댓글 디스패치 감사 이벤트 조회 제한 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import {
   buildCanonicalScanKey,
   buildCommentDispatchIdempotencyKey,
+  COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE,
   COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
@@ -330,13 +331,17 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch audit target type filter is invalid.");
     }
 
-    return this.commentDispatchAuditEvents.filter(
+    const limit = this.parseCommentDispatchAuditEventLimit(query.limit);
+
+    const events = this.commentDispatchAuditEvents.filter(
       (event) =>
         event.tenantId === query.tenantId &&
         (query.eventType === undefined || event.eventType === query.eventType) &&
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)
     );
+
+    return limit === undefined ? events : events.slice(0, limit);
   }
 
   enqueueCommentDispatch(input: CommentDispatchEnqueueRequest): CommentDispatchOutboxItem {
@@ -724,6 +729,23 @@ export class ControlPlaneService {
       eventType === "comment_dispatch.outbox_lease_renewed" ||
       eventType === "comment_dispatch.outbox_status_updated"
     );
+  }
+
+  private parseCommentDispatchAuditEventLimit(limit: number | string | undefined): number | undefined {
+    if (limit === undefined) {
+      return undefined;
+    }
+
+    const parsedLimit = typeof limit === "number" ? limit : Number(limit);
+    if (
+      !Number.isInteger(parsedLimit) ||
+      parsedLimit <= 0 ||
+      parsedLimit > COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE
+    ) {
+      throw new BadRequestException("Comment dispatch audit event limit must be an integer from 1 through 100.");
+    }
+
+    return parsedLimit;
   }
 
   private assertValidCommentDispatchLease(workerId: string, leaseSeconds: number): void {

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1247,6 +1247,76 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("limits audit event reads after tenant and metadata filters are applied", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_limit",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-limit"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_audit_limit",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_limit", planId: plan.id })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_audit_limit",
+        workerId: "comment-dispatch-worker-audit-limit",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    const limitedEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_limit", limit: 2 })
+      .expect(200);
+    expect(dataOf<Array<Record<string, unknown>>>(limitedEventsResponse.body).map((event) => event.eventType)).toEqual([
+      "comment_dispatch.planned",
+      "comment_dispatch.enqueued"
+    ]);
+
+    const limitedOutboxEventsResponse = await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_limit",
+        targetType: "comment_dispatch_outbox_item",
+        limit: 1
+      })
+      .expect(200);
+    expect(dataOf<Array<Record<string, unknown>>>(limitedOutboxEventsResponse.body).map((event) => event.eventType)).toEqual([
+      "comment_dispatch.enqueued"
+    ]);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_limit", limit: 0 })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_limit", limit: 101 })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_limit", limit: 1.5 })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -324,11 +324,14 @@ export interface CommentDispatchAuditEvent extends AuditEvent {
   };
 }
 
+export const COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE = 100;
+
 export interface CommentDispatchAuditEventListQuery {
   tenantId: string;
   eventType?: CommentDispatchAuditEvent['eventType'];
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;
+  limit?: number | string;
 }
 
 export interface TokenBrokerIssueRequest {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -252,6 +252,10 @@ SCM token values, repo-read principals, integration-admin principals, external c
 full repository content, source archives, raw scanner payloads, or SCM write-result
 metadata.
 
+Audit event reads may also accept `limit` after tenant and metadata filters are applied.
+`limit` must be an integer from 1 through 100. Invalid, zero, fractional, negative, or
+excessive limits are rejected before any response body is returned.
+
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return
 the existing outbox item and do not create duplicate enqueue audit events. Enqueue audit

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -225,6 +225,13 @@
 - [x] T128 Reject invalid audit filters and sensitive audit read query fields
 - [x] T129 Add e2e coverage for audit filter behavior, tenant scoping, and credential/source leakage guardrails
 
+## Phase 33: Comment Dispatch Audit Event Read Limit Boundary Slice
+
+- [x] T130 Add shared comment dispatch audit event maximum page size contract
+- [x] T131 Apply tenant-scoped audit read `limit` after metadata filters
+- [x] T132 Reject zero, negative, fractional, and excessive audit read limits
+- [x] T133 Add e2e coverage for limit behavior and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/181-comment-dispatch-audit-limit`
- 이슈: Closes #181

## 주요 변경 사항

- 댓글 디스패치 감사 이벤트 최대 조회 제한 계약(`COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE`)을 추가했습니다.
- `GET /api/comment-dispatches/audit-events`의 `limit`을 tenant/filter 적용 이후 결과에 적용하도록 했습니다.
- `limit`은 1-100 정수만 허용하고, 0/초과/소수 입력은 400으로 거절합니다.
- limit 동작과 invalid limit e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 33으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
