### PR TITLE
feat: 댓글 디스패치 감사 이벤트 저장소 바인딩 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -342,6 +342,8 @@ export class ControlPlaneService {
     const events = this.commentDispatchAuditEvents.filter(
       (event) =>
         event.tenantId === query.tenantId &&
+        (query.repositoryBindingId === undefined ||
+          event.metadata.repositoryBindingId === query.repositoryBindingId) &&
         (query.eventType === undefined || event.eventType === query.eventType) &&
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1437,6 +1437,121 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       });
   });
 
+  it("filters audit event reads by repository binding inside the tenant boundary", async () => {
+    const firstRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_repository_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-repo-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_repository_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-audit-repo-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_audit_repository_filter" })
+      .expect(200);
+    const secondRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== firstRepositoryBinding.id
+    );
+    if (!secondRepositoryBinding) {
+      throw new Error("Expected a second repository binding for audit repository filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_audit_repository_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan(firstRepositoryBinding.id, "abc123audit-repo-filter-1");
+    const secondPlan = await createPlan(secondRepositoryBinding.id, "abc123audit-repo-filter-2");
+    const firstOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_audit_repository_filter", planId: firstPlan.id })
+          .expect(201)
+      ).body
+    );
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_repository_filter", planId: secondPlan.id })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_repository_filter",
+        repositoryBindingId: secondRepositoryBinding.id
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.planned",
+          "comment_dispatch.enqueued"
+        ]);
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            metadata: expect.objectContaining({ repositoryBindingId: secondRepositoryBinding.id })
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({ repositoryBindingId: secondRepositoryBinding.id })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_repository_filter",
+        repositoryBindingId: firstRepositoryBinding.id,
+        targetType: "comment_dispatch_outbox_item",
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            eventType: "comment_dispatch.enqueued",
+            targetId: firstOutboxItem.id,
+            metadata: expect.objectContaining({ repositoryBindingId: firstRepositoryBinding.id })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_repository_filter_other",
+        repositoryBindingId: firstRepositoryBinding.id
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_repository_filter",
+        repositoryBindingId: secondRepositoryBinding.id,
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -335,6 +335,7 @@ export const COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE = 100;
 
 export interface CommentDispatchAuditEventListQuery {
   tenantId: string;
+  repositoryBindingId?: string;
   eventType?: CommentDispatchAuditEvent['eventType'];
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -253,20 +253,21 @@ finding ID, target ref, commit SHA, and comment-write principal ID. Audit events
 include SCM token values, repo-read principals, integration-admin principals, full
 repository content, source archives, or raw scanner payloads.
 
-Audit event reads accept metadata-only `eventType`, `targetType`, and `targetId` filters
-after tenant scoping is applied. Invalid event or target type filters and sensitive query
-fields are rejected. Filters must not expand visibility across tenants and must not accept
-SCM token values, repo-read principals, integration-admin principals, external comment IDs,
-full repository content, source archives, raw scanner payloads, or SCM write-result
-metadata.
+Audit event reads accept metadata-only `repositoryBindingId`, `eventType`, `targetType`,
+and `targetId` filters after tenant scoping is applied. Invalid event or target type filters
+and sensitive query fields are rejected. Filters must not expand visibility across tenants
+and must not accept SCM token values, repo-read principals, integration-admin principals,
+external comment IDs, full repository content, source archives, raw scanner payloads, or SCM
+write-result metadata.
 
 Audit event reads may also accept `limit` after tenant and metadata filters are applied.
 `limit` must be an integer from 1 through 100. Invalid, zero, fractional, negative, or
 excessive limits are rejected before any response body is returned.
 
-Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, event, and
-target filters and before `limit`. `ASC` returns audit metadata in creation order, while
-`DESC` returns the newest audit metadata first. Invalid order values are rejected.
+Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository
+binding, event, and target filters and before `limit`. `ASC` returns audit metadata in
+creation order, while `DESC` returns the newest audit metadata first. Invalid order values
+are rejected.
 
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -260,6 +260,13 @@
 - [x] T148 Prevent repository binding filters from expanding cross-tenant outbox visibility
 - [x] T149 Add e2e coverage for repository binding filter behavior and tenant scoping guardrails
 
+## Phase 38: Comment Dispatch Audit Event Repository Binding Filter Boundary Slice
+
+- [x] T150 Add shared comment dispatch audit event `repositoryBindingId` list query contract
+- [x] T151 Apply tenant-scoped audit event repository binding filters with event, target, order, and limit composition
+- [x] T152 Prevent repository binding filters from expanding cross-tenant audit visibility
+- [x] T153 Add e2e coverage for audit repository binding filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/192-comment-dispatch-audit-repository-filter`
- 이슈: Closes #192

## 주요 변경 사항

- 댓글 디스패치 감사 이벤트 조회 query에 `repositoryBindingId` 계약을 추가했습니다.
- `GET /api/comment-dispatches/audit-events`가 tenant 범위 안에서 `metadata.repositoryBindingId`를 필터링하도록 했습니다.
- repository binding 필터가 event/target/order/limit 조합과 함께 동작하도록 e2e로 고정했습니다.
- cross-tenant visibility 확장 방지와 민감정보 query 차단 경계를 검증했습니다.
- 002 production scan architecture contracts/tasks 문서를 Phase 38로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**하였나요?

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` 실패 확인
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts`
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment-dispatch audit events can now be filtered by repository binding ID within tenant boundaries, allowing users to query events for specific repository bindings.

* **Documentation**
  * Updated audit event filtering contract documentation to reflect the new repository binding ID filter capability and its interaction with existing filters and ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->