### PR TITLE
feat: 댓글 디스패치 감사 이벤트 제공자 저장소 ID 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -349,6 +349,7 @@ export class ControlPlaneService {
         (query.repositoryBindingId === undefined ||
           event.metadata.repositoryBindingId === query.repositoryBindingId) &&
         (query.provider === undefined || event.metadata.provider === query.provider) &&
+        (query.providerRepoId === undefined || event.metadata.providerRepoId === query.providerRepoId) &&
         (query.eventType === undefined || event.eventType === query.eventType) &&
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)
@@ -405,6 +406,7 @@ export class ControlPlaneService {
         idempotencyKey: plan.idempotencyKey,
         repositoryBindingId: plan.repositoryBindingId,
         provider: plan.provider,
+        providerRepoId: plan.providerRepoId,
         policyDecisionId: plan.policyDecisionId,
         findingId: plan.findingId,
         targetRef: plan.targetRef,

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -370,6 +370,7 @@ describe("Comment dispatcher boundary API (e2e)", () => {
           idempotencyKey: plan.idempotencyKey,
           repositoryBindingId: repositoryBinding.id,
           provider: "GITHUB",
+          providerRepoId: "github-repo-1",
           policyDecisionId: "policy_decision_comment_1",
           findingId: "finding_comment_1",
           targetRef: "refs/pull/42/head",
@@ -1875,6 +1876,130 @@ describe("Comment dispatcher boundary API (e2e)", () => {
         provider: "BITBUCKET"
       })
       .expect(400);
+  });
+
+  it("filters audit event reads by provider repository id inside the tenant boundary", async () => {
+    const githubRepositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_provider_repo_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-provider-repo-filter-1"
+    });
+    await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_provider_repo_filter",
+      provider: "gitlab",
+      commentWritePrincipalId: "gitlab-project-integration:comment-write-audit-provider-repo-filter-2"
+    });
+    const repositoryBindingsResponse = await request(app.getHttpServer())
+      .get("/api/repository-bindings")
+      .query({ tenantId: "tenant_comment_audit_provider_repo_filter" })
+      .expect(200);
+    const gitlabRepositoryBinding = dataOf<Array<Record<string, unknown>>>(repositoryBindingsResponse.body).find(
+      (binding) => binding.id !== githubRepositoryBinding.id
+    );
+    if (!gitlabRepositoryBinding) {
+      throw new Error("Expected a GitLab repository binding for audit provider repository filter coverage.");
+    }
+
+    const createPlan = async (repositoryBindingId: unknown, commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_audit_provider_repo_filter",
+            repositoryBindingId,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const githubPlan = await createPlan(githubRepositoryBinding.id, "abc123audit-provider-repo-filter-1");
+    const gitlabPlan = await createPlan(gitlabRepositoryBinding.id, "abc123audit-provider-repo-filter-2");
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_provider_repo_filter", planId: githubPlan.id })
+      .expect(201);
+    const gitlabOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_audit_provider_repo_filter", planId: gitlabPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_repo_filter",
+        providerRepoId: "gitlab-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.planned",
+          "comment_dispatch.enqueued"
+        ]);
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            metadata: expect.objectContaining({ providerRepoId: "gitlab-repo-1" })
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({ providerRepoId: "gitlab-repo-1" })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_repo_filter",
+        provider: "GITLAB",
+        providerRepoId: "gitlab-repo-1",
+        repositoryBindingId: gitlabRepositoryBinding.id,
+        targetType: "comment_dispatch_outbox_item",
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            eventType: "comment_dispatch.enqueued",
+            targetId: gitlabOutboxItem.id,
+            metadata: expect.objectContaining({
+              provider: "GITLAB",
+              providerRepoId: "gitlab-repo-1",
+              repositoryBindingId: gitlabRepositoryBinding.id
+            })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_repo_filter",
+        provider: "GITHUB",
+        providerRepoId: "gitlab-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_provider_repo_filter_other",
+        providerRepoId: "github-repo-1"
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
   });
 
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -339,6 +339,7 @@ export interface CommentDispatchAuditEventListQuery {
   tenantId: string;
   repositoryBindingId?: string;
   provider?: ScmProvider;
+  providerRepoId?: string;
   eventType?: CommentDispatchAuditEvent['eventType'];
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -255,10 +255,10 @@ finding ID, target ref, commit SHA, and comment-write principal ID. Audit events
 include SCM token values, repo-read principals, integration-admin principals, full
 repository content, source archives, or raw scanner payloads.
 
-Audit event reads accept metadata-only `repositoryBindingId`, `provider`, `eventType`,
-`targetType`, and `targetId` filters after tenant scoping is applied. Invalid provider,
-event, or target type filters and sensitive query fields are rejected. Filters must not
-expand visibility across tenants and must not accept SCM token values, repo-read
+Audit event reads accept metadata-only `repositoryBindingId`, `provider`, `providerRepoId`,
+`eventType`, `targetType`, and `targetId` filters after tenant scoping is applied. Invalid
+provider, event, or target type filters and sensitive query fields are rejected. Filters
+must not expand visibility across tenants and must not accept SCM token values, repo-read
 principals, integration-admin principals, external comment IDs, full repository content,
 source archives, raw scanner payloads, or SCM write-result metadata.
 
@@ -267,16 +267,16 @@ Audit event reads may also accept `limit` after tenant and metadata filters are 
 excessive limits are rejected before any response body is returned.
 
 Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository
-binding, provider, event, and target filters and before `limit`. `ASC` returns audit
-metadata in creation order, while `DESC` returns the newest audit metadata first. Invalid
-order values are rejected.
+binding, provider, provider repository ID, event, and target filters and before `limit`.
+`ASC` returns audit metadata in creation order, while `DESC` returns the newest audit
+metadata first. Invalid order values are rejected.
 
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return
 the existing outbox item and do not create duplicate enqueue audit events. Enqueue audit
 metadata is limited to outbox item ID, plan ID, idempotency key, repository binding ID,
-provider, policy decision ID, finding ID, target ref, commit SHA, and comment-write
-principal ID. It must not include SCM token values, repo-read principals,
+provider, provider repository ID, policy decision ID, finding ID, target ref, commit SHA,
+and comment-write principal ID. It must not include SCM token values, repo-read principals,
 integration-admin principals, external comment IDs, full repository content, source
 archives, or raw scanner payloads.
 

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -288,6 +288,13 @@
 - [x] T164 Prevent provider repository filters from expanding cross-tenant outbox visibility
 - [x] T165 Add e2e coverage for outbox provider repository filter behavior and tenant scoping guardrails
 
+## Phase 42: Comment Dispatch Audit Event Provider Repository Filter Boundary Slice
+
+- [x] T166 Add shared comment dispatch audit event `providerRepoId` list query contract
+- [x] T167 Apply tenant-scoped audit event provider repository filters with repository, provider, event, target, order, and limit composition
+- [x] T168 Prevent provider repository filters from expanding cross-tenant audit visibility
+- [x] T169 Add e2e coverage for audit provider repository filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/200-comment-dispatch-audit-provider-repo-filter`
- 이슈: #200

## 주요 변경 사항

- 댓글 디스패치 audit event list query 계약에 `providerRepoId` 필터를 추가했습니다.
- Control Plane 감사 이벤트 조회에서 tenant scoping 이후 provider repository id 필터를 적용합니다.
- enqueue audit metadata에 안전한 `providerRepoId`를 포함해 provider repository id 기반 감사 조회가 계획/대기열 이벤트를 함께 찾을 수 있게 했습니다.
- `provider`, `providerRepoId`, `repositoryBindingId`, `targetType`, `order`, `limit` 조합 및 cross-tenant 격리 e2e 테스트를 추가했습니다.
- `002-production-scan-architecture` contracts/tasks 문서를 Phase 42 기준으로 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록을 확인했습니다.
- [x] **Label** 등록을 확인했습니다.
- [x] PR 머지 전 CI가 정상적으로 작동하는지 확인해야 합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because `providerRepoId=gitlab-repo-1` returned mixed GitHub/GitLab audit events.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 26 tests.
- [x] `corepack pnpm --filter @aegisai/api lint`
- [x] `corepack pnpm --filter @aegisai/api typecheck`
- [x] `corepack pnpm --filter @aegisai/shared typecheck`
- [x] `corepack pnpm lint`
- [ ] `corepack pnpm test` locally hit non-deterministic web timeout failures under Windows workspace parallel execution; GitHub CI must pass before merge.
- [x] `corepack pnpm --filter @aegisai/web test -- src/pages/VulnerabilityReviewPage.test.tsx` passed, 15 files / 54 tests.
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check`