### PR TITLE
feat: 댓글 디스패치 대기열 제공자 저장소 ID 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -449,6 +449,7 @@ export class ControlPlaneService {
         item.tenantId === query.tenantId &&
         (query.repositoryBindingId === undefined || item.repositoryBindingId === query.repositoryBindingId) &&
         (query.provider === undefined || item.provider === query.provider) &&
+        (query.providerRepoId === undefined || item.providerRepoId === query.providerRepoId) &&
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1538,6 +1538,112 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       .expect(400);
   });
 
+  it("filters outbox reads by provider repository id inside the tenant boundary", async () => {
+    const githubRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_provider_repo_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-provider-repo-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_provider_repo_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-outbox-provider-repo-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_outbox_provider_repo_filter" })
+      .expect(200);
+    const gitlabRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== githubRepositoryBinding.id
+    );
+    if (!gitlabRepositoryBinding) {
+      throw new Error("Expected a GitLab repository binding for outbox provider repository filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_provider_repo_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const githubPlan = await createPlan(githubRepositoryBinding.id, "abc123provider-repo-filter-1");
+    const gitlabPlan = await createPlan(gitlabRepositoryBinding.id, "abc123provider-repo-filter-2");
+    const githubOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_provider_repo_filter", planId: githubPlan.id })
+          .expect(201)
+      ).body
+    );
+    const gitlabOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_provider_repo_filter", planId: gitlabPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_repo_filter",
+        providerRepoId: "gitlab-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([gitlabOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_repo_filter",
+        provider: "GITHUB",
+        providerRepoId: "github-repo-1",
+        repositoryBindingId: githubRepositoryBinding.id,
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([githubOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_repo_filter",
+        provider: "GITHUB",
+        providerRepoId: "gitlab-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_provider_repo_filter_other",
+        providerRepoId: "github-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+  });
+
   it("filters audit event reads by repository binding inside the tenant boundary", async () => {
     const firstRepositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_repository_filter",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -224,6 +224,7 @@ export interface CommentDispatchOutboxListQuery {
   tenantId: string;
   repositoryBindingId?: string;
   provider?: ScmProvider;
+  providerRepoId?: string;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
   limit?: number | string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -188,21 +188,21 @@ existing outbox item. `GET /api/comment-dispatches/outbox` returns tenant-scoped
 metadata for dispatcher runtime pickup. This milestone does not publish external GitHub or
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
-Outbox reads accept metadata-only `repositoryBindingId`, `provider`, `status`, and
-`workerId` filters after tenant scoping is applied. Invalid provider/status values and
-sensitive query fields are rejected. Filters must not expand visibility across tenants
-and must not accept SCM token values, repo-read principals, integration-admin principals,
-external comment IDs, full repository content, source archives, raw scanner payloads, or
-SCM write-result metadata.
+Outbox reads accept metadata-only `repositoryBindingId`, `provider`, `providerRepoId`,
+`status`, and `workerId` filters after tenant scoping is applied. Invalid provider/status
+values and sensitive query fields are rejected. Filters must not expand visibility across
+tenants and must not accept SCM token values, repo-read principals, integration-admin
+principals, external comment IDs, full repository content, source archives, raw scanner
+payloads, or SCM write-result metadata.
 
 Outbox reads may also accept `limit` after tenant and metadata filters are applied. `limit`
 must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive
 limits are rejected before any response body is returned.
 
 Outbox reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository,
-provider, status, and worker filters and before `limit`. `ASC` returns dispatcher metadata
-in enqueue order, while `DESC` returns the newest enqueued metadata first. Invalid order
-values are rejected.
+provider, provider repository ID, status, and worker filters and before `limit`. `ASC`
+returns dispatcher metadata in enqueue order, while `DESC` returns the newest enqueued
+metadata first. Invalid order values are rejected.
 
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -281,6 +281,13 @@
 - [x] T160 Reject invalid audit event provider filter values
 - [x] T161 Add e2e coverage for audit provider filter behavior and tenant scoping guardrails
 
+## Phase 41: Comment Dispatch Outbox Provider Repository Filter Boundary Slice
+
+- [x] T162 Add shared comment dispatch outbox `providerRepoId` list query contract
+- [x] T163 Apply tenant-scoped outbox provider repository filters with repository, provider, status, worker, order, and limit composition
+- [x] T164 Prevent provider repository filters from expanding cross-tenant outbox visibility
+- [x] T165 Add e2e coverage for outbox provider repository filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/198-comment-dispatch-outbox-provider-repo-filter`
- 이슈: #198

## 주요 변경 사항

- 댓글 디스패치 outbox list query 계약에 `providerRepoId` 필터를 추가했습니다.
- Control Plane outbox 조회에서 tenant scoping 이후 provider repository id 필터를 적용합니다.
- `provider`, `providerRepoId`, `repositoryBindingId`, `order`, `limit` 조합 및 cross-tenant 격리 e2e 테스트를 추가했습니다.
- `002-production-scan-architecture` contracts/tasks 문서를 Phase 41 기준으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 확인했습니다.
- [x] **Label** 등록을 확인했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인해야 합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because `providerRepoId=gitlab-repo-1` returned mixed GitHub/GitLab outbox items.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 25 tests.
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`