### PR TITLE
feat: 댓글 디스패치 감사 이벤트 조회 정렬 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -332,7 +332,12 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch audit target type filter is invalid.");
     }
 
+    if (query.order !== undefined && query.order !== "ASC" && query.order !== "DESC") {
+      throw new BadRequestException("Comment dispatch audit event order filter is invalid.");
+    }
+
     const limit = this.parseCommentDispatchAuditEventLimit(query.limit);
+    const order = query.order ?? "ASC";
 
     const events = this.commentDispatchAuditEvents.filter(
       (event) =>
@@ -341,8 +346,9 @@ export class ControlPlaneService {
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)
     );
+    const orderedEvents = order === "ASC" ? events : [...events].reverse();
 
-    return limit === undefined ? events : events.slice(0, limit);
+    return limit === undefined ? orderedEvents : orderedEvents.slice(0, limit);
   }
 
   enqueueCommentDispatch(input: CommentDispatchEnqueueRequest): CommentDispatchOutboxItem {

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1508,6 +1508,85 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("orders audit event reads after metadata filters and before limit is applied", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_order",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-order"
+    });
+
+    const planResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/plan")
+      .send(
+        dispatchRequest({
+          tenantId: "tenant_comment_audit_order",
+          repositoryBindingId: repositoryBinding.id,
+          policyCommentAllowed: true
+        })
+      )
+      .expect(201);
+    const plan = dataOf<Record<string, unknown>>(planResponse.body);
+
+    const enqueueResponse = await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_order", planId: plan.id })
+      .expect(201);
+    const outboxItem = dataOf<Record<string, unknown>>(enqueueResponse.body);
+
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/outbox/claim")
+      .send({
+        tenantId: "tenant_comment_audit_order",
+        workerId: "comment-dispatch-worker-audit-order",
+        leaseSeconds: 300
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_order", order: "ASC" })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.planned",
+          "comment_dispatch.enqueued",
+          "comment_dispatch.outbox_claimed"
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_order", order: "DESC", limit: 2 })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.outbox_claimed",
+          "comment_dispatch.enqueued"
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_order",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: outboxItem.id,
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.outbox_claimed"
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({ tenantId: "tenant_comment_audit_order", order: "SIDEWAYS" })
+      .expect(400);
+  });
+
   it("records tenant-scoped audit events for dispatch planning without exposing source or credential fields", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -338,6 +338,7 @@ export interface CommentDispatchAuditEventListQuery {
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;
   limit?: number | string;
+  order?: CommentDispatchReadOrder;
 }
 
 export interface TokenBrokerIssueRequest {

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -264,6 +264,10 @@ Audit event reads may also accept `limit` after tenant and metadata filters are 
 `limit` must be an integer from 1 through 100. Invalid, zero, fractional, negative, or
 excessive limits are rejected before any response body is returned.
 
+Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, event, and
+target filters and before `limit`. `ASC` returns audit metadata in creation order, while
+`DESC` returns the newest audit metadata first. Invalid order values are rejected.
+
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return
 the existing outbox item and do not create duplicate enqueue audit events. Enqueue audit

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -246,6 +246,13 @@
 - [x] T140 Reject invalid outbox read order values
 - [x] T141 Add e2e coverage for outbox order and limit composition guardrails
 
+## Phase 36: Comment Dispatch Audit Event Read Order Boundary Slice
+
+- [x] T142 Add shared comment dispatch audit event read order contract
+- [x] T143 Apply tenant-scoped audit event read `order` after metadata filters and before limit
+- [x] T144 Reject invalid audit event read order values
+- [x] T145 Add e2e coverage for audit event order and limit composition guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/188-comment-dispatch-audit-order`
- 이슈: Closes #188

## 주요 변경 사항

- 댓글 디스패치 감사 이벤트 조회 계약에 `order=ASC|DESC`를 추가했습니다.
- `GET /api/comment-dispatches/audit-events`에서 invalid order를 400으로 거절하도록 했습니다.
- 정렬이 tenant/event/target 필터 이후, `limit` 적용 이전에 동작하도록 했습니다.
- audit event order와 `target + order + limit` 조합 e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 36으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
