### PR TITLE
feat: 댓글 디스패치 대기열 멱등성 키 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -452,6 +452,7 @@ export class ControlPlaneService {
         (query.repositoryBindingId === undefined || item.repositoryBindingId === query.repositoryBindingId) &&
         (query.provider === undefined || item.provider === query.provider) &&
         (query.providerRepoId === undefined || item.providerRepoId === query.providerRepoId) &&
+        (query.idempotencyKey === undefined || item.idempotencyKey === query.idempotencyKey) &&
         (query.status === undefined || item.status === query.status) &&
         (query.workerId === undefined || item.claimedBy === query.workerId)
     );

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -1645,6 +1645,87 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       });
   });
 
+  it("filters outbox reads by idempotency key inside the tenant boundary", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_outbox_idempotency_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-outbox-idempotency-filter"
+    });
+
+    const createPlan = async (commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_outbox_idempotency_filter",
+            repositoryBindingId: repositoryBinding.id,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan("abc123idempotency-filter-1");
+    const secondPlan = await createPlan("abc123idempotency-filter-2");
+    const firstOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_idempotency_filter", planId: firstPlan.id })
+          .expect(201)
+      ).body
+    );
+    const secondOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_outbox_idempotency_filter", planId: secondPlan.id })
+          .expect(201)
+      ).body
+    );
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_idempotency_filter",
+        idempotencyKey: secondOutboxItem.idempotencyKey
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([secondOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_idempotency_filter",
+        idempotencyKey: firstOutboxItem.idempotencyKey,
+        repositoryBindingId: repositoryBinding.id,
+        provider: "GITHUB",
+        providerRepoId: "github-repo-1",
+        status: "PENDING",
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([firstOutboxItem]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/outbox")
+      .query({
+        tenantId: "tenant_comment_outbox_idempotency_filter_other",
+        idempotencyKey: firstOutboxItem.idempotencyKey
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+  });
+
   it("filters audit event reads by repository binding inside the tenant boundary", async () => {
     const firstRepositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_repository_filter",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -225,6 +225,7 @@ export interface CommentDispatchOutboxListQuery {
   repositoryBindingId?: string;
   provider?: ScmProvider;
   providerRepoId?: string;
+  idempotencyKey?: string;
   status?: CommentDispatchOutboxItem['status'];
   workerId?: string;
   limit?: number | string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -189,20 +189,20 @@ metadata for dispatcher runtime pickup. This milestone does not publish external
 GitLab comments, does not persist external comment IDs, and does not call SCM write APIs.
 
 Outbox reads accept metadata-only `repositoryBindingId`, `provider`, `providerRepoId`,
-`status`, and `workerId` filters after tenant scoping is applied. Invalid provider/status
-values and sensitive query fields are rejected. Filters must not expand visibility across
-tenants and must not accept SCM token values, repo-read principals, integration-admin
-principals, external comment IDs, full repository content, source archives, raw scanner
-payloads, or SCM write-result metadata.
+`idempotencyKey`, `status`, and `workerId` filters after tenant scoping is applied. Invalid
+provider/status values and sensitive query fields are rejected. Filters must not expand
+visibility across tenants and must not accept SCM token values, repo-read principals,
+integration-admin principals, external comment IDs, full repository content, source archives,
+raw scanner payloads, or SCM write-result metadata.
 
 Outbox reads may also accept `limit` after tenant and metadata filters are applied. `limit`
 must be an integer from 1 through 100. Invalid, zero, fractional, negative, or excessive
 limits are rejected before any response body is returned.
 
 Outbox reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository,
-provider, provider repository ID, status, and worker filters and before `limit`. `ASC`
-returns dispatcher metadata in enqueue order, while `DESC` returns the newest enqueued
-metadata first. Invalid order values are rejected.
+provider, provider repository ID, idempotency key, status, and worker filters and before
+`limit`. `ASC` returns dispatcher metadata in enqueue order, while `DESC` returns the newest
+enqueued metadata first. Invalid order values are rejected.
 
 `POST /api/comment-dispatches/outbox/claim` lets a dispatcher worker claim one tenant-scoped
 `PENDING` outbox item with metadata-only lease fields. A worker retry inside the lease window

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -295,6 +295,13 @@
 - [x] T168 Prevent provider repository filters from expanding cross-tenant audit visibility
 - [x] T169 Add e2e coverage for audit provider repository filter behavior and tenant scoping guardrails
 
+## Phase 43: Comment Dispatch Outbox Idempotency Key Filter Boundary Slice
+
+- [x] T170 Add shared comment dispatch outbox `idempotencyKey` list query contract
+- [x] T171 Apply tenant-scoped outbox idempotency key filters with repository, provider, provider repository, status, order, and limit composition
+- [x] T172 Prevent idempotency key filters from expanding cross-tenant outbox visibility
+- [x] T173 Add e2e coverage for outbox idempotency key filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/202-comment-dispatch-outbox-idempotency-filter`
- 이슈: Closes #202

## 주요 변경 사항

- `CommentDispatchOutboxListQuery`에 `idempotencyKey` 필터 계약을 추가했습니다.
- Control Plane outbox 조회가 tenant scoping 이후 idempotency key로 필터링하도록 했습니다.
- repository/provider/providerRepoId/status/order/limit 조합 및 cross-tenant 격리 e2e를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because idempotencyKey was ignored and both tenant outbox items were returned.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 27 tests.
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check` (CRLF warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotency key filtering for comment dispatch outbox queries.

* **Tests**
  * Added end-to-end test coverage for idempotency key filtering across tenant boundaries.

* **Documentation**
  * Updated query parameter documentation and validation rules for comment dispatcher outbox reads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AigisAI/AegisAI_v2/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->