### PR TITLE
feat: 댓글 디스패치 대기열 조회 제한 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -4,6 +4,7 @@ import {
   buildCommentDispatchIdempotencyKey,
   COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE,
   COMMENT_DISPATCH_MAX_CLAIM_LEASE_SECONDS,
+  COMMENT_DISPATCH_OUTBOX_MAX_PAGE_SIZE,
   shouldEscalateIsolation,
   type CommentDispatchAuditEvent,
   type CommentDispatchAuditEventListQuery,
@@ -419,12 +420,16 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch outbox status filter is invalid.");
     }
 
-    return Array.from(this.commentDispatchOutboxItems.values()).filter(
+    const limit = this.parseCommentDispatchOutboxLimit(query.limit);
+
+    const items = Array.from(this.commentDispatchOutboxItems.values()).filter(
       (item) =>
         item.tenantId === query.tenantId &&
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );
+
+    return limit === undefined ? items : items.slice(0, limit);
   }
 
   claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {
@@ -743,6 +748,19 @@ export class ControlPlaneService {
       parsedLimit > COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE
     ) {
       throw new BadRequestException("Comment dispatch audit event limit must be an integer from 1 through 100.");
+    }
+
+    return parsedLimit;
+  }
+
+  private parseCommentDispatchOutboxLimit(limit: number | string | undefined): number | undefined {
+    if (limit === undefined) {
+      return undefined;
+    }
+
+    const parsedLimit = typeof limit === "number" ? limit : Number(limit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit <= 0 || parsedLimit > COMMENT_DISPATCH_OUTBOX_MAX_PAGE_SIZE) {
+      throw new BadRequestException("Comment dispatch outbox limit must be an integer from 1 through 100.");
     }
 
     return parsedLimit;

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1154,6 +1154,117 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("limits outbox reads after tenant and metadata filters are applied", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_limit",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-limit"
+    });
+
+    const createPlan = async (commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_limit",
+            repositoryBindingId: repositoryBinding.id,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan("abc123limit1");
+    const secondPlan = await createPlan("abc123limit2");
+    const thirdPlan = await createPlan("abc123limit3");
+
+    const firstOutboxResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_outbox_limit", planId: firstPlan.id })
+      .expect(201);
+    const firstOutboxItem = dataOf<Record<string, unknown>>(firstOutboxResponse.body);
+    const secondOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_limit", planId: secondPlan.id })
+          .expect(201)
+      ).body.data
+    );
+    const thirdOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_limit", planId: thirdPlan.id })
+          .expect(201)
+      ).body.data
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", limit: 2 })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([firstOutboxItem, secondOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_outbox_limit",
+        workerId: "comment-dispatch-worker-outbox-limit",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/comment-dispatches/outbox/${firstOutboxItem.id}/status`)
+      .send({
+        tenantId: "tenant_comment_outbox_limit",
+        workerId: "comment-dispatch-worker-outbox-limit",
+        status: "FAILED",
+        statusReason: "SCM_RATE_LIMIT"
+      })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", status: "PENDING", limit: 1 })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([secondOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", workerId: "comment-dispatch-worker-outbox-limit", limit: 1 })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)[0]).toEqual(
+          expect.objectContaining({ id: firstOutboxItem.id, status: "FAILED" })
+        );
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", limit: 0 })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", limit: 101 })
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_limit", limit: 1.5 })
+      .expect(400);
+
+    expect(thirdOutboxItem.id).toEqual(expect.stringMatching(/^comment_dispatch_outbox_\d+$/));
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -216,10 +216,13 @@ export interface CommentDispatchOutboxItem {
   statusUpdatedAt?: string;
 }
 
+export const COMMENT_DISPATCH_OUTBOX_MAX_PAGE_SIZE = 100;
+
 export interface CommentDispatchOutboxListQuery {
   tenantId: string;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
+  limit?: number | string;
 }
 
 export interface CommentDispatchOutboxClaimRequest {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -194,6 +194,10 @@ expand visibility across tenants and must not accept SCM token values, repo-read
 integration-admin principals, external comment IDs, full repository content, source
 archives, raw scanner payloads, or SCM write-result metadata.
 
+Outbox reads may also accept `limit` after tenant and metadata filters are applied. `limit`
+must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive
+limits are rejected before any response body is returned.
+
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window
 returns the same claimed item. Other workers and other tenants do not receive an item while

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -232,6 +232,13 @@
 - [x] T132 Reject zero, negative, fractional, and excessive audit read limits
 - [x] T133 Add e2e coverage for limit behavior and credential/source leakage guardrails
 
+## Phase 34: Comment Dispatch Outbox Read Limit Boundary Slice
+
+- [x] T134 Add shared comment dispatch outbox maximum page size contract
+- [x] T135 Apply tenant-scoped outbox read `limit` after status and worker filters
+- [x] T136 Reject zero, negative, fractional, and excessive outbox read limits
+- [x] T137 Add e2e coverage for outbox limit behavior and credential/source leakage guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/183-comment-dispatch-outbox-limit`
- 이슈: Closes #183

## 주요 변경 사항

- 댓글 디스패치 대기열 최대 조회 제한 계약(`COMMENT_DISPATCH_OUTBOX_MAX_PAGE_SIZE`)을 추가했습니다.
- `GET /api/comment-dispatches/outbox`의 `limit`을 tenant/status/worker 필터 적용 이후 결과에 적용하도록 했습니다.
- `limit`은 1-100 정수만 허용하고, 0/초과/소수 입력은 400으로 거절합니다.
- outbox limit 동작과 invalid limit e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 34로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
