### PR TITLE
feat: 댓글 디스패치 감사 이벤트 제공자 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -336,6 +336,10 @@ export class ControlPlaneService {
       throw new BadRequestException("Comment dispatch audit event order filter is invalid.");
     }
 
+    if (query.provider !== undefined && query.provider !== "GITHUB" && query.provider !== "GITLAB") {
+      throw new BadRequestException("Comment dispatch audit provider filter is invalid.");
+    }
+
     const limit = this.parseCommentDispatchAuditEventLimit(query.limit);
     const order = query.order ?? "ASC";
 
@@ -344,6 +348,7 @@ export class ControlPlaneService {
         event.tenantId === query.tenantId &&
         (query.repositoryBindingId === undefined ||
           event.metadata.repositoryBindingId === query.repositoryBindingId) &&
+        (query.provider === undefined || event.metadata.provider === query.provider) &&
         (query.eventType === undefined || event.eventType === query.eventType) &&
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1653,6 +1653,124 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("filters audit event reads by provider inside the tenant boundary", async () => {
+    const githubRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_provider_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-provider-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_provider_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-audit-provider-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_audit_provider_filter" })
+      .expect(200);
+    const gitlabRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== githubRepositoryBinding.id
+    );
+    if (!gitlabRepositoryBinding) {
+      throw new Error("Expected a GitLab repository binding for audit provider filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_audit_provider_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const githubPlan = await createPlan(githubRepositoryBinding.id, "abc123audit-provider-filter-1");
+    const gitlabPlan = await createPlan(gitlabRepositoryBinding.id, "abc123audit-provider-filter-2");
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_provider_filter", planId: githubPlan.id })
+      .expect(201);
+    const gitlabOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_audit_provider_filter", planId: gitlabPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_filter",
+        provider: "GITLAB"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.planned",
+          "comment_dispatch.enqueued"
+        ]);
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            metadata: expect.objectContaining({ provider: "GITLAB" })
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({ provider: "GITLAB" })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_filter",
+        provider: "GITLAB",
+        repositoryBindingId: gitlabRepositoryBinding.id,
+        targetType: "comment_dispatch_outbox_item",
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            eventType: "comment_dispatch.enqueued",
+            targetId: gitlabOutboxItem.id,
+            metadata: expect.objectContaining({
+              provider: "GITLAB",
+              repositoryBindingId: gitlabRepositoryBinding.id
+            })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_filter_other",
+        provider: "GITHUB"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_filter",
+        provider: "BITBUCKET"
+      })
+      .expect(400);
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -337,6 +337,7 @@ export const COMMENT_DISPATCH_AUDIT_EVENT_MAX_PAGE_SIZE = 100;
 export interface CommentDispatchAuditEventListQuery {
   tenantId: string;
   repositoryBindingId?: string;
+  provider?: ScmProvider;
   eventType?: CommentDispatchAuditEvent['eventType'];
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -255,21 +255,21 @@ finding ID, target ref, commit SHA, and comment-write principal ID. Audit events
 include SCM token values, repo-read principals, integration-admin principals, full
 repository content, source archives, or raw scanner payloads.
 
-Audit event reads accept metadata-only `repositoryBindingId`, `eventType`, `targetType`,
-and `targetId` filters after tenant scoping is applied. Invalid event or target type filters
-and sensitive query fields are rejected. Filters must not expand visibility across tenants
-and must not accept SCM token values, repo-read principals, integration-admin principals,
-external comment IDs, full repository content, source archives, raw scanner payloads, or SCM
-write-result metadata.
+Audit event reads accept metadata-only `repositoryBindingId`, `provider`, `eventType`,
+`targetType`, and `targetId` filters after tenant scoping is applied. Invalid provider,
+event, or target type filters and sensitive query fields are rejected. Filters must not
+expand visibility across tenants and must not accept SCM token values, repo-read
+principals, integration-admin principals, external comment IDs, full repository content,
+source archives, raw scanner payloads, or SCM write-result metadata.
 
 Audit event reads may also accept `limit` after tenant and metadata filters are applied.
 `limit` must be an integer from 1 through 100. Invalid, zero, fractional, negative, or
 excessive limits are rejected before any response body is returned.
 
 Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository
-binding, event, and target filters and before `limit`. `ASC` returns audit metadata in
-creation order, while `DESC` returns the newest audit metadata first. Invalid order values
-are rejected.
+binding, provider, event, and target filters and before `limit`. `ASC` returns audit
+metadata in creation order, while `DESC` returns the newest audit metadata first. Invalid
+order values are rejected.
 
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -274,6 +274,13 @@
 - [x] T156 Reject invalid outbox provider filter values
 - [x] T157 Add e2e coverage for provider filter behavior and tenant scoping guardrails
 
+## Phase 40: Comment Dispatch Audit Event Provider Filter Boundary Slice
+
+- [x] T158 Add shared comment dispatch audit event `provider` list query contract
+- [x] T159 Apply tenant-scoped audit event provider filters with repository, event, target, order, and limit composition
+- [x] T160 Reject invalid audit event provider filter values
+- [x] T161 Add e2e coverage for audit provider filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/196-comment-dispatch-audit-provider-filter`
- 이슈: #196

## 주요 변경 사항

- 댓글 디스패치 audit event list query 계약에 `provider` 필터를 추가했습니다.
- Control Plane 감사 이벤트 조회에서 tenant scoping 이후 `GITHUB`/`GITLAB` provider 필터를 적용하고, 잘못된 provider 값을 400으로 거부합니다.
- provider 필터가 repository/event/target/order/limit 조합 및 cross-tenant 경계와 함께 동작하는 e2e 테스트를 추가했습니다.
- `002-production-scan-architecture` contracts/tasks 문서를 Phase 40 기준으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 확인했습니다.
- [x] **Label** 등록을 확인했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인해야 합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because `provider=GITLAB` returned mixed GitHub/GitLab audit events.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 24 tests.
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test` initially exposed a non-reproducing web timeout; rerun passed.
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`