### PR TITLE
feat: 003 AI 자문 메타데이터 저장과 권한 경계 구현

### DIFF
--- a/apps/api/prisma/migrations/20260603072000_ai_advisory_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260603072000_ai_advisory_metadata/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "AiAdvisoryMetadata" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "scanRequestId" TEXT NOT NULL,
+    "findingId" TEXT NOT NULL,
+    "modelVersion" TEXT NOT NULL,
+    "advisoryOnly" BOOLEAN NOT NULL DEFAULT true,
+    "redactedEvidenceOnly" BOOLEAN NOT NULL DEFAULT true,
+    "detectorSignals" JSONB NOT NULL,
+    "plannerSteps" JSONB NOT NULL,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "detectorAdvisories" JSONB,
+    "plannerAdvisories" JSONB,
+    "modelMetadata" JSONB,
+    "fallback" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AiAdvisoryMetadata_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AiAdvisoryMetadata_tenantId_idx" ON "AiAdvisoryMetadata"("tenantId");
+
+-- CreateIndex
+CREATE INDEX "AiAdvisoryMetadata_scanRequestId_idx" ON "AiAdvisoryMetadata"("scanRequestId");
+
+-- CreateIndex
+CREATE INDEX "AiAdvisoryMetadata_findingId_idx" ON "AiAdvisoryMetadata"("findingId");
+
+-- CreateIndex
+CREATE INDEX "AiAdvisoryMetadata_createdAt_idx" ON "AiAdvisoryMetadata"("createdAt" DESC);
+
+-- AddForeignKey
+ALTER TABLE "AiAdvisoryMetadata" ADD CONSTRAINT "AiAdvisoryMetadata_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AiAdvisoryMetadata" ADD CONSTRAINT "AiAdvisoryMetadata_scanRequestId_fkey" FOREIGN KEY ("scanRequestId") REFERENCES "ScanRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -267,6 +267,7 @@ model Tenant {
   normalizedFindings NormalizedFinding[]
   evidencePacks      EvidencePack[]
   policyDecisions    PolicyDecision[]
+  aiAdvisoryMetadata  AiAdvisoryMetadata[]
   waivers            Waiver[]
   suppressions       Suppression[]
   auditEvents        AuditEvent[]
@@ -335,6 +336,7 @@ model ScanRequest {
   findings          NormalizedFinding[]
   evidencePacks     EvidencePack[]
   policyDecisions   PolicyDecision[]
+  aiAdvisoryMetadata AiAdvisoryMetadata[]
   suppressions      Suppression[]
   auditEvents       AuditEvent[]
 
@@ -443,6 +445,33 @@ model PolicyDecision {
   @@index([tenantId])
   @@index([scanRequestId])
   @@index([findingId])
+}
+
+model AiAdvisoryMetadata {
+  id                   String   @id
+  tenantId             String
+  scanRequestId        String
+  findingId            String
+  modelVersion         String
+  advisoryOnly         Boolean  @default(true)
+  redactedEvidenceOnly Boolean  @default(true)
+  detectorSignals      Json
+  plannerSteps         Json
+  confidence           Float
+  detectorAdvisories   Json?
+  plannerAdvisories    Json?
+  modelMetadata        Json?
+  fallback             Json?
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  tenant      Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  scanRequest ScanRequest @relation(fields: [scanRequestId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([scanRequestId])
+  @@index([findingId])
+  @@index([createdAt(sort: Desc)])
 }
 
 model Waiver {

--- a/apps/api/src/ai-plane/ai-advisory.service.ts
+++ b/apps/api/src/ai-plane/ai-advisory.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException, Optional } from "@nestjs/common";
 
 import type {
   AiAdvisoryRequest,
@@ -10,6 +10,7 @@ import type {
   AiPlannerAdvisory
 } from "../../../../packages/shared/src";
 import { ConfigService } from "../config/config.service";
+import { PrismaService } from "../prisma/prisma.service";
 import { AiAdvisoryRuntimeClient } from "./ai-advisory-runtime.client";
 
 interface AiAdvisoryRuntimeProjection {
@@ -21,6 +22,29 @@ interface AiAdvisoryRuntimeProjection {
   plannerAdvisories?: AiPlannerAdvisory[];
   modelMetadata?: AiModelMetadata;
   fallback?: AiInferenceFallback;
+}
+
+interface AiAdvisoryMetadataRecord {
+  id: string;
+  tenantId: string;
+  scanRequestId: string;
+  findingId: string;
+  modelVersion: string;
+  advisoryOnly: boolean;
+  redactedEvidenceOnly: boolean;
+  detectorSignals: unknown;
+  plannerSteps: unknown;
+  confidence: number;
+  detectorAdvisories?: unknown;
+  plannerAdvisories?: unknown;
+  modelMetadata?: unknown;
+  fallback?: unknown;
+  createdAt: Date | string;
+}
+
+interface AiAdvisoryMetadataDelegate {
+  create(input: { data: Record<string, unknown> }): Promise<AiAdvisoryMetadataRecord>;
+  findFirst(input: { where: { id: string; tenantId: string } }): Promise<AiAdvisoryMetadataRecord | null>;
 }
 
 const FORBIDDEN_AI_INPUT_KEYS = [
@@ -42,7 +66,8 @@ export class AiAdvisoryService {
 
   constructor(
     private readonly config?: ConfigService,
-    private readonly runtimeClient?: AiAdvisoryRuntimeClient
+    private readonly runtimeClient?: AiAdvisoryRuntimeClient,
+    @Optional() private readonly prisma?: PrismaService
   ) {}
 
   async createAdvisory(input: AiAdvisoryRequest): Promise<AiAdvisoryResult> {
@@ -67,12 +92,50 @@ export class AiAdvisoryService {
       createdAt: new Date().toISOString()
     };
 
+    const persistentStore = this.persistentStore();
+    if (persistentStore) {
+      return this.toAdvisoryResult(
+        await persistentStore.create({
+          data: {
+            id: advisory.id,
+            tenantId: advisory.tenantId,
+            scanRequestId: advisory.scanRequestId,
+            findingId: advisory.findingId,
+            modelVersion: advisory.modelVersion,
+            advisoryOnly: advisory.advisoryOnly,
+            redactedEvidenceOnly: advisory.redactedEvidenceOnly,
+            detectorSignals: advisory.detectorSignals,
+            plannerSteps: advisory.plannerSteps,
+            confidence: advisory.confidence,
+            detectorAdvisories: advisory.detectorAdvisories,
+            plannerAdvisories: advisory.plannerAdvisories,
+            modelMetadata: advisory.modelMetadata,
+            fallback: advisory.fallback
+          }
+        })
+      );
+    }
+
     this.advisories.push(advisory);
 
     return advisory;
   }
 
-  getAdvisory(tenantId: string, advisoryId: string): AiAdvisoryResult {
+  async getAdvisory(tenantId: string, advisoryId: string): Promise<AiAdvisoryResult> {
+    const persistentStore = this.persistentStore();
+    if (persistentStore) {
+      const advisory = await persistentStore.findFirst({
+        where: {
+          id: advisoryId,
+          tenantId
+        }
+      });
+
+      if (advisory) {
+        return this.toAdvisoryResult(advisory);
+      }
+    }
+
     const advisory = this.advisories.find(
       (candidate) => candidate.id === advisoryId && candidate.tenantId === tenantId
     );
@@ -82,6 +145,40 @@ export class AiAdvisoryService {
     }
 
     return advisory;
+  }
+
+  private persistentStore(): AiAdvisoryMetadataDelegate | undefined {
+    const candidate = this.prisma as unknown as { aiAdvisoryMetadata?: AiAdvisoryMetadataDelegate } | undefined;
+
+    if (
+      candidate?.aiAdvisoryMetadata &&
+      typeof candidate.aiAdvisoryMetadata.create === "function" &&
+      typeof candidate.aiAdvisoryMetadata.findFirst === "function"
+    ) {
+      return candidate.aiAdvisoryMetadata;
+    }
+
+    return undefined;
+  }
+
+  private toAdvisoryResult(record: AiAdvisoryMetadataRecord): AiAdvisoryResult {
+    return {
+      id: record.id,
+      tenantId: record.tenantId,
+      scanRequestId: record.scanRequestId,
+      findingId: record.findingId,
+      modelVersion: record.modelVersion,
+      advisoryOnly: true,
+      redactedEvidenceOnly: true,
+      detectorSignals: toStringArray(record.detectorSignals),
+      plannerSteps: toStringArray(record.plannerSteps),
+      confidence: record.confidence,
+      detectorAdvisories: toDetectorAdvisories(record.detectorAdvisories),
+      plannerAdvisories: toPlannerAdvisories(record.plannerAdvisories),
+      modelMetadata: toModelMetadata(record.modelMetadata),
+      fallback: toFallback(record.fallback),
+      createdAt: record.createdAt instanceof Date ? record.createdAt.toISOString() : record.createdAt
+    };
   }
 
   private assertReducedInput(input: AiAdvisoryRequest): void {
@@ -162,4 +259,94 @@ export class AiAdvisoryService {
 
     return 0.61;
   }
+}
+
+function toStringArray(input: unknown): string[] {
+  return Array.isArray(input) ? input.filter((item): item is string => typeof item === "string") : [];
+}
+
+function toDetectorAdvisories(input: unknown): AiDetectorAdvisory[] | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+
+  return input.filter(isDetectorAdvisory);
+}
+
+function toPlannerAdvisories(input: unknown): AiPlannerAdvisory[] | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+
+  return input.filter(isPlannerAdvisory);
+}
+
+function toModelMetadata(input: unknown): AiModelMetadata | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  if (
+    typeof candidate.provider === "string" &&
+    typeof candidate.model === "string" &&
+    typeof candidate.version === "string"
+  ) {
+    return {
+      provider: candidate.provider,
+      model: candidate.model,
+      version: candidate.version
+    };
+  }
+
+  return undefined;
+}
+
+function toFallback(input: unknown): AiInferenceFallback | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  if (typeof candidate.used !== "boolean") {
+    return undefined;
+  }
+
+  return {
+    used: candidate.used,
+    reason: typeof candidate.reason === "string" ? candidate.reason : undefined
+  };
+}
+
+function isDetectorAdvisory(input: unknown): input is AiDetectorAdvisory {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return false;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  return (
+    typeof candidate.findingId === "string" &&
+    typeof candidate.confidence === "number" &&
+    typeof candidate.rationale === "string" &&
+    Array.isArray(candidate.signals) &&
+    candidate.signals.every((signal) => typeof signal === "string")
+  );
+}
+
+function isPlannerAdvisory(input: unknown): input is AiPlannerAdvisory {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return false;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  return (
+    (candidate.findingId === undefined || typeof candidate.findingId === "string") &&
+    typeof candidate.action === "string" &&
+    typeof candidate.rationale === "string" &&
+    (candidate.priority === "low" || candidate.priority === "medium" || candidate.priority === "high")
+  );
 }

--- a/apps/api/src/ai-plane/ai-advisory.service.ts
+++ b/apps/api/src/ai-plane/ai-advisory.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException, Optional } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
 
 import type {
   AiAdvisoryRequest,
@@ -73,9 +74,10 @@ export class AiAdvisoryService {
   async createAdvisory(input: AiAdvisoryRequest): Promise<AiAdvisoryResult> {
     this.assertReducedInput(input);
     const runtimeOutput = await this.resolveRuntimeOutput(input);
+    const persistentStore = this.persistentStore();
 
     const advisory: AiAdvisoryResult = {
-      id: `ai_advisory_${++this.advisorySequence}`,
+      id: persistentStore ? randomUUID() : `ai_advisory_${++this.advisorySequence}`,
       tenantId: input.tenantId,
       scanRequestId: input.scanRequestId,
       findingId: input.findingId,
@@ -92,7 +94,6 @@ export class AiAdvisoryService {
       createdAt: new Date().toISOString()
     };
 
-    const persistentStore = this.persistentStore();
     if (persistentStore) {
       return this.toAdvisoryResult(
         await persistentStore.create({

--- a/apps/api/src/ai-plane/ai-plane.module.ts
+++ b/apps/api/src/ai-plane/ai-plane.module.ts
@@ -4,9 +4,10 @@ import { AiAdvisoryController } from "./ai-advisory.controller";
 import { AiAdvisoryRuntimeClient } from "./ai-advisory-runtime.client";
 import { AiAdvisoryService } from "./ai-advisory.service";
 import { ConfigModule } from "../config/config.module";
+import { PrismaModule } from "../prisma/prisma.module";
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, PrismaModule],
   controllers: [AiAdvisoryController],
   providers: [AiAdvisoryService, AiAdvisoryRuntimeClient],
   exports: [AiAdvisoryService]

--- a/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
@@ -203,6 +203,8 @@ describe("AiAdvisoryService", () => {
 
     const advisory = await service.createAdvisory(request);
 
+    expect(advisory.id).not.toBe("ai_advisory_1");
+    expect(advisory.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
     expect(prisma.aiAdvisoryMetadata.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         id: advisory.id,

--- a/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
+++ b/apps/api/test/ai-plane/ai-advisory.service.e2e-spec.ts
@@ -159,4 +159,87 @@ describe("AiAdvisoryService", () => {
       /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/i
     );
   });
+
+  it("persists advisory metadata without granting finding or policy authority", async () => {
+    const createdAt = new Date("2026-05-26T00:00:00.000Z");
+    const prisma = {
+      aiAdvisoryMetadata: {
+        create: jest.fn(async ({ data }) => ({
+          ...data,
+          createdAt,
+          updatedAt: createdAt
+        })),
+        findFirst: jest.fn(async ({ where }) => ({
+          id: where.id,
+          tenantId: where.tenantId,
+          scanRequestId: "scan_request_1",
+          findingId: "finding_1",
+          modelVersion: "detector-planner-mock-v1",
+          advisoryOnly: true,
+          redactedEvidenceOnly: true,
+          detectorSignals: ["SCANNER_CONFIRMED", "SEVERITY_HIGH", "PROVENANCE_OPENGREP"],
+          plannerSteps: [
+            "Review scanner evidence before remediation.",
+            "Prioritize owner review before merging affected changes.",
+            "Apply remediation outside the AI advisory boundary."
+          ],
+          confidence: 0.74,
+          detectorAdvisories: null,
+          plannerAdvisories: null,
+          modelMetadata: null,
+          fallback: null,
+          createdAt,
+          updatedAt: createdAt
+        }))
+      }
+    };
+    const service = new AiAdvisoryService(
+      {
+        get: jest.fn().mockReturnValue("false")
+      } as never,
+      undefined,
+      prisma as never
+    );
+
+    const advisory = await service.createAdvisory(request);
+
+    expect(prisma.aiAdvisoryMetadata.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        id: advisory.id,
+        tenantId: "tenant_ai",
+        scanRequestId: "scan_request_1",
+        findingId: "finding_1",
+        modelVersion: "detector-planner-mock-v1",
+        advisoryOnly: true,
+        redactedEvidenceOnly: true,
+        confidence: 0.74
+      })
+    });
+    expect(JSON.stringify(prisma.aiAdvisoryMetadata.create.mock.calls)).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/i
+    );
+
+    const stored = await service.getAdvisory("tenant_ai", advisory.id);
+
+    expect(prisma.aiAdvisoryMetadata.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: advisory.id,
+        tenantId: "tenant_ai"
+      }
+    });
+    expect(stored).toEqual(
+      expect.objectContaining({
+        id: advisory.id,
+        tenantId: "tenant_ai",
+        scanRequestId: "scan_request_1",
+        findingId: "finding_1",
+        advisoryOnly: true,
+        redactedEvidenceOnly: true,
+        detectorSignals: ["SCANNER_CONFIRMED", "SEVERITY_HIGH", "PROVENANCE_OPENGREP"]
+      })
+    );
+    expect(JSON.stringify(stored)).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/i
+    );
+  });
 });

--- a/apps/api/test/architecture/production-architecture-contracts.e2e-spec.ts
+++ b/apps/api/test/architecture/production-architecture-contracts.e2e-spec.ts
@@ -160,4 +160,19 @@ describe('production scan architecture contracts', () => {
       expect(body).toContain('@@index([tenantId])');
     }
   });
+
+  it('persists AI advisory metadata without policy or finding authority fields', () => {
+    const body = modelBody('AiAdvisoryMetadata');
+
+    expect(body).toContain('tenantId');
+    expect(body).toContain('scanRequestId');
+    expect(body).toContain('findingId');
+    expect(body).toContain('detectorAdvisories');
+    expect(body).toContain('plannerAdvisories');
+    expect(body).toContain('modelMetadata');
+    expect(body).toContain('fallback');
+    expect(body).toContain('@@index([tenantId])');
+    expect(body).toContain('@@index([scanRequestId])');
+    expect(body).not.toMatch(/enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/);
+  });
 });

--- a/apps/api/test/architecture/production-architecture-contracts.e2e-spec.ts
+++ b/apps/api/test/architecture/production-architecture-contracts.e2e-spec.ts
@@ -12,6 +12,10 @@ import { join } from 'node:path';
 
 describe('production scan architecture contracts', () => {
   const schema = readFileSync(join(__dirname, '../../prisma/schema.prisma'), 'utf8');
+  const aiAdvisoryMetadataMigration = readFileSync(
+    join(__dirname, '../../prisma/migrations/20260603072000_ai_advisory_metadata/migration.sql'),
+    'utf8'
+  );
   const modelBody = (model: string) => {
     const start = schema.indexOf(`model ${model} {`);
     if (start === -1) {
@@ -174,5 +178,15 @@ describe('production scan architecture contracts', () => {
     expect(body).toContain('@@index([tenantId])');
     expect(body).toContain('@@index([scanRequestId])');
     expect(body).not.toMatch(/enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/);
+  });
+
+  it('ships a deployable Prisma migration for AI advisory metadata', () => {
+    expect(aiAdvisoryMetadataMigration).toContain('CREATE TABLE "AiAdvisoryMetadata"');
+    expect(aiAdvisoryMetadataMigration).toContain('CONSTRAINT "AiAdvisoryMetadata_pkey" PRIMARY KEY ("id")');
+    expect(aiAdvisoryMetadataMigration).toContain('FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id")');
+    expect(aiAdvisoryMetadataMigration).toContain('FOREIGN KEY ("scanRequestId") REFERENCES "ScanRequest"("id")');
+    expect(aiAdvisoryMetadataMigration).not.toMatch(
+      /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed/
+    );
   });
 });

--- a/specs/003-production-ai-inference-runtime/data-model.md
+++ b/specs/003-production-ai-inference-runtime/data-model.md
@@ -47,6 +47,24 @@
 - `rejectionReason`
 - `createdAt`
 
+### AiAdvisoryMetadata
+
+- `id`
+- `tenantId`
+- `scanRequestId`
+- `findingId`
+- `modelVersion`
+- `advisoryOnly`
+- `redactedEvidenceOnly`
+- `detectorSignals`
+- `plannerSteps`
+- `confidence`
+- `detectorAdvisories`
+- `plannerAdvisories`
+- `modelMetadata`
+- `fallback`
+- `createdAt`
+
 ## State
 
 - `requested`: request accepted by the model gateway
@@ -61,3 +79,6 @@
 - Rejections are audited with a specific reason.
 - Provider credentials are never persisted in these entities.
 - Raw source, repository archives, and SCM tokens are not valid fields.
+- Advisory metadata is persisted for tenant/scan/finding attribution only and
+  does not grant finding creation, policy override, waiver, or suppression
+  authority.

--- a/specs/003-production-ai-inference-runtime/tasks.md
+++ b/specs/003-production-ai-inference-runtime/tasks.md
@@ -26,7 +26,7 @@
 ## Phase 5: API Integration Slice
 
 - [x] T012 Wire API advisory client to the model gateway response shape
-- [ ] T013 Persist advisory metadata without granting finding or policy authority
+- [x] T013 Persist advisory metadata without granting finding or policy authority
 
 ## Deferred
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/222-003-ai-advisory-metadata`
- 이슈: #222

## 🔎 주요 변경 사항

- `AiAdvisoryMetadata` Prisma 모델을 추가해 tenant/scan/finding attribution과 detector/planner/model/fallback metadata를 저장
- AI advisory service가 Prisma delegate가 있으면 persistent metadata store를 사용하고, delegate가 없는 테스트/mock 경계에서는 기존 in-memory fallback을 유지
- 저장/조회 결과에 finding 생성, policy override, enforcement, waiver/suppression authority 필드가 없음을 service 및 architecture contract 테스트로 검증
- 003 data model과 T013 task completion 상태를 동기화

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI advisory metadata can now be persistently stored and retrieved from the database.
  * Advisory records include confidence scores, timestamps, and privacy/redaction flags for compliance.
  * System maintains proper isolation between tenants and scan requests.

* **Documentation**
  * Updated data model documentation for advisory metadata storage capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->