### PR TITLE
feat: 댓글 디스패치 대기열 조회 정렬 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -420,7 +420,12 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch outbox status filter is invalid.");
     }
 
+    if (query.order !== undefined && query.order !== "ASC" && query.order !== "DESC") {
+      throw new BadRequestException("Comment dispatch outbox order filter is invalid.");
+    }
+
     const limit = this.parseCommentDispatchOutboxLimit(query.limit);
+    const order = query.order ?? "ASC";
 
     const items = Array.from(this.commentDispatchOutboxItems.values()).filter(
       (item) =>
@@ -428,8 +433,9 @@ export class ControlPlaneService {
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );
+    const orderedItems = order === "ASC" ? items : [...items].reverse();
 
-    return limit === undefined ? items : items.slice(0, limit);
+    return limit === undefined ? orderedItems : orderedItems.slice(0, limit);
   }
 
   claimCommentDispatchOutbox(input: CommentDispatchOutboxClaimRequest): CommentDispatchOutboxItem | null {

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1265,6 +1265,86 @@ describe("Comment dispatcher boundary API (e2e)", () => {
     expect(thirdOutboxItem.id).toEqual(expect.stringMatching(/^comment_dispatch_outbox_\d+$/));
   });
 
+  it("orders outbox reads after metadata filters and before limit is applied", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_order",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-order"
+    });
+
+    const createPlan = async (commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_order",
+            repositoryBindingId: repositoryBinding.id,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan("abc123order1");
+    const secondPlan = await createPlan("abc123order2");
+    const thirdPlan = await createPlan("abc123order3");
+
+    const firstOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_order", planId: firstPlan.id })
+          .expect(201)
+      ).body
+    );
+    const secondOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_order", planId: secondPlan.id })
+          .expect(201)
+      ).body
+    );
+    const thirdOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_order", planId: thirdPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_order", order: "ASC" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((item) => item.id)).toEqual([
+          firstOutboxItem.id,
+          secondOutboxItem.id,
+          thirdOutboxItem.id
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_order", order: "DESC", limit: 2 })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((item) => item.id)).toEqual([
+          thirdOutboxItem.id,
+          secondOutboxItem.id
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({ tenantId: "tenant_comment_outbox_order", order: "SIDEWAYS" })
+      .expect(400);
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -217,12 +217,15 @@ export interface CommentDispatchOutboxItem {
 }
 
 export const COMMENT_DISPATCH_OUTBOX_MAX_PAGE_SIZE = 100;
+export const COMMENT_DISPATCH_READ_ORDERS = ['ASC', 'DESC'] as const;
+export type CommentDispatchReadOrder = (typeof COMMENT_DISPATCH_READ_ORDERS)[number];
 
 export interface CommentDispatchOutboxListQuery {
   tenantId: string;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
   limit?: number | string;
+  order?: CommentDispatchReadOrder;
 }
 
 export interface CommentDispatchOutboxClaimRequest {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -198,6 +198,10 @@ Outbox reads may also accept `limit` after tenant and metadata filters are appli
 must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive
 limits are rejected before any response body is returned.
 
+Outbox reads may accept `order=ASC|DESC`. Ordering is applied after tenant, status, and
+worker filters and before `limit`. `ASC` returns dispatcher metadata in enqueue order, while
+`DESC` returns the newest enqueued metadata first. Invalid order values are rejected.
+
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window
 returns the same claimed item. Other workers and other tenants do not receive an item while

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -239,6 +239,13 @@
 - [x] T136 Reject zero, negative, fractional, and excessive outbox read limits
 - [x] T137 Add e2e coverage for outbox limit behavior and credential/source leakage guardrails
 
+## Phase 35: Comment Dispatch Outbox Read Order Boundary Slice
+
+- [x] T138 Add shared comment dispatch outbox read order contract
+- [x] T139 Apply tenant-scoped outbox read `order` after metadata filters and before limit
+- [x] T140 Reject invalid outbox read order values
+- [x] T141 Add e2e coverage for outbox order and limit composition guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/185-comment-dispatch-outbox-order`
- 이슈: Closes #185

## 주요 변경 사항

- 댓글 디스패치 대기열 조회 정렬 계약(`CommentDispatchReadOrder`)을 추가했습니다.
- `GET /api/comment-dispatches/outbox`에 `order=ASC|DESC` 검증과 적용을 추가했습니다.
- 정렬은 tenant/status/worker 필터 이후, limit 적용 이전에 수행됩니다.
- invalid order와 `order + limit` 조합 e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 35로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
