### PR TITLE
feat: 댓글 디스패치 대기열 제공자 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -432,6 +432,10 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch outbox order filter is invalid.");
     }
 
+    if (query.provider !== undefined && query.provider !== "GITHUB" && query.provider !== "GITLAB") {
+      throw new BadRequestException("Comment dispatch outbox provider filter is invalid.");
+    }
+
     const limit = this.parseCommentDispatchOutboxLimit(query.limit);
     const order = query.order ?? "ASC";
 
@@ -439,6 +443,7 @@ export class ControlPlaneService {
       (item) =>
         item.tenantId === query.tenantId &&
         (query.repositoryBindingId === undefined || item.repositoryBindingId === query.repositoryBindingId) &&
+        (query.provider === undefined || item.provider === query.provider) &&
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1437,6 +1437,107 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       });
   });
 
+  it("filters outbox reads by provider inside the tenant boundary", async () => {
+    const githubRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_provider_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-provider-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_provider_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-outbox-provider-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_outbox_provider_filter" })
+      .expect(200);
+    const gitlabRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== githubRepositoryBinding.id
+    );
+    if (!gitlabRepositoryBinding) {
+      throw new Error("Expected a GitLab repository binding for outbox provider filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_provider_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const githubPlan = await createPlan(githubRepositoryBinding.id, "abc123provider-filter-1");
+    const gitlabPlan = await createPlan(gitlabRepositoryBinding.id, "abc123provider-filter-2");
+    const githubOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_provider_filter", planId: githubPlan.id })
+          .expect(201)
+      ).body
+    );
+    const gitlabOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_provider_filter", planId: gitlabPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_filter",
+        provider: "GITLAB"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([gitlabOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_filter",
+        provider: "GITHUB",
+        repositoryBindingId: githubRepositoryBinding.id,
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([githubOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_filter_other",
+        provider: "GITHUB"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_filter",
+        provider: "BITBUCKET"
+      })
+      .expect(400);
+  });
+
   it("filters audit event reads by repository binding inside the tenant boundary", async () => {
     const firstRepositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_repository_filter",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -223,6 +223,7 @@ export type CommentDispatchReadOrder = (typeof COMMENT_DISPATCH_READ_ORDERS)[num
 export interface CommentDispatchOutboxListQuery {
   tenantId: string;
   repositoryBindingId?: string;
+  provider?: ScmProvider;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
   limit?: number | string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -188,19 +188,21 @@ existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
-Outbox reads accept metadata-only `repositoryBindingId`, `status`, and `workerId` filters
-after tenant scoping is applied. Invalid status values and sensitive query fields are
-rejected. Filters must not expand visibility across tenants and must not accept SCM token
-values, repo-read principals, integration-admin principals, external comment IDs, full
-repository content, source archives, raw scanner payloads, or SCM write-result metadata.
+Outbox reads accept metadata-only `repositoryBindingId`, `provider`, `status`, and
+`workerId` filters after tenant scoping is applied. Invalid provider/status values and
+sensitive query fields are rejected. Filters must not expand visibility across tenants
+and must not accept SCM token values, repo-read principals, integration-admin principals,
+external comment IDs, full repository content, source archives, raw scanner payloads, or
+SCM write-result metadata.
 
 Outbox reads may also accept `limit` after tenant and metadata filters are applied. `limit`
 must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive
 limits are rejected before any response body is returned.
 
-Outbox reads may accept `order=ASC|DESC`. Ordering is applied after tenant, status, and
-worker filters and before `limit`. `ASC` returns dispatcher metadata in enqueue order, while
-`DESC` returns the newest enqueued metadata first. Invalid order values are rejected.
+Outbox reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository,
+provider, status, and worker filters and before `limit`. `ASC` returns dispatcher metadata
+in enqueue order, while `DESC` returns the newest enqueued metadata first. Invalid order
+values are rejected.
 
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -267,6 +267,13 @@
 - [x] T152 Prevent repository binding filters from expanding cross-tenant audit visibility
 - [x] T153 Add e2e coverage for audit repository binding filter behavior and tenant scoping guardrails
 
+## Phase 39: Comment Dispatch Outbox Provider Filter Boundary Slice
+
+- [x] T154 Add shared comment dispatch outbox `provider` list query contract
+- [x] T155 Apply tenant-scoped outbox provider filters with repository, status, worker, order, and limit composition
+- [x] T156 Reject invalid outbox provider filter values
+- [x] T157 Add e2e coverage for provider filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/194-comment-dispatch-outbox-provider-filter`
- 이슈: #194

## 주요 변경 사항

- 댓글 디스패치 outbox list query 계약에 `provider` 필터를 추가했습니다.
- Control Plane outbox 조회에서 tenant scoping 이후 `GITHUB`/`GITLAB` provider 필터를 적용하고, 잘못된 provider 값을 400으로 거부합니다.
- provider 필터가 repository/order/limit 조합 및 cross-tenant 경계와 함께 동작하는 e2e 테스트를 추가했습니다.
- `002-production-scan-architecture` contracts/tasks 문서를 Phase 39 기준으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 확인했습니다.
- [x] **Label** 등록을 확인했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인해야 합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because `provider=GITLAB` returned both GitHub and GitLab outbox items.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 23 tests.
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`