### PR TITLE
feat: 댓글 디스패치 감사 이벤트 멱등성 키 필터 경계 구현

### DIFF
--- a/apps/api/src/control-plane/control-plane.service.ts
+++ b/apps/api/src/control-plane/control-plane.service.ts
@@ -297,6 +297,7 @@ export class ControlPlaneService {
       targetId: plan.id,
       occurredAt: new Date(0).toISOString(),
       metadata: {
+        idempotencyKey,
         repositoryBindingId: repositoryBinding.id,
         provider: integration.provider,
         providerRepoId: repositoryBinding.providerRepoId,
@@ -350,6 +351,7 @@ export class ControlPlaneService {
           event.metadata.repositoryBindingId === query.repositoryBindingId) &&
         (query.provider === undefined || event.metadata.provider === query.provider) &&
         (query.providerRepoId === undefined || event.metadata.providerRepoId === query.providerRepoId) &&
+        (query.idempotencyKey === undefined || event.metadata.idempotencyKey === query.idempotencyKey) &&
         (query.eventType === undefined || event.eventType === query.eventType) &&
         (query.targetType === undefined || event.targetType === query.targetType) &&
         (query.targetId === undefined || event.targetId === query.targetId)

--- a/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
+++ b/apps/api/test/control-plane/comment-dispatcher.e2e-spec.ts
@@ -2083,6 +2083,111 @@ describe("Comment dispatcher boundary API (e2e)", () => {
       });
   });
 
+  it("filters audit event reads by idempotency key inside the tenant boundary", async () => {
+    const repositoryBinding = await installRepositoryBinding({
+      tenantId: "tenant_comment_audit_idempotency_filter",
+      provider: "github",
+      commentWritePrincipalId: "github-app-installation:comment-write-audit-idempotency-filter"
+    });
+
+    const createPlan = async (commitSha: string) => {
+      const planResponse = await request(app.getHttpServer())
+        .post("/api/comment-dispatches/plan")
+        .send({
+          ...dispatchRequest({
+            tenantId: "tenant_comment_audit_idempotency_filter",
+            repositoryBindingId: repositoryBinding.id,
+            policyCommentAllowed: true
+          }),
+          commitSha
+        })
+        .expect(201);
+      return dataOf<Record<string, unknown>>(planResponse.body);
+    };
+
+    const firstPlan = await createPlan("abc123audit-idempotency-filter-1");
+    const secondPlan = await createPlan("abc123audit-idempotency-filter-2");
+    const firstOutboxItem = dataOf<Record<string, unknown>>(
+      (
+        await request(app.getHttpServer())
+          .post("/api/comment-dispatches/enqueue")
+          .send({ tenantId: "tenant_comment_audit_idempotency_filter", planId: firstPlan.id })
+          .expect(201)
+      ).body
+    );
+    await request(app.getHttpServer())
+      .post("/api/comment-dispatches/enqueue")
+      .send({ tenantId: "tenant_comment_audit_idempotency_filter", planId: secondPlan.id })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_idempotency_filter",
+        idempotencyKey: secondPlan.idempotencyKey
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body).map((event) => event.eventType)).toEqual([
+          "comment_dispatch.planned",
+          "comment_dispatch.enqueued"
+        ]);
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            metadata: expect.objectContaining({ idempotencyKey: secondPlan.idempotencyKey })
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({ idempotencyKey: secondPlan.idempotencyKey })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_idempotency_filter",
+        idempotencyKey: firstPlan.idempotencyKey,
+        repositoryBindingId: repositoryBinding.id,
+        provider: "GITHUB",
+        providerRepoId: "github-repo-1",
+        eventType: "comment_dispatch.enqueued",
+        targetType: "comment_dispatch_outbox_item",
+        targetId: firstOutboxItem.id,
+        order: "DESC",
+        limit: 1
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([
+          expect.objectContaining({
+            eventType: "comment_dispatch.enqueued",
+            targetId: firstOutboxItem.id,
+            metadata: expect.objectContaining({ idempotencyKey: firstPlan.idempotencyKey })
+          })
+        ]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_idempotency_filter_other",
+        idempotencyKey: firstPlan.idempotencyKey
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(dataOf<Array<Record<string, unknown>>>(response.body)).toEqual([]);
+      });
+
+    await request(app.getHttpServer())
+      .get("/api/comment-dispatches/audit-events")
+      .query({
+        tenantId: "tenant_comment_audit_idempotency_filter",
+        idempotencyKey: firstPlan.idempotencyKey,
+        accessToken: "ghs_secret"
+      })
+      .expect(400);
+  });
+
   it("filters audit event reads by event type and target without crossing tenant or sensitive boundaries", async () => {
     const repositoryBinding = await installRepositoryBinding({
       tenantId: "tenant_comment_audit_filters",
@@ -2359,6 +2464,7 @@ describe("Comment dispatcher boundary API (e2e)", () => {
         targetId: plan.id,
         occurredAt: "1970-01-01T00:00:00.000Z",
         metadata: {
+          idempotencyKey: plan.idempotencyKey,
           repositoryBindingId: repositoryBinding.id,
           provider: "GITHUB",
           providerRepoId: "github-repo-1",

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -341,6 +341,7 @@ export interface CommentDispatchAuditEventListQuery {
   repositoryBindingId?: string;
   provider?: ScmProvider;
   providerRepoId?: string;
+  idempotencyKey?: string;
   eventType?: CommentDispatchAuditEvent['eventType'];
   targetType?: CommentDispatchAuditEvent['targetType'];
   targetId?: string;

--- a/specs/002-production-scan-architecture/contracts/scan-architecture.md
+++ b/specs/002-production-scan-architecture/contracts/scan-architecture.md
@@ -250,26 +250,26 @@ rejected.
 
 Every successful dispatch planning operation records a tenant-scoped
 `comment_dispatch.planned` audit event. `GET /api/comment-dispatches/audit-events` returns
-metadata only: repository binding ID, provider, provider repository ID, policy decision ID,
-finding ID, target ref, commit SHA, and comment-write principal ID. Audit events must not
-include SCM token values, repo-read principals, integration-admin principals, full
-repository content, source archives, or raw scanner payloads.
+metadata only: idempotency key, repository binding ID, provider, provider repository ID,
+policy decision ID, finding ID, target ref, commit SHA, and comment-write principal ID.
+Audit events must not include SCM token values, repo-read principals, integration-admin
+principals, full repository content, source archives, or raw scanner payloads.
 
 Audit event reads accept metadata-only `repositoryBindingId`, `provider`, `providerRepoId`,
-`eventType`, `targetType`, and `targetId` filters after tenant scoping is applied. Invalid
-provider, event, or target type filters and sensitive query fields are rejected. Filters
-must not expand visibility across tenants and must not accept SCM token values, repo-read
-principals, integration-admin principals, external comment IDs, full repository content,
-source archives, raw scanner payloads, or SCM write-result metadata.
+`idempotencyKey`, `eventType`, `targetType`, and `targetId` filters after tenant scoping is
+applied. Invalid provider, event, or target type filters and sensitive query fields are
+rejected. Filters must not expand visibility across tenants and must not accept SCM token
+values, repo-read principals, integration-admin principals, external comment IDs, full
+repository content, source archives, raw scanner payloads, or SCM write-result metadata.
 
 Audit event reads may also accept `limit` after tenant and metadata filters are applied.
 `limit` must be an integer from 1 through 100. Invalid, zero, fractional, negative, or
 excessive limits are rejected before any response body is returned.
 
 Audit event reads may accept `order=ASC|DESC`. Ordering is applied after tenant, repository
-binding, provider, provider repository ID, event, and target filters and before `limit`.
-`ASC` returns audit metadata in creation order, while `DESC` returns the newest audit
-metadata first. Invalid order values are rejected.
+binding, provider, provider repository ID, idempotency key, event, and target filters and
+before `limit`. `ASC` returns audit metadata in creation order, while `DESC` returns the
+newest audit metadata first. Invalid order values are rejected.
 
 Every first successful outbox enqueue records one tenant-scoped
 `comment_dispatch.enqueued` audit event. Repeated enqueue requests for the same plan return

--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -302,6 +302,13 @@
 - [x] T172 Prevent idempotency key filters from expanding cross-tenant outbox visibility
 - [x] T173 Add e2e coverage for outbox idempotency key filter behavior and tenant scoping guardrails
 
+## Phase 44: Comment Dispatch Audit Event Idempotency Key Filter Boundary Slice
+
+- [x] T174 Add shared comment dispatch audit event `idempotencyKey` list query contract
+- [x] T175 Apply tenant-scoped audit event idempotency key filters with repository, provider, provider repository, event, target, order, and limit composition
+- [x] T176 Prevent idempotency key filters from expanding cross-tenant audit visibility
+- [x] T177 Add e2e coverage for audit idempotency key filter behavior and tenant scoping guardrails
+
 ## Deferred
 
 - [ ] Implement trained production AI detector/planner model inference


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/204-comment-dispatch-audit-idempotency-filter`
- 이슈: Closes #204

## 주요 변경 사항

- `CommentDispatchAuditEventListQuery`에 `idempotencyKey` 필터 계약을 추가했습니다.
- Control Plane audit event 조회가 tenant scoping 이후 idempotency key로 필터링하도록 했습니다.
- dispatch planning audit metadata에도 idempotency key를 포함해 planned/enqueued 이벤트를 같은 dispatch boundary로 조회할 수 있게 했습니다.
- repository/provider/providerRepoId/event/target/order/limit 조합 및 cross-tenant 격리 e2e를 추가했습니다.
- 002 production scan architecture contracts/tasks 문서를 동기화했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` failed because idempotencyKey was ignored and unrelated audit events were returned.
- [x] GREEN: `corepack pnpm --filter @aegisai/api test -- test/control-plane/comment-dispatcher.e2e-spec.ts` passed, 28 tests.
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check` (CRLF warnings only)
