### PR TITLE
feat: 003 API 자문 클라이언트 모델 게이트웨이 응답 연동

### DIFF
--- a/apps/ai/src/advisory-runtime.ts
+++ b/apps/ai/src/advisory-runtime.ts
@@ -1,4 +1,6 @@
-import type { AiAdvisoryRequest } from "@aegisai/shared";
+import type { AiAdvisoryRequest, AiInferenceRequest, AiInferenceResponse } from "@aegisai/shared";
+
+import { createDeterministicFallbackProvider, createModelGateway } from "./model-gateway";
 
 export interface AiAdvisoryRuntimeResponse {
   detectorSignals: string[];
@@ -40,6 +42,21 @@ export async function handleAiAdvisoryRequest(request: Request): Promise<Respons
 
   try {
     const body = (await request.json()) as unknown;
+
+    if (isAiInferenceRequestLike(body)) {
+      const gateway = createModelGateway({
+        config: {
+          providerId: "deterministic",
+          model: "detector-planner-fallback",
+          version: "v1",
+          allowFallback: true
+        },
+        fallbackProvider: createDeterministicFallbackProvider()
+      });
+
+      return jsonResponse(await gateway.infer(body), 200);
+    }
+
     const advisoryRequest = parseReducedAdvisoryRequest(body);
 
     return jsonResponse(createDetectorPlannerAdvisory(advisoryRequest), 200);
@@ -112,6 +129,15 @@ function parseReducedAdvisoryRequest(input: unknown): AiAdvisoryRequest {
   return input as unknown as AiAdvisoryRequest;
 }
 
+function isAiInferenceRequestLike(input: unknown): input is AiInferenceRequest {
+  return (
+    isRecord(input) &&
+    isRecord(input.reducedEvidence) &&
+    Array.isArray(input.requestedCapabilities) &&
+    isRecord(input.runtimePolicy)
+  );
+}
+
 function plannerStepsFor(input: AiAdvisoryRequest): string[] {
   const steps = ["Review normalized scanner evidence before remediation planning."];
 
@@ -136,7 +162,7 @@ function confidenceFor(input: AiAdvisoryRequest): number {
   return 0.61;
 }
 
-function jsonResponse(body: Record<string, unknown> | AiAdvisoryRuntimeResponse, status: number): Response {
+function jsonResponse(body: Record<string, unknown> | AiAdvisoryRuntimeResponse | AiInferenceResponse, status: number): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {

--- a/apps/ai/test/advisory-runtime.test.ts
+++ b/apps/ai/test/advisory-runtime.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { handleAiAdvisoryRequest } from "../src/advisory-runtime";
 
-import type { AiAdvisoryRequest } from "@aegisai/shared";
+import type { AiAdvisoryRequest, AiInferenceRequest } from "@aegisai/shared";
 
 const baseRequest: AiAdvisoryRequest = {
   tenantId: "tenant_ai_service",
@@ -65,6 +65,55 @@ test("POST /ai/advisories returns advisory-only detector and planner output", as
   assert.equal(typeof body.confidence, "number");
   assert.ok(body.confidence >= 0);
   assert.ok(body.confidence <= 1);
+});
+
+test("POST /ai/advisories accepts model gateway inference requests", async () => {
+  const inferenceRequest: AiInferenceRequest = {
+    tenantId: "tenant_ai_service",
+    scanRequestId: "scan_request_1",
+    canonicalScanKey: "tenant_ai_service:scan_request_1:finding_1:AI_ADVISORY:detector-planner-runtime-v1",
+    requestId: "ai_inference_scan_request_1_finding_1",
+    reducedEvidence: {
+      findingIds: ["finding_1"],
+      scannerNames: ["OPENGREP"],
+      evidencePackId: "evidence_1",
+      summary: "SQL injection sink (HIGH)",
+      snippets: [
+        {
+          label: "finding-location",
+          redactedText: "src/user.controller.ts:42"
+        }
+      ],
+      metadata: {
+        severity: "HIGH",
+        scannerProvenance: "OPENGREP"
+      },
+      redactionState: "redacted"
+    },
+    requestedCapabilities: ["detector", "planner"],
+    runtimePolicy: {
+      allowFallback: true,
+      maxLatencyMs: 2500
+    },
+    createdAt: "2026-05-26T00:00:00.000Z"
+  };
+
+  const response = await handleAiAdvisoryRequest(advisoryHttpRequest(inferenceRequest));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.requestId, "ai_inference_scan_request_1_finding_1");
+  assert.equal(body.tenantId, "tenant_ai_service");
+  assert.equal(body.scanRequestId, "scan_request_1");
+  assert.equal(body.advisoryOnly, true);
+  assert.equal(body.fallback.used, true);
+  assert.equal(body.modelMetadata.provider, "deterministic");
+  assert.deepEqual(body.detectorAdvisories[0].signals, [
+    "FALLBACK_DETERMINISTIC",
+    "EVIDENCE_REDACTED",
+    "SCANNERS_OPENGREP"
+  ]);
+  assert.equal(body.plannerAdvisories[0].action, "Review normalized scanner evidence with the owning team.");
 });
 
 test("GET /health returns the AI runtime health status", async () => {

--- a/apps/api/src/ai-plane/ai-advisory-runtime.client.ts
+++ b/apps/api/src/ai-plane/ai-advisory-runtime.client.ts
@@ -3,14 +3,7 @@ import axios from "axios";
 
 import { ConfigService } from "../config/config.service";
 
-import type { AiAdvisoryRequest } from "../../../../packages/shared/src";
-
-export interface AiAdvisoryRuntimeOutput {
-  detectorSignals: string[];
-  plannerSteps: string[];
-  confidence: number;
-  modelVersion: string;
-}
+import type { AiAdvisoryRequest, AiInferenceRequest, AiInferenceResponse } from "../../../../packages/shared/src";
 
 const FORBIDDEN_RUNTIME_RESPONSE_KEYS = [
   "accessToken",
@@ -32,9 +25,9 @@ const FORBIDDEN_RUNTIME_RESPONSE_KEYS = [
 export class AiAdvisoryRuntimeClient {
   constructor(private readonly config: ConfigService) {}
 
-  async createAdvisory(input: AiAdvisoryRequest): Promise<AiAdvisoryRuntimeOutput> {
+  async createAdvisory(input: AiAdvisoryRequest): Promise<AiInferenceResponse> {
     try {
-      const response = await axios.post(this.runtimeUrl(), input, {
+      const response = await axios.post(this.runtimeUrl(), this.toInferenceRequest(input), {
         timeout: this.config.get("AI_ADVISORY_TIMEOUT_MS")
       });
 
@@ -48,45 +41,143 @@ export class AiAdvisoryRuntimeClient {
     }
   }
 
-  private parseRuntimeOutput(input: unknown): AiAdvisoryRuntimeOutput {
+  private toInferenceRequest(input: AiAdvisoryRequest): AiInferenceRequest {
+    const maxLatencyMs = Number(this.config.get("AI_ADVISORY_TIMEOUT_MS"));
+    const location =
+      input.normalizedFinding.lineEnd && input.normalizedFinding.lineEnd !== input.normalizedFinding.lineStart
+        ? `${input.normalizedFinding.filePath}:${input.normalizedFinding.lineStart}-${input.normalizedFinding.lineEnd}`
+        : `${input.normalizedFinding.filePath}:${input.normalizedFinding.lineStart}`;
+
+    return {
+      tenantId: input.tenantId,
+      scanRequestId: input.scanRequestId,
+      canonicalScanKey: [
+        input.tenantId,
+        input.scanRequestId,
+        input.findingId,
+        "AI_ADVISORY",
+        input.modelVersion
+      ].join(":"),
+      requestId: `ai_inference_${input.scanRequestId}_${input.findingId}`,
+      reducedEvidence: {
+        findingIds: [input.findingId],
+        scannerNames: [input.normalizedFinding.scannerProvenance],
+        evidencePackId: input.evidence.id,
+        summary: `${input.normalizedFinding.title} (${input.normalizedFinding.severity})`,
+        snippets: [
+          {
+            label: "finding-location",
+            redactedText: location
+          }
+        ],
+        metadata: {
+          severity: input.normalizedFinding.severity,
+          scannerProvenance: input.normalizedFinding.scannerProvenance,
+          findingStatus: input.normalizedFinding.status,
+          evidenceByteSize: input.evidence.byteSize,
+          evidenceExpiresAt: input.evidence.expiresAt
+        },
+        redactionState: input.evidence.redacted ? "redacted" : "reduced"
+      },
+      requestedCapabilities: ["detector", "planner"],
+      runtimePolicy: {
+        allowFallback: true,
+        maxLatencyMs: Number.isFinite(maxLatencyMs) ? maxLatencyMs : 2500
+      },
+      createdAt: new Date().toISOString()
+    };
+  }
+
+  private parseRuntimeOutput(input: unknown): AiInferenceResponse {
     if (!input || typeof input !== "object" || Array.isArray(input)) {
       throw new BadGatewayException("AI advisory runtime response must be an object.");
     }
 
-    const serialized = JSON.stringify(input);
-
-    for (const forbiddenKey of FORBIDDEN_RUNTIME_RESPONSE_KEYS) {
-      if (new RegExp(forbiddenKey, "i").test(serialized)) {
-        throw new BadGatewayException(
-          "AI advisory runtime response contains forbidden authority or sensitive content."
-        );
-      }
+    if (hasForbiddenRuntimeResponseKey(input)) {
+      throw new BadGatewayException("AI advisory runtime response contains forbidden authority or sensitive content.");
     }
 
-    const candidate = input as Partial<AiAdvisoryRuntimeOutput>;
+    const candidate = input as Partial<AiInferenceResponse>;
 
     if (
-      !Array.isArray(candidate.detectorSignals) ||
-      !candidate.detectorSignals.every((signal) => typeof signal === "string") ||
-      !Array.isArray(candidate.plannerSteps) ||
-      !candidate.plannerSteps.every((step) => typeof step === "string") ||
-      typeof candidate.confidence !== "number" ||
-      candidate.confidence < 0 ||
-      candidate.confidence > 1 ||
-      typeof candidate.modelVersion !== "string"
+      typeof candidate.requestId !== "string" ||
+      typeof candidate.tenantId !== "string" ||
+      typeof candidate.scanRequestId !== "string" ||
+      candidate.advisoryOnly !== true ||
+      !Array.isArray(candidate.detectorAdvisories) ||
+      !candidate.detectorAdvisories.every(isDetectorAdvisory) ||
+      !Array.isArray(candidate.plannerAdvisories) ||
+      !candidate.plannerAdvisories.every(isPlannerAdvisory) ||
+      !candidate.modelMetadata ||
+      typeof candidate.modelMetadata.provider !== "string" ||
+      typeof candidate.modelMetadata.model !== "string" ||
+      typeof candidate.modelMetadata.version !== "string" ||
+      !candidate.fallback ||
+      typeof candidate.fallback.used !== "boolean" ||
+      (candidate.fallback.reason !== undefined && typeof candidate.fallback.reason !== "string") ||
+      typeof candidate.latencyMs !== "number" ||
+      typeof candidate.createdAt !== "string"
     ) {
       throw new BadGatewayException("AI advisory runtime response is malformed.");
     }
 
-    return {
-      detectorSignals: candidate.detectorSignals,
-      plannerSteps: candidate.plannerSteps,
-      confidence: candidate.confidence,
-      modelVersion: candidate.modelVersion
-    };
+    return candidate as AiInferenceResponse;
   }
 
   private runtimeUrl(): string {
     return `${this.config.get("AI_SERVER_URL").replace(/\/$/, "")}/ai/advisories`;
   }
+}
+
+function isDetectorAdvisory(input: unknown): boolean {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return false;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  return (
+    typeof candidate.findingId === "string" &&
+    typeof candidate.confidence === "number" &&
+    candidate.confidence >= 0 &&
+    candidate.confidence <= 1 &&
+    typeof candidate.rationale === "string" &&
+    Array.isArray(candidate.signals) &&
+    candidate.signals.every((signal) => typeof signal === "string")
+  );
+}
+
+function isPlannerAdvisory(input: unknown): boolean {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return false;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  return (
+    (candidate.findingId === undefined || typeof candidate.findingId === "string") &&
+    typeof candidate.action === "string" &&
+    typeof candidate.rationale === "string" &&
+    (candidate.priority === "low" || candidate.priority === "medium" || candidate.priority === "high")
+  );
+}
+
+function hasForbiddenRuntimeResponseKey(input: unknown): boolean {
+  if (input === null || typeof input !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(input)) {
+    return input.some((item) => hasForbiddenRuntimeResponseKey(item));
+  }
+
+  return Object.entries(input as Record<string, unknown>).some(
+    ([key, value]) => isForbiddenRuntimeResponseKey(key) || hasForbiddenRuntimeResponseKey(value)
+  );
+}
+
+function isForbiddenRuntimeResponseKey(key: string): boolean {
+  return FORBIDDEN_RUNTIME_RESPONSE_KEYS.some(
+    (forbiddenKey) => forbiddenKey.toLowerCase() === key.toLowerCase()
+  );
 }

--- a/apps/api/src/ai-plane/ai-advisory.service.ts
+++ b/apps/api/src/ai-plane/ai-advisory.service.ts
@@ -1,10 +1,27 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 
-import type { AiAdvisoryRequest, AiAdvisoryResult } from "../../../../packages/shared/src";
+import type {
+  AiAdvisoryRequest,
+  AiAdvisoryResult,
+  AiDetectorAdvisory,
+  AiInferenceFallback,
+  AiInferenceResponse,
+  AiModelMetadata,
+  AiPlannerAdvisory
+} from "../../../../packages/shared/src";
 import { ConfigService } from "../config/config.service";
 import { AiAdvisoryRuntimeClient } from "./ai-advisory-runtime.client";
 
-import type { AiAdvisoryRuntimeOutput } from "./ai-advisory-runtime.client";
+interface AiAdvisoryRuntimeProjection {
+  detectorSignals: string[];
+  plannerSteps: string[];
+  confidence: number;
+  modelVersion: string;
+  detectorAdvisories?: AiDetectorAdvisory[];
+  plannerAdvisories?: AiPlannerAdvisory[];
+  modelMetadata?: AiModelMetadata;
+  fallback?: AiInferenceFallback;
+}
 
 const FORBIDDEN_AI_INPUT_KEYS = [
   "accessToken",
@@ -43,6 +60,10 @@ export class AiAdvisoryService {
       detectorSignals: runtimeOutput.detectorSignals,
       plannerSteps: runtimeOutput.plannerSteps,
       confidence: runtimeOutput.confidence,
+      detectorAdvisories: runtimeOutput.detectorAdvisories,
+      plannerAdvisories: runtimeOutput.plannerAdvisories,
+      modelMetadata: runtimeOutput.modelMetadata,
+      fallback: runtimeOutput.fallback,
       createdAt: new Date().toISOString()
     };
 
@@ -77,13 +98,13 @@ export class AiAdvisoryService {
     }
   }
 
-  private async resolveRuntimeOutput(input: AiAdvisoryRequest): Promise<AiAdvisoryRuntimeOutput> {
+  private async resolveRuntimeOutput(input: AiAdvisoryRequest): Promise<AiAdvisoryRuntimeProjection> {
     if (this.config?.get("USE_INTERNAL_AI") === "true") {
       if (!this.runtimeClient) {
         throw new BadRequestException("AI advisory runtime client is not configured.");
       }
 
-      return this.runtimeClient.createAdvisory(input);
+      return this.projectInferenceResponse(await this.runtimeClient.createAdvisory(input));
     }
 
     return {
@@ -91,6 +112,22 @@ export class AiAdvisoryService {
       plannerSteps: this.plannerStepsFor(input),
       confidence: this.confidenceFor(input),
       modelVersion: input.modelVersion
+    };
+  }
+
+  private projectInferenceResponse(response: AiInferenceResponse): AiAdvisoryRuntimeProjection {
+    return {
+      detectorSignals: Array.from(new Set(response.detectorAdvisories.flatMap((advisory) => advisory.signals))),
+      plannerSteps: response.plannerAdvisories.map((advisory) => advisory.action),
+      confidence: response.detectorAdvisories.reduce(
+        (highestConfidence, advisory) => Math.max(highestConfidence, advisory.confidence),
+        0
+      ),
+      modelVersion: response.modelMetadata.version,
+      detectorAdvisories: response.detectorAdvisories,
+      plannerAdvisories: response.plannerAdvisories,
+      modelMetadata: response.modelMetadata,
+      fallback: response.fallback
     };
   }
 

--- a/apps/api/test/ai-plane/ai-advisory-runtime.client.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory-runtime.client.e2e-spec.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 import { AiAdvisoryRuntimeClient } from "../../src/ai-plane/ai-advisory-runtime.client";
 
-import type { AiAdvisoryRequest } from "../../../../packages/shared/src";
+import type { AiAdvisoryRequest, AiInferenceResponse } from "../../../../packages/shared/src";
 
 jest.mock("axios");
 
@@ -42,14 +42,42 @@ describe("AiAdvisoryRuntimeClient", () => {
     mockedAxios.post.mockReset();
   });
 
-  it("sends only reduced AI advisory requests to the configured runtime endpoint", async () => {
+  it("sends reduced inference requests and accepts the model gateway response shape", async () => {
+    const runtimeResponse: AiInferenceResponse = {
+      requestId: "ai_request_1",
+      tenantId: "tenant_runtime",
+      scanRequestId: "scan_request_1",
+      advisoryOnly: true,
+      detectorAdvisories: [
+        {
+          findingId: "finding_1",
+          confidence: 0.91,
+          rationale: "Model gateway mapped reduced evidence to a detector advisory.",
+          signals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"]
+        }
+      ],
+      plannerAdvisories: [
+        {
+          findingId: "finding_1",
+          action: "Review scanner evidence before remediation.",
+          rationale: "Planner advisory generated from reduced evidence.",
+          priority: "high"
+        }
+      ],
+      modelMetadata: {
+        provider: "deterministic",
+        model: "detector-planner-runtime",
+        version: "2026-05-26"
+      },
+      fallback: {
+        used: true,
+        reason: "provider not configured"
+      },
+      latencyMs: 13,
+      createdAt: "2026-05-26T00:00:00.000Z"
+    };
     mockedAxios.post.mockResolvedValueOnce({
-      data: {
-        detectorSignals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"],
-        plannerSteps: ["Review scanner evidence before remediation."],
-        confidence: 0.81,
-        modelVersion: "detector-planner-runtime-v1"
-      }
+      data: runtimeResponse
     });
     const client = new AiAdvisoryRuntimeClient({
       get: jest.fn((key: string) => {
@@ -63,21 +91,35 @@ describe("AiAdvisoryRuntimeClient", () => {
     } as never);
 
     const result = await client.createAdvisory(request);
+    const inferenceRequest = mockedAxios.post.mock.calls[0]?.[1] as Record<string, unknown>;
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
       "https://ai-runtime.example/ai/advisories",
-      request,
+      expect.objectContaining({
+        tenantId: "tenant_runtime",
+        scanRequestId: "scan_request_1",
+        requestId: expect.any(String),
+        canonicalScanKey: expect.any(String),
+        reducedEvidence: expect.objectContaining({
+          findingIds: ["finding_1"],
+          evidencePackId: "evidence_1",
+          scannerNames: ["OPENGREP"],
+          redactionState: "redacted"
+        }),
+        requestedCapabilities: ["detector", "planner"],
+        runtimePolicy: {
+          allowFallback: true,
+          maxLatencyMs: 2500
+        }
+      }),
       expect.objectContaining({
         timeout: 2500
       })
     );
-    expect(result).toEqual({
-      detectorSignals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"],
-      plannerSteps: ["Review scanner evidence before remediation."],
-      confidence: 0.81,
-      modelVersion: "detector-planner-runtime-v1"
-    });
-    expect(JSON.stringify(mockedAxios.post.mock.calls)).not.toMatch(
+    expect(inferenceRequest).not.toHaveProperty("normalizedFinding");
+    expect(inferenceRequest).not.toHaveProperty("evidence");
+    expect(result).toEqual(runtimeResponse);
+    expect(JSON.stringify({ calls: mockedAxios.post.mock.calls, result })).not.toMatch(
       /accessToken|refreshToken|tokenValue|secretValue|sourceArchive|fullRepository|rawScannerPayload/i
     );
   });
@@ -85,10 +127,22 @@ describe("AiAdvisoryRuntimeClient", () => {
   it("rejects runtime responses that attempt to override findings or policy", async () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: {
-        detectorSignals: ["SCANNER_CONFIRMED"],
-        plannerSteps: ["Override policy."],
-        confidence: 0.9,
-        modelVersion: "detector-planner-runtime-v1",
+        requestId: "ai_request_1",
+        tenantId: "tenant_runtime",
+        scanRequestId: "scan_request_1",
+        advisoryOnly: true,
+        detectorAdvisories: [],
+        plannerAdvisories: [],
+        modelMetadata: {
+          provider: "deterministic",
+          model: "detector-planner-runtime",
+          version: "2026-05-26"
+        },
+        fallback: {
+          used: false
+        },
+        latencyMs: 1,
+        createdAt: "2026-05-26T00:00:00.000Z",
         enforcementAction: "BLOCK"
       }
     });

--- a/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { AiAdvisoryService } from "../../src/ai-plane/ai-advisory.service";
 
-import type { AiAdvisoryRequest } from "../../../../packages/shared/src";
+import type { AiAdvisoryRequest, AiInferenceResponse } from "../../../../packages/shared/src";
 
 describe("AiAdvisoryService", () => {
   const request: AiAdvisoryRequest = {
@@ -84,13 +84,41 @@ describe("AiAdvisoryService", () => {
   });
 
   it("uses runtime detector planner output when internal AI runtime is enabled", async () => {
+    const runtimeResponse: AiInferenceResponse = {
+      requestId: "ai_request_1",
+      tenantId: "tenant_ai",
+      scanRequestId: "scan_request_1",
+      advisoryOnly: true,
+      detectorAdvisories: [
+        {
+          findingId: "finding_1",
+          confidence: 0.83,
+          rationale: "Runtime detector advisory.",
+          signals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"]
+        }
+      ],
+      plannerAdvisories: [
+        {
+          findingId: "finding_1",
+          action: "Review scanner evidence before remediation.",
+          rationale: "Runtime planner advisory.",
+          priority: "high"
+        }
+      ],
+      modelMetadata: {
+        provider: "deterministic",
+        model: "detector-planner-runtime",
+        version: "2026-05-26"
+      },
+      fallback: {
+        used: true,
+        reason: "provider not configured"
+      },
+      latencyMs: 11,
+      createdAt: "2026-05-26T00:00:00.000Z"
+    };
     const runtime = {
-      createAdvisory: jest.fn().mockResolvedValue({
-        detectorSignals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"],
-        plannerSteps: ["Review scanner evidence before remediation."],
-        confidence: 0.83,
-        modelVersion: "detector-planner-runtime-v1"
-      })
+      createAdvisory: jest.fn().mockResolvedValue(runtimeResponse)
     };
     const service = new AiAdvisoryService(
       {
@@ -115,13 +143,20 @@ describe("AiAdvisoryService", () => {
     );
     expect(advisory).toEqual(
       expect.objectContaining({
-        modelVersion: "detector-planner-runtime-v1",
+        modelVersion: "2026-05-26",
         detectorSignals: ["SCANNER_CONFIRMED", "MODEL_TRIAGED"],
+        plannerSteps: ["Review scanner evidence before remediation."],
         confidence: 0.83,
         advisoryOnly: true,
-        redactedEvidenceOnly: true
+        redactedEvidenceOnly: true,
+        detectorAdvisories: runtimeResponse.detectorAdvisories,
+        plannerAdvisories: runtimeResponse.plannerAdvisories,
+        modelMetadata: runtimeResponse.modelMetadata,
+        fallback: runtimeResponse.fallback
       })
     );
-    expect(JSON.stringify(advisory)).not.toMatch(/enforcementAction|policyOverride|findingOverride/i);
+    expect(JSON.stringify(advisory)).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/i
+    );
   });
 });

--- a/packages/shared/src/types/production-architecture.ts
+++ b/packages/shared/src/types/production-architecture.ts
@@ -1,3 +1,5 @@
+import type { AiDetectorAdvisory, AiInferenceFallback, AiModelMetadata, AiPlannerAdvisory } from './ai-inference-runtime';
+
 export const PRODUCTION_SCAN_ARCHITECTURE_FEATURE_ID = '002-production-scan-architecture';
 
 export const SCAN_LANES = ['FAST', 'DEEP'] as const;
@@ -379,6 +381,10 @@ export interface AiAdvisoryResult {
   detectorSignals: string[];
   plannerSteps: string[];
   confidence: number;
+  detectorAdvisories?: AiDetectorAdvisory[];
+  plannerAdvisories?: AiPlannerAdvisory[];
+  modelMetadata?: AiModelMetadata;
+  fallback?: AiInferenceFallback;
   createdAt: string;
 }
 

--- a/specs/003-production-ai-inference-runtime/tasks.md
+++ b/specs/003-production-ai-inference-runtime/tasks.md
@@ -25,7 +25,7 @@
 
 ## Phase 5: API Integration Slice
 
-- [ ] T012 Wire API advisory client to the model gateway response shape
+- [x] T012 Wire API advisory client to the model gateway response shape
 - [ ] T013 Persist advisory metadata without granting finding or policy authority
 
 ## Deferred


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/220-003-api-advisory-client`
- 이슈: #220

## 🔎 주요 변경 사항

- API AI advisory runtime client가 legacy advisory request를 reduced `AiInferenceRequest`로 변환해 AI Plane `/ai/advisories`에 전송하도록 연동
- runtime response parser를 `AiInferenceResponse` 모델 게이트웨이 shape로 전환하고 forbidden authority/sensitive key를 key 경계에서 검증
- API advisory result가 기존 flat detector/planner 필드와 함께 detector/planner advisory, model metadata, fallback metadata를 보존하도록 projection 추가
- T012 완료 상태를 `specs/003-production-ai-inference-runtime/tasks.md`에 반영

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI advisory responses now include comprehensive detector and planner recommendations alongside model metadata and fallback provider information.

* **Improvements**
  * Enhanced advisory request handling to support expanded response data structures and deterministic fallback routing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->