### PR TITLE
docs: 002 완료 게이트 README 포인터 문구 정합성 보강

### DIFF
--- a/specs/002-production-scan-architecture/tasks.md
+++ b/specs/002-production-scan-architecture/tasks.md
@@ -313,7 +313,7 @@
 
 - [x] T178 Add active feature tests that require quickstart, README, and CI completion gates to stay synchronized
 - [x] T179 Include Prisma schema validation and `git diff --check` in the 002 quickstart validation command list
-- [x] T180 Mirror the 002 completion gate in README completion and CI sections
+- [x] T180 Point README completion guidance at the 002 quickstart and CI workflow without duplicating command checklists
 - [x] T181 Run Prisma schema validation and whitespace diff checks in GitHub Actions CI
 
 ## Deferred

--- a/test/github-actions/active-feature.test.mjs
+++ b/test/github-actions/active-feature.test.mjs
@@ -62,6 +62,7 @@ test('production scan architecture completion gate stays synchronized between qu
   const readme = readNormalizedText(files.readme);
   const ci = readNormalizedText(files.ci);
   const quickstart = readNormalizedText(files.quickstart);
+  const tasks = readNormalizedText(files.tasks);
 
   const requiredCommands = [
     'corepack pnpm lint',
@@ -79,5 +80,8 @@ test('production scan architecture completion gate stays synchronized between qu
 
   assert.match(readme, /specs\/002-production-scan-architecture\/quickstart\.md/);
   assert.match(readme, /\.github\/workflows\/ci\.yml/);
+  assert.doesNotMatch(readme, /`corepack pnpm/);
+  assert.doesNotMatch(tasks, /Mirror the 002 completion gate in README/);
+  assert.match(tasks, /Point README completion guidance at the 002 quickstart and CI workflow without duplicating command checklists/);
   assert.match(ci, /DATABASE_URL:\s*postgresql:\/\/postgres:postgres@localhost:5432\/aegisai/);
 });


### PR DESCRIPTION
﻿## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/208-002-completion-readme-pointer`
- 이슈: Closes #208

## 주요 변경 사항

- active feature 테스트가 README를 lightweight landing page로 유지하는지 검증하도록 보강했습니다.
- README가 quickstart와 CI workflow를 가리키고 직접 command checklist를 담지 않는지 검증했습니다.
- Phase 45 tasks 문구를 README pointer 방식으로 정정했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## 검증

- [x] RED: `node --test test/github-actions/active-feature.test.mjs` failed because Phase 45 still described README as mirroring completion gate commands.
- [x] GREEN: `node --test test/github-actions/active-feature.test.mjs` passed, 2 tests.
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test` (passed; existing Jest worker teardown warning emitted after all tests passed)
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check` (CRLF warnings only)
