### PR TITLE
feat: 003 AI 추론 공유 계약 타입과 금지 필드 테스트 구현

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,3 +8,4 @@ export * from './types/vulnerability';
 export * from './types/dashboard';
 export * from './types/report';
 export * from './types/production-architecture';
+export * from './types/ai-inference-runtime';

--- a/packages/shared/src/types/ai-inference-runtime.ts
+++ b/packages/shared/src/types/ai-inference-runtime.ts
@@ -1,0 +1,105 @@
+export const AI_INFERENCE_RUNTIME_FEATURE_ID = '003-production-ai-inference-runtime';
+
+export const AI_INFERENCE_CAPABILITIES = ['detector', 'planner'] as const;
+export type AiInferenceCapability = (typeof AI_INFERENCE_CAPABILITIES)[number];
+
+export const AI_INFERENCE_REJECTION_REASONS = [
+  'UNREDACTED_EVIDENCE',
+  'FORBIDDEN_INPUT_CLASS',
+  'MISSING_TENANT_ATTRIBUTION',
+  'MISSING_SCAN_ATTRIBUTION',
+  'MODEL_GATEWAY_UNAVAILABLE'
+] as const;
+export type AiInferenceRejectionReason = (typeof AI_INFERENCE_REJECTION_REASONS)[number];
+
+export const AI_INFERENCE_EVENT_TYPES = [
+  'ai_inference.requested',
+  'ai_inference.rejected',
+  'ai_inference.completed',
+  'ai_inference.fallback_completed',
+  'ai_inference.failed'
+] as const;
+export type AiInferenceEventType = (typeof AI_INFERENCE_EVENT_TYPES)[number];
+
+export interface ReducedEvidenceSnippet {
+  label: string;
+  language?: string;
+  redactedText: string;
+}
+
+export interface ReducedEvidence {
+  findingIds: string[];
+  scannerNames: string[];
+  evidencePackId: string;
+  summary: string;
+  snippets: ReducedEvidenceSnippet[];
+  metadata: Record<string, string | number | boolean>;
+  redactionState: 'redacted' | 'reduced';
+}
+
+export interface AiRuntimePolicy {
+  allowFallback: boolean;
+  maxLatencyMs: number;
+}
+
+export interface AiInferenceRequest {
+  tenantId: string;
+  scanRequestId: string;
+  canonicalScanKey: string;
+  requestId: string;
+  reducedEvidence: ReducedEvidence;
+  requestedCapabilities: AiInferenceCapability[];
+  runtimePolicy: AiRuntimePolicy;
+  createdAt: string;
+}
+
+export interface AiDetectorAdvisory {
+  findingId: string;
+  confidence: number;
+  rationale: string;
+  signals: string[];
+}
+
+export interface AiPlannerAdvisory {
+  findingId?: string;
+  action: string;
+  rationale: string;
+  priority: 'low' | 'medium' | 'high';
+}
+
+export interface AiModelMetadata {
+  provider: string;
+  model: string;
+  version: string;
+}
+
+export interface AiInferenceFallback {
+  used: boolean;
+  reason?: string;
+}
+
+export interface AiInferenceResponse {
+  requestId: string;
+  tenantId: string;
+  scanRequestId: string;
+  advisoryOnly: true;
+  detectorAdvisories: AiDetectorAdvisory[];
+  plannerAdvisories: AiPlannerAdvisory[];
+  modelMetadata: AiModelMetadata;
+  fallback: AiInferenceFallback;
+  latencyMs: number;
+  createdAt: string;
+}
+
+export interface AiInferenceAuditEvent {
+  tenantId: string;
+  scanRequestId: string;
+  requestId: string;
+  eventType: AiInferenceEventType;
+  provider?: string;
+  model?: string;
+  fallbackUsed: boolean;
+  rejectionReason?: AiInferenceRejectionReason;
+  latencyMs?: number;
+  createdAt: string;
+}

--- a/packages/shared/test/shared-contract-exports.test.mjs
+++ b/packages/shared/test/shared-contract-exports.test.mjs
@@ -10,6 +10,7 @@ const files = {
   vulnerability: new URL('../src/types/vulnerability.ts', import.meta.url),
   dashboard: new URL('../src/types/dashboard.ts', import.meta.url),
   report: new URL('../src/types/report.ts', import.meta.url),
+  aiInferenceRuntime: new URL('../src/types/ai-inference-runtime.ts', import.meta.url),
   index: new URL('../src/index.ts', import.meta.url)
 };
 
@@ -20,11 +21,55 @@ test('shared contract modules exist and are re-exported from the package root', 
 
   const indexContent = readFileSync(files.index, 'utf8');
 
-  for (const moduleName of ['common', 'auth', 'repo', 'scan', 'vulnerability', 'dashboard', 'report']) {
+  for (const moduleName of [
+    'common',
+    'auth',
+    'repo',
+    'scan',
+    'vulnerability',
+    'dashboard',
+    'report',
+    'ai-inference-runtime'
+  ]) {
     assert.match(
       indexContent,
       new RegExp(`export \\* from './types/${moduleName}'`),
       `Expected packages/shared/src/index.ts to re-export ./types/${moduleName}`
     );
   }
+});
+
+test('AI inference runtime contracts are advisory-only and exclude forbidden payload fields', () => {
+  assert.equal(existsSync(files.aiInferenceRuntime), true);
+
+  const contract = readFileSync(files.aiInferenceRuntime, 'utf8');
+
+  for (const exportName of [
+    'ReducedEvidence',
+    'AiInferenceRequest',
+    'AiInferenceResponse',
+    'AiDetectorAdvisory',
+    'AiPlannerAdvisory',
+    'AiInferenceAuditEvent',
+    'AI_INFERENCE_REJECTION_REASONS'
+  ]) {
+    assert.match(contract, new RegExp(`export (interface|const|type) ${exportName}\\b`));
+  }
+
+  for (const forbiddenField of [
+    'scmCredential',
+    'scmToken',
+    'repositoryArchive',
+    'sourceArchive',
+    'fullRepository',
+    'rawScannerPayload',
+    'authoritativeFinding',
+    'policyOverride'
+  ]) {
+    assert.doesNotMatch(contract, new RegExp(`\\b${forbiddenField}\\b`, 'i'));
+  }
+
+  assert.match(contract, /advisoryOnly:\s*true/);
+  assert.match(contract, /redactionState:\s*'redacted'\s*\|\s*'reduced'/);
+  assert.match(contract, /fallback:\s*AiInferenceFallback/);
 });

--- a/specs/003-production-ai-inference-runtime/tasks.md
+++ b/specs/003-production-ai-inference-runtime/tasks.md
@@ -9,8 +9,8 @@
 
 ## Phase 2: Shared Contract Slice
 
-- [ ] T005 Add `AiInferenceRequest`, `AiInferenceResponse`, and `ReducedEvidence` contracts to `packages/shared`
-- [ ] T006 Add contract tests proving AI inference contracts exclude SCM credentials, source archives, and raw scanner payloads
+- [x] T005 Add `AiInferenceRequest`, `AiInferenceResponse`, and `ReducedEvidence` contracts to `packages/shared`
+- [x] T006 Add contract tests proving AI inference contracts exclude SCM credentials, source archives, and raw scanner payloads
 
 ## Phase 3: Model Gateway Slice
 


### PR DESCRIPTION
## 작업 중인 브랜치 및 이슈

- 브랜치: `feat/214-003-ai-shared-contracts`
- 이슈: Closes #214

## 주요 변경 사항

- `packages/shared`에 `AiInferenceRequest`, `AiInferenceResponse`, `ReducedEvidence` 및 detector/planner advisory 계약 타입을 추가했습니다.
- AI inference audit event, rejection reason, fallback, model metadata 계약을 추가했습니다.
- shared package root export에서 `./types/ai-inference-runtime`을 re-export했습니다.
- shared contract 테스트가 AI inference 계약의 advisory-only 속성과 forbidden payload field 부재를 검증하도록 보강했습니다.
- 003 tasks에서 T005/T006 완료 상태를 기록했습니다.

## 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따릅니다.
- [x] 이슈 제목과 PR 제목을 동일하게 작성했습니다.
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따릅니다.

## Check List

- [x] **Assignees** 등록했습니다.
- [x] **라벨(Label)** 등록했습니다.
- [x] PR merge 전 CI가 정상적으로 동작하는지 확인합니다.

## 검증

- [x] RED: `corepack pnpm --filter @aegisai/shared test` failed because `ai-inference-runtime.ts` did not exist.
- [x] GREEN: `corepack pnpm --filter @aegisai/shared test` passed, 2 tests.
- [x] `corepack pnpm lint`
- [x] `corepack pnpm test`
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`
- [x] `$env:DATABASE_URL='postgresql://postgres:postgres@localhost:5432/aegisai'; corepack pnpm --filter @aegisai/api prisma:validate`
- [x] `git diff --check` (Windows CRLF warning only)