### PR TITLE
feat: 댓글 디스패치 대기열 저장소 바인딩 조회 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -436,6 +436,7 @@ export class ControlPlaneService {
     const items = Array.from(this.commentDispatchOutboxItems.values()).filter(
       (item) =>
         item.tenantId === query.tenantId &&
+        (query.repositoryBindingId === undefined || item.repositoryBindingId === query.repositoryBindingId) &&
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1345,6 +1345,98 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("filters outbox reads by repository binding inside the tenant boundary", async () => {
+    const firstRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_repository_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-repo-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_repository_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-outbox-repo-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_outbox_repository_filter" })
+      .expect(200);
+    const secondRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== firstRepositoryBinding.id
+    );
+    if (!secondRepositoryBinding) {
+      throw new Error("Expected a second repository binding for outbox repository filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_repository_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan(firstRepositoryBinding.id, "abc123repo-filter-1");
+    const secondPlan = await createPlan(secondRepositoryBinding.id, "abc123repo-filter-2");
+    const firstOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_repository_filter", planId: firstPlan.id })
+          .expect(201)
+      ).body
+    );
+    const secondOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_repository_filter", planId: secondPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_repository_filter",
+        repositoryBindingId: secondRepositoryBinding.id
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([secondOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_repository_filter",
+        repositoryBindingId: firstRepositoryBinding.id,
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([firstOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_repository_filter_other",
+        repositoryBindingId: firstRepositoryBinding.id
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -222,6 +222,7 @@ export type CommentDispatchReadOrder = (typeof COMMENT_DISPATCH_READ_ORDERS)[num
 
 export interface CommentDispatchOutboxListQuery {
   tenantId: string;
+  repositoryBindingId?: string;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
   limit?: number | string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -188,11 +188,11 @@ existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
-Outbox reads accept metadata-only `status` and `workerId` filters after tenant scoping is
-applied. Invalid status values and sensitive query fields are rejected. Filters must not
-expand visibility across tenants and must not accept SCM token values, repo-read principals,
-integration-admin principals, external comment IDs, full repository content, source
-archives, raw scanner payloads, or SCM write-result metadata.
+Outbox reads accept metadata-only `repositoryBindingId`, `status`, and `workerId` filters
+after tenant scoping is applied. Invalid status values and sensitive query fields are
+rejected. Filters must not expand visibility across tenants and must not accept SCM token
+values, repo-read principals, integration-admin principals, external comment IDs, full
+repository content, source archives, raw scanner payloads, or SCM write-result metadata.
 
 Outbox reads may also accept `limit` after tenant and metadata filters are applied. `limit`
 must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -253,6 +253,13 @@
 - [x] T144 Reject invalid audit event read order values
 - [x] T145 Add e2e coverage for audit event order and limit composition guardrails
 
+## Phase 37: Comment Dispatch Outbox Repository Binding Filter Boundary Slice
+
+- [x] T146 Add shared comment dispatch outbox `repositoryBindingId` list query contract
+- [x] T147 Apply tenant-scoped outbox repository binding filters with status, worker, order, and limit composition
+- [x] T148 Prevent repository binding filters from expanding cross-tenant outbox visibility
+- [x] T149 Add e2e coverage for repository binding filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/190-comment-dispatch-outbox-repository-filter`
- 이슈: Closes #190

## 주요 변경 사항

- 댓글 디스패치 대기열 조회 계약에 `repositoryBindingId` 필터를 추가했습니다.
- `GET /api/comment-dispatches/outbox`에서 tenant 범위 안에서만 repository binding 필터가 적용되도록 했습니다.
- repository binding 필터가 `status`, `workerId`, `order`, `limit`과 함께 조합되도록 했습니다.
- cross-tenant repository binding visibility가 생기지 않는 e2e 테스트를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 37로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`
