### PR TITLE
feat: 004 쿠버네티스 AI Plane 인프라 패키지 골격 수립

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,23 +2,24 @@
 
 ## Mandatory Start Path
 
-1. Open the canonical execution entry point: [`specs/003-production-ai-inference-runtime/quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md)
+1. Open the canonical execution entry point: [`specs/004-production-runtime-infrastructure/quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md)
 2. Follow the read order and execution flow defined there before touching code.
-3. Use [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/) as the default implementation target unless a narrower active feature replaces it.
+3. Use [`specs/004-production-runtime-infrastructure/`](./specs/004-production-runtime-infrastructure/) as the default implementation target unless a narrower active feature replaces it.
 
 ## Core References
 
-- Canonical execution entry point: [`specs/003-production-ai-inference-runtime/quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md)
+- Canonical execution entry point: [`specs/004-production-runtime-infrastructure/quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md)
 - Primary product baseline: `C:\Users\권태욱\Desktop\Security Scan SaaS Final Specification.docx`
 - Legacy product baseline: [`spec 2.2.md`](./spec%202.2.md)
 - Repository constitution: [`.specify/memory/constitution.md`](./.specify/memory/constitution.md)
-- Active implementation package: [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/)
+- Active implementation package: [`specs/004-production-runtime-infrastructure/`](./specs/004-production-runtime-infrastructure/)
+- Completed production AI inference baseline: [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/)
 - Completed production scan architecture baseline: [`specs/002-production-scan-architecture/`](./specs/002-production-scan-architecture/)
 - Legacy MVP package: [`specs/001-aegisai-mvp-foundation/`](./specs/001-aegisai-mvp-foundation/)
 
 ## Active Feature Baseline
 
-- Feature id: `003-production-ai-inference-runtime`
+- Feature id: `004-production-runtime-infrastructure`
 - Use this feature package as the default implementation target until a narrower feature spec replaces it.
 
 ## GitHub Workflow Convention
@@ -37,7 +38,7 @@ The repository-level GitHub workflow convention is documented in
 GitHub branch names do not need to match the spec directory name. In a PowerShell session, run:
 
 ```powershell
-$env:SPECIFY_FEATURE = "003-production-ai-inference-runtime"
+$env:SPECIFY_FEATURE = "004-production-runtime-infrastructure"
 ```
 
 This makes Spec Kit scripts resolve the active feature directory directly while you continue
@@ -49,9 +50,10 @@ working on GitHub-style branches such as `feat/<issue-number>-<short-feature>`.
 2. `quickstart.md` defines the canonical read order, execution flow, and completion flow.
 3. `Security Scan SaaS Final Specification.docx` is the highest-priority product, platform, security, and operations baseline.
 4. The active feature package defines implementation-ready scope and task detail.
-5. `002-production-scan-architecture` remains the completed production scan architecture baseline.
-6. `spec 2.2.md` and `001-aegisai-mvp-foundation` remain legacy MVP references.
-7. `.specify/memory/constitution.md` remains a repository guardrail reference.
+5. `003-production-ai-inference-runtime` remains the completed production AI inference baseline.
+6. `002-production-scan-architecture` remains the completed production scan architecture baseline.
+7. `spec 2.2.md` and `001-aegisai-mvp-foundation` remain legacy MVP references.
+8. `.specify/memory/constitution.md` remains a repository guardrail reference.
 
 ## Agent Execution Policy
 
@@ -63,13 +65,14 @@ working on GitHub-style branches such as `feat/<issue-number>-<short-feature>`.
 
 ## Non-Negotiable Rules
 
-- Stay inside the active production AI inference milestone unless the current spec explicitly reclassifies deferred work.
+- Stay inside the active production runtime infrastructure milestone unless the current spec explicitly reclassifies deferred work.
 - Keep user authentication separate from SCM integration credentials.
 - Model GitHub Cloud repository access through GitHub App installation and GitLab Cloud access through scoped integration plus webhook flows.
 - Keep Scan Plane, AI Plane, and Data/Security Plane boundaries explicit.
 - Do not add direct source upload.
 - Do not execute customer code, install packages, or build customer repositories.
 - AI is advisory-only and must not create authoritative findings, override policy, or receive SCM credentials/full repository inputs.
+- Kubernetes AI Plane deployment and scanner sandbox provisioning must preserve the separated Control, Scan, AI, and Data/Security plane boundaries.
 - Shared API contracts belong in `packages/shared`.
 - Sessions, CSRF protection, throttling, health checks, and critical integration tests are required.
 
@@ -82,7 +85,7 @@ working on GitHub-style branches such as `feat/<issue-number>-<short-feature>`.
 
 ## Completion Gate
 
-- Re-run the final validation path from [`quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md) before claiming completion.
+- Re-run the final validation path from [`quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md) before claiming completion.
 - Re-check [`specs/001-aegisai-mvp-foundation/hardening-review.md`](./specs/001-aegisai-mvp-foundation/hardening-review.md) only when legacy MVP hardening or release-readiness is explicitly part of the task.
 - Keep entrypoint docs synchronized whenever execution guidance changes.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 This repository is organized around the production scan architecture baseline for AegisAI.
 
 - Agents should start with [`AGENTS.md`](./AGENTS.md).
-- The canonical execution path lives in [`specs/003-production-ai-inference-runtime/quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md).
+- The canonical execution path lives in [`specs/004-production-runtime-infrastructure/quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md).
 - The production product baseline is `C:\Users\권태욱\Desktop\Security Scan SaaS Final Specification.docx`.
-- The active implementation package lives in [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/).
+- The active implementation package lives in [`specs/004-production-runtime-infrastructure/`](./specs/004-production-runtime-infrastructure/).
+- The completed production AI inference baseline remains available in [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/).
 - The completed production scan architecture baseline remains available in [`specs/002-production-scan-architecture/`](./specs/002-production-scan-architecture/).
 - The legacy MVP baseline remains available in [`specs/001-aegisai-mvp-foundation/`](./specs/001-aegisai-mvp-foundation/) and [`spec 2.2.md`](./spec%202.2.md).
 
@@ -16,13 +17,13 @@ feature package` instead of jumping directly to `tasks.md`.
 
 ## Completion
 
-When validating the active production AI inference runtime milestone, use the completion flow in
-[`specs/003-production-ai-inference-runtime/quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md).
+When validating the active production runtime infrastructure milestone, use the completion flow in
+[`specs/004-production-runtime-infrastructure/quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md).
 The legacy MVP hardening review remains available for tasks that explicitly touch the shipped
 MVP baseline: [`specs/001-aegisai-mvp-foundation/hardening-review.md`](./specs/001-aegisai-mvp-foundation/hardening-review.md).
 
 The canonical CLI validation commands live in
-[`specs/003-production-ai-inference-runtime/quickstart.md`](./specs/003-production-ai-inference-runtime/quickstart.md).
+[`specs/004-production-runtime-infrastructure/quickstart.md`](./specs/004-production-runtime-infrastructure/quickstart.md).
 
 ## GitHub Conventions
 
@@ -35,8 +36,8 @@ The repository follows the GitHub workflow convention documented in
 - Issue titles and PR titles must match
 - `dev` is the default integration branch and `main` remains the release-ready branch
 
-Spec Kit feature docs now live in [`specs/003-production-ai-inference-runtime/`](./specs/003-production-ai-inference-runtime/),
-so GitHub-style working branches may need `SPECIFY_FEATURE=003-production-ai-inference-runtime`
+Spec Kit feature docs now live in [`specs/004-production-runtime-infrastructure/`](./specs/004-production-runtime-infrastructure/),
+so GitHub-style working branches may need `SPECIFY_FEATURE=004-production-runtime-infrastructure`
 when running Spec Kit helpers.
 
 ## CI

--- a/docs/github-conventions.md
+++ b/docs/github-conventions.md
@@ -59,14 +59,15 @@ Issue references may be added in the footer when needed.
 
 ## Spec Kit Compatibility
 
-The active implementation package lives under `specs/003-production-ai-inference-runtime/`.
-The completed `specs/002-production-scan-architecture/` package remains the production scan
-architecture baseline. The previous `specs/001-aegisai-mvp-foundation/` package remains a
-legacy MVP baseline.
+The active implementation package lives under `specs/004-production-runtime-infrastructure/`.
+The completed `specs/003-production-ai-inference-runtime/` package remains the production AI
+inference baseline. The completed `specs/002-production-scan-architecture/` package remains the
+production scan architecture baseline. The previous `specs/001-aegisai-mvp-foundation/` package
+remains a legacy MVP baseline.
 
 When you are working on a GitHub-style branch such as `feat/4-github-setup`, use
 `SPECIFY_FEATURE` to point Spec Kit scripts at the active feature directory when needed:
 
 ```powershell
-$env:SPECIFY_FEATURE = "003-production-ai-inference-runtime"
+$env:SPECIFY_FEATURE = "004-production-runtime-infrastructure"
 ```

--- a/specs/003-production-ai-inference-runtime/plan.md
+++ b/specs/003-production-ai-inference-runtime/plan.md
@@ -13,7 +13,7 @@ observability.
 - `apps/ai`: model gateway, reduced evidence validation, provider adapters, and
   fallback runtime
 - `apps/api`: AI advisory client integration and audit attribution
-- `specs/003-production-ai-inference-runtime`: active feature package
+- `specs/003-production-ai-inference-runtime`: completed AI inference baseline
 
 ## Runtime Shape
 

--- a/specs/003-production-ai-inference-runtime/quickstart.md
+++ b/specs/003-production-ai-inference-runtime/quickstart.md
@@ -15,8 +15,10 @@ Control, Scan, AI, and Data/Security planes.
 ## Canonical Use
 
 - Agents should arrive here from [`AGENTS.md`](../../AGENTS.md).
-- This package is the active implementation target for trained production AI
-  detector/planner inference runtime work.
+- This package is the completed production AI detector/planner inference
+  runtime baseline.
+- `004-production-runtime-infrastructure` is the active follow-up package for
+  Kubernetes AI Plane deployment and microVM scanner provisioning.
 - `002-production-scan-architecture` remains the completed production scan
   architecture baseline.
 - `001-aegisai-mvp-foundation` remains the legacy MVP baseline and historical
@@ -72,8 +74,8 @@ evidence produced by the scanner-first pipeline. It is advisory-only:
 4. Add reduced evidence validation and rejection tests for forbidden payloads.
 5. Add deterministic mock inference for local/dev execution.
 6. Add production model provider wiring behind configuration and audit events.
-7. Keep Kubernetes/microVM production provisioning for a later infrastructure
-   package unless this feature package explicitly reclassifies it.
+7. Kubernetes/microVM production provisioning moved to
+   `004-production-runtime-infrastructure`.
 
 ## Deployment Position
 
@@ -81,6 +83,9 @@ Oracle VPS and Docker Compose remain dev/demo paths. Production inference runtim
 readiness is defined around the AI Plane running behind a model gateway with
 tenant-aware audit, bounded reduced-evidence retention, and Kubernetes-compatible
 deployment boundaries.
+
+The Kubernetes-compatible deployment boundary is implemented in the follow-up
+`004-production-runtime-infrastructure` package.
 
 ## Spec Kit Compatibility
 
@@ -96,12 +101,14 @@ Before claiming this milestone is complete:
 
 1. Re-run the validation commands below.
 2. Confirm this quickstart, `AGENTS.md`, `README.md`, and
-   `docs/github-conventions.md` all point to `003-production-ai-inference-runtime`.
+   `docs/github-conventions.md` point to the currently active feature package.
 3. Confirm `002-production-scan-architecture` remains available as the completed
    production scan architecture baseline.
 4. Confirm `001-aegisai-mvp-foundation` remains available as the legacy MVP baseline.
 5. Confirm AI remains advisory-only and never receives SCM credentials, full
    repositories, source archives, or raw scanner payloads.
+6. Confirm Kubernetes AI Plane deployment and microVM scanner provisioning are
+   tracked under `004-production-runtime-infrastructure`.
 
 ## Validation Commands
 

--- a/specs/003-production-ai-inference-runtime/spec.md
+++ b/specs/003-production-ai-inference-runtime/spec.md
@@ -47,7 +47,7 @@ that consumes reduced evidence and returns advisory detector/planner output.
 
 - Shared contracts describe `AiInferenceRequest`, `AiInferenceResponse`, and
   `ReducedEvidence`.
-- Entry-point docs identify `003-production-ai-inference-runtime` as the active
-  feature package.
+- Entry-point docs preserve `003-production-ai-inference-runtime` as the
+  completed production AI inference baseline.
 - The completed 002 baseline remains linked and preserved.
 - The completion gate stays synchronized with CI.

--- a/specs/003-production-ai-inference-runtime/tasks.md
+++ b/specs/003-production-ai-inference-runtime/tasks.md
@@ -28,7 +28,7 @@
 - [x] T012 Wire API advisory client to the model gateway response shape
 - [x] T013 Persist advisory metadata without granting finding or policy authority
 
-## Deferred
+## Deferred Follow-Up
 
-- [ ] Kubernetes production AI Plane deployment manifests and runtime autoscaling
-- [ ] microVM-backed scanner provisioning
+- [x] Kubernetes production AI Plane deployment manifests and runtime autoscaling moved to `004-production-runtime-infrastructure`
+- [x] microVM-backed scanner provisioning moved to `004-production-runtime-infrastructure`

--- a/specs/004-production-runtime-infrastructure/checklists/requirements.md
+++ b/specs/004-production-runtime-infrastructure/checklists/requirements.md
@@ -1,0 +1,15 @@
+# Requirements Checklist: Production Runtime Infrastructure
+
+- [x] 004 feature package has a canonical quickstart.
+- [x] 004 references the completed 003 production AI inference baseline.
+- [x] 004 references the completed 002 production scan architecture baseline.
+- [x] 004 keeps 001 as the legacy MVP baseline.
+- [x] Kubernetes AI Plane deployment preserves advisory-only AI.
+- [x] AI does not create authoritative findings.
+- [x] AI does not override policy decisions.
+- [x] AI does not receive SCM credentials.
+- [x] AI does not receive full repositories, source archives, or raw scanner payloads.
+- [x] Scanner sandbox provisioning uses stronger-than-pod isolation.
+- [x] Scanner sandbox provisioning forbids package install/build, dynamic testing, direct source upload, and auto-fix PR/MR flows.
+- [x] Runtime infrastructure work is split into issue-sized package, manifest, autoscaling, and sandbox slices.
+- [x] Completion validation points to quickstart and CI rather than duplicating command checklists in README.

--- a/specs/004-production-runtime-infrastructure/contracts/runtime-infrastructure.md
+++ b/specs/004-production-runtime-infrastructure/contracts/runtime-infrastructure.md
@@ -1,0 +1,80 @@
+# Contracts: Production Runtime Infrastructure
+
+## AiPlaneDeployment
+
+```ts
+interface AiPlaneDeployment {
+  name: string;
+  namespace: string;
+  image: string;
+  serviceName: string;
+  healthPath: "/health";
+  configRefs: string[];
+  secretRefs: string[];
+  networkPolicyRefs: string[];
+  advisoryOnly: true;
+}
+```
+
+The AI Plane deployment must not include SCM credential, repository archive,
+full repository, raw scanner payload, policy override, waiver, suppression, or
+finding authority fields.
+
+## RuntimeAutoscalingPolicy
+
+```ts
+interface RuntimeAutoscalingPolicy {
+  targetName: string;
+  minReplicas: number;
+  maxReplicas: number;
+  latencyP95Ms: number;
+  queueDepth: number;
+  providerErrorRate: number;
+  fallbackRate: number;
+  cpuUtilization: number;
+  memoryUtilization: number;
+}
+```
+
+Autoscaling policy is advisory to infrastructure controllers. It must not create
+findings, override policy, or alter waiver/suppression state.
+
+## ScannerSandboxProvisioning
+
+```ts
+interface ScannerSandboxProvisioning {
+  sandboxProvider: "MICROVM";
+  isolationClass: "HARDENED" | "RESTRICTED";
+  tenantId: string;
+  scanRequestId: string;
+  repositoryBindingId: string;
+  scannerSetVersion: string;
+  ttlSeconds: number;
+  networkEgressPolicy: "SCM_AND_SCANNER_UPDATES_ONLY" | "SCM_ONLY";
+  evidenceOutputRef: string;
+}
+```
+
+Scanner sandbox provisioning may request scan-scoped repository access through
+the token broker, but token values are short-lived, non-persisted, and never
+exposed to the AI Plane.
+
+## InfrastructureAuditSignal
+
+```ts
+interface InfrastructureAuditSignal {
+  tenantId: string;
+  scanRequestId?: string;
+  runtimeId?: string;
+  sandboxId?: string;
+  eventType: string;
+  actor: "CONTROL_PLANE" | "SCAN_PLANE" | "AI_PLANE" | "DATA_SECURITY_PLANE";
+  targetType: string;
+  targetId: string;
+  metadata?: Record<string, unknown>;
+  occurredAt: string;
+}
+```
+
+Audit metadata must not contain secret values, SCM tokens, full repository
+content, source archives, or raw scanner payloads.

--- a/specs/004-production-runtime-infrastructure/data-model.md
+++ b/specs/004-production-runtime-infrastructure/data-model.md
@@ -1,0 +1,72 @@
+# Data Model: Production Runtime Infrastructure
+
+## Entities
+
+### AiPlaneDeployment
+
+- `name`
+- `namespace`
+- `image`
+- `serviceName`
+- `healthPath`
+- `configRefs`
+- `secretRefs`
+- `networkPolicyRefs`
+- `advisoryOnly`
+
+### RuntimeAutoscalingPolicy
+
+- `targetName`
+- `minReplicas`
+- `maxReplicas`
+- `latencyP95Ms`
+- `queueDepth`
+- `providerErrorRate`
+- `fallbackRate`
+- `cpuUtilization`
+- `memoryUtilization`
+
+### ScannerSandboxProvisioning
+
+- `sandboxProvider`
+- `isolationClass`
+- `tenantId`
+- `scanRequestId`
+- `repositoryBindingId`
+- `scannerSetVersion`
+- `ttlSeconds`
+- `networkEgressPolicy`
+- `evidenceOutputRef`
+
+### InfrastructureAuditSignal
+
+- `tenantId`
+- `scanRequestId`
+- `runtimeId`
+- `sandboxId`
+- `eventType`
+- `actor`
+- `targetType`
+- `targetId`
+- `metadata`
+- `occurredAt`
+
+## State
+
+- `planned`: deployment or sandbox request is accepted for planning
+- `provisioning`: runtime or sandbox resources are being prepared
+- `ready`: runtime or sandbox health gate passed
+- `running`: runtime or scanner workload is active
+- `draining`: runtime or sandbox is stopping new work
+- `terminated`: runtime or sandbox lifecycle ended
+- `failed`: runtime or sandbox lifecycle failed
+
+## Boundary Rules
+
+- AI Plane deployment data cannot include SCM credentials, repository archives,
+  full source trees, raw scanner payloads, or policy override fields.
+- Scanner sandbox provisioning can reference repository binding and scan request
+  identifiers, but must not persist issued token values.
+- Sandbox output is evidence metadata only; raw artifacts stay under object
+  storage retention and redaction rules.
+- Autoscaling policies do not override policy decisions or finding authority.

--- a/specs/004-production-runtime-infrastructure/plan.md
+++ b/specs/004-production-runtime-infrastructure/plan.md
@@ -1,0 +1,50 @@
+# Plan: Production Runtime Infrastructure
+
+## Approach
+
+Implement runtime infrastructure in thin, testable slices. The first slice is
+documentation and active feature re-baselining. Later slices add deployment
+manifests, runtime autoscaling, scanner sandbox provisioning, and operational
+guardrails.
+
+## Target Boundaries
+
+- `specs/004-production-runtime-infrastructure`: active feature package
+- `packages/shared`: public runtime infrastructure contracts when code contracts
+  are introduced
+- `deploy/kubernetes`: Kubernetes deployment manifests for Control, Scan, AI,
+  and Data/Security plane integration points
+- `deploy/scanner-sandbox`: scanner sandbox provisioning configuration and
+  microVM lifecycle contracts
+- `apps/ai`: AI Plane runtime image and health contract consumed by manifests
+- `apps/api`: Control Plane integration points for planner, token broker, and audit
+
+## Runtime Shape
+
+1. Control Plane accepts integration, webhook, scan planner, token broker, policy,
+   and comment dispatcher traffic.
+2. Scan Plane provisions ephemeral scanner sandboxes with stronger-than-pod
+   isolation before repository fetch or scanner execution.
+3. AI Plane runs behind Kubernetes service boundaries and only receives reduced
+   evidence through the model gateway.
+4. Data/Security Plane provides tenant-aware database, object storage retention,
+   audit, KMS, and secrets boundaries.
+5. Observability tracks queue pressure, latency, provider health, fallback use,
+   sandbox lifecycle, and policy-safe audit events.
+
+## Key Interfaces
+
+- AiPlaneDeployment: deployment manifests, service, health, configuration, and
+  secret references for the AI Plane.
+- RuntimeAutoscalingPolicy: request latency, queue pressure, provider health,
+  fallback, and resource thresholds.
+- ScannerSandboxProvisioning: microVM sandbox request, lifecycle, repository
+  fetch boundary, scanner adapter boundary, and evidence handoff.
+- InfrastructureAuditSignal: tenant, scan, runtime, sandbox, and deployment
+  attribution without secret values.
+
+## Completion Strategy
+
+Use TDD for each implementation slice. Keep the production scan architecture and
+AI inference guardrails intact. Add tests whenever a deployment manifest,
+autoscaling policy, sandbox lifecycle, or secret boundary is introduced.

--- a/specs/004-production-runtime-infrastructure/quickstart.md
+++ b/specs/004-production-runtime-infrastructure/quickstart.md
@@ -1,0 +1,126 @@
+# Quickstart: Production Runtime Infrastructure
+
+## Goal
+
+Use this feature package as the canonical implementation entry point for the
+production runtime infrastructure milestone. The source product and platform
+baseline remains `C:\Users\권태욱\Desktop\Security Scan SaaS Final Specification.docx`.
+
+This package follows the completed production AI inference baseline in
+[`specs/003-production-ai-inference-runtime/`](../003-production-ai-inference-runtime/)
+and the completed production scan architecture baseline in
+[`specs/002-production-scan-architecture/`](../002-production-scan-architecture/).
+It reclassifies the deferred Kubernetes and microVM infrastructure work into an
+implementation-ready package while preserving the scanner-first pipeline,
+advisory-only AI boundary, and separated Control, Scan, AI, and Data/Security
+planes.
+
+## Canonical Use
+
+- Agents should arrive here from [`AGENTS.md`](../../AGENTS.md).
+- This package is the active implementation target for production runtime
+  infrastructure work.
+- `003-production-ai-inference-runtime` remains the completed production AI
+  inference baseline.
+- `002-production-scan-architecture` remains the completed production scan
+  architecture baseline.
+- `001-aegisai-mvp-foundation` remains the legacy MVP baseline and historical
+  implementation reference.
+
+## Document Map
+
+- `Security Scan SaaS Final Specification.docx`: highest-priority product,
+  security, and operations specification
+- `.specify/memory/constitution.md`: repository guardrails
+- `specs/003-production-ai-inference-runtime/`: completed AI runtime baseline
+- `specs/002-production-scan-architecture/`: completed production architecture
+  baseline for scanner-first flows and plane separation
+- `spec.md`: active infrastructure scope and acceptance criteria
+- `research.md`: infrastructure decisions and rejected alternatives
+- `data-model.md`: deployment, autoscaling, and sandbox model
+- `contracts/runtime-infrastructure.md`: runtime infrastructure contracts
+- `plan.md`: implementation approach and project structure
+- `tasks.md`: execution-ordered milestone task list
+- `checklists/requirements.md`: quality checklist
+
+## Required Read Order
+
+1. `C:\Users\권태욱\Desktop\Security Scan SaaS Final Specification.docx`
+2. `.specify/memory/constitution.md`
+3. `specs/002-production-scan-architecture/quickstart.md`
+4. `specs/002-production-scan-architecture/contracts/scan-architecture.md`
+5. `specs/003-production-ai-inference-runtime/quickstart.md`
+6. `specs/003-production-ai-inference-runtime/contracts/ai-inference-runtime.md`
+7. `specs/004-production-runtime-infrastructure/spec.md`
+8. `specs/004-production-runtime-infrastructure/research.md`
+9. `specs/004-production-runtime-infrastructure/data-model.md`
+10. `specs/004-production-runtime-infrastructure/contracts/runtime-infrastructure.md`
+11. `specs/004-production-runtime-infrastructure/plan.md`
+12. `specs/004-production-runtime-infrastructure/tasks.md`
+13. `specs/004-production-runtime-infrastructure/checklists/requirements.md`
+
+## Architecture Baseline
+
+Production runtime infrastructure separates deployable planes and hardens scan
+execution:
+
+- Kubernetes production AI Plane deployment MUST preserve advisory-only AI.
+- AI Plane pods MUST NOT receive SCM credentials, full repositories, source
+  archives, or raw scanner payloads.
+- Runtime autoscaling MUST be described around request latency, queue pressure,
+  provider health, and tenant-aware audit signals.
+- microVM-backed scanner provisioning MUST isolate customer repository fetch and
+  scanner execution from the Control Plane and AI Plane.
+- Scanner sandboxes MUST NOT install packages, build customer repositories, run
+  dynamic tests, or add direct source upload.
+
+## Execution Flow
+
+1. Re-baseline repository documentation to this feature package.
+2. Add runtime infrastructure contracts and data model docs.
+3. Add Kubernetes AI Plane manifest skeletons and tests.
+4. Add runtime autoscaling policy skeletons and tests.
+5. Add scanner sandbox provisioning contracts for microVM-backed execution.
+6. Keep provider-specific cluster credentials and production cluster rollout for
+   explicit deployment operations, not local development defaults.
+
+## Deployment Position
+
+Oracle VPS and Docker Compose remain dev/demo paths. Production readiness is
+defined around Kubernetes-compatible Control, Scan, AI, and Data/Security plane
+boundaries with stronger-than-pod scan isolation.
+
+## Spec Kit Compatibility
+
+When working on GitHub-style branches, use:
+
+```powershell
+$env:SPECIFY_FEATURE = "004-production-runtime-infrastructure"
+```
+
+## Completion Gate
+
+Before claiming this milestone is complete:
+
+1. Re-run the validation commands below.
+2. Confirm this quickstart, `AGENTS.md`, `README.md`, and
+   `docs/github-conventions.md` all point to `004-production-runtime-infrastructure`.
+3. Confirm `003-production-ai-inference-runtime` remains available as the
+   completed production AI inference baseline.
+4. Confirm `002-production-scan-architecture` remains available as the completed
+   production scan architecture baseline.
+5. Confirm `001-aegisai-mvp-foundation` remains available as the legacy MVP baseline.
+6. Confirm Kubernetes AI Plane deployment preserves advisory-only AI boundaries.
+7. Confirm scanner sandbox provisioning does not permit package install/build,
+   dynamic testing, direct source upload, or AI access to full repositories.
+
+## Validation Commands
+
+```powershell
+corepack pnpm lint
+corepack pnpm test
+corepack pnpm typecheck
+corepack pnpm build
+corepack pnpm --filter @aegisai/api prisma:validate
+git diff --check
+```

--- a/specs/004-production-runtime-infrastructure/research.md
+++ b/specs/004-production-runtime-infrastructure/research.md
@@ -1,0 +1,46 @@
+# Research: Production Runtime Infrastructure
+
+## Decisions
+
+### Kubernetes AI Plane first
+
+Define the AI Plane deployment boundary before adding cluster-specific rollout.
+This keeps production topology clear while avoiding premature credential and
+provider coupling.
+
+### Runtime autoscaling as policy
+
+Autoscaling is modeled as policy driven by latency, queue pressure, provider
+health, fallback use, and resource pressure. This avoids tying the product
+contract to one autoscaler implementation too early.
+
+### microVM-backed scanner isolation
+
+Scanner provisioning is modeled around stronger-than-pod isolation because scan
+jobs fetch customer repositories and run static scanners. The Control Plane and
+AI Plane stay outside customer repository execution boundaries.
+
+### Oracle VPS remains dev/demo
+
+The existing Docker Compose path remains useful for development and demos, but it
+does not represent the production topology for separated planes or stronger
+scan isolation.
+
+## Rejected Alternatives
+
+### Kubernetes cluster provisioning in the first slice
+
+Rejected because this issue is the package skeleton and contract baseline. Live
+cluster rollout needs separate secrets, environment decisions, and operational
+approval.
+
+### AI Plane receives repository input for convenience
+
+Rejected because 002 and 003 require AI to consume reduced evidence only and
+remain advisory-only.
+
+### Pod-only scanner isolation
+
+Rejected because scanner jobs handle fetched customer repositories. The baseline
+requires stronger-than-pod isolation before customer repository fetch or scanner
+execution.

--- a/specs/004-production-runtime-infrastructure/spec.md
+++ b/specs/004-production-runtime-infrastructure/spec.md
@@ -1,0 +1,56 @@
+# Specification: Production Runtime Infrastructure
+
+## Scope
+
+This milestone turns the deferred Kubernetes and microVM infrastructure work
+from 003 into an implementation-ready feature package. It does not replace the
+completed scanner-first architecture or the completed AI inference runtime. It
+defines the production deployment and isolation contracts needed to run those
+planes safely.
+
+## In Scope
+
+- Kubernetes production AI Plane deployment manifests
+- Runtime autoscaling policy for the AI Plane
+- Kubernetes-compatible service, health, configuration, and secret boundaries
+- microVM-backed scanner provisioning model
+- Scanner sandbox lifecycle and isolation requirements
+- Tenant, scan, runtime, and sandbox audit attribution
+- Dev/demo Oracle VPS path preservation as a non-production deploy path
+
+## Out of Scope
+
+- Provisioning a live production Kubernetes cluster
+- Vendor-specific cluster credential handling
+- Customer code execution outside hardened scan isolation
+- Package install/build, dynamic testing, auto-fix PR/MR, or direct source upload
+- AI finding authority or policy override
+- AI access to SCM credentials, full repositories, source archives, or raw scanner payloads
+
+## Requirements
+
+- Kubernetes AI Plane manifests MUST keep AI advisory-only.
+- Kubernetes AI Plane manifests MUST NOT expose SCM credentials or repository
+  source inputs to AI containers.
+- Runtime autoscaling MUST include request latency, queue pressure, provider
+  health, and failure/fallback signals.
+- Scanner sandbox provisioning MUST model microVM-backed stronger-than-pod
+  isolation.
+- Scanner sandbox provisioning MUST separate repository fetch and scanner
+  execution from Control Plane and AI Plane responsibilities.
+- The system MUST NOT execute customer code outside hardened scan isolation.
+- The system MUST NOT install packages, build customer repositories, run dynamic
+  tests, add direct source upload, or create auto-fix PR/MR flows in this package.
+- Oracle VPS and Docker Compose MUST remain documented as dev/demo paths only.
+
+## Acceptance
+
+- Entry-point docs identify `004-production-runtime-infrastructure` as the active
+  feature package.
+- `003-production-ai-inference-runtime` remains linked and preserved as the
+  completed AI inference baseline.
+- `002-production-scan-architecture` remains linked and preserved as the
+  completed production scan architecture baseline.
+- Contracts describe `AiPlaneDeployment`, `RuntimeAutoscalingPolicy`, and
+  `ScannerSandboxProvisioning`.
+- The completion gate stays synchronized with CI.

--- a/specs/004-production-runtime-infrastructure/tasks.md
+++ b/specs/004-production-runtime-infrastructure/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Production Runtime Infrastructure
+
+## Phase 1: Feature Package Re-Baseline
+
+- [x] T001 Add 004 production runtime infrastructure feature package skeleton
+- [x] T002 Point AGENTS, README, and GitHub conventions at the 004 quickstart
+- [x] T003 Add active feature tests for the 004 entrypoint and 003 baseline preservation
+- [x] T004 Point README completion guidance at the 004 quickstart and CI workflow without duplicating command checklists
+
+## Phase 2: Kubernetes AI Plane Manifest Slice
+
+- [ ] T005 Add Kubernetes AI Plane deployment and service manifest skeletons
+- [ ] T006 Add manifest tests proving AI containers do not receive SCM credentials, repository archives, full repositories, source archives, or raw scanner payloads
+
+## Phase 3: Runtime Autoscaling Slice
+
+- [ ] T007 Add runtime autoscaling policy skeleton for latency, queue pressure, provider health, fallback, CPU, and memory signals
+- [ ] T008 Add autoscaling tests proving policy cannot grant finding or policy authority
+
+## Phase 4: Scanner Sandbox Provisioning Slice
+
+- [ ] T009 Add microVM scanner sandbox provisioning contract skeleton
+- [ ] T010 Add scanner sandbox tests proving package install/build, dynamic testing, direct source upload, and AI repository access remain forbidden
+
+## Deferred
+
+- [ ] Live production Kubernetes cluster provisioning
+- [ ] Provider-specific microVM platform rollout

--- a/test/github-actions/active-feature.test.mjs
+++ b/test/github-actions/active-feature.test.mjs
@@ -7,14 +7,17 @@ const files = {
   readme: new URL('../../README.md', import.meta.url),
   conventions: new URL('../../docs/github-conventions.md', import.meta.url),
   ci: new URL('../../.github/workflows/ci.yml', import.meta.url),
-  quickstart: new URL('../../specs/003-production-ai-inference-runtime/quickstart.md', import.meta.url),
-  spec: new URL('../../specs/003-production-ai-inference-runtime/spec.md', import.meta.url),
-  plan: new URL('../../specs/003-production-ai-inference-runtime/plan.md', import.meta.url),
-  research: new URL('../../specs/003-production-ai-inference-runtime/research.md', import.meta.url),
-  dataModel: new URL('../../specs/003-production-ai-inference-runtime/data-model.md', import.meta.url),
-  tasks: new URL('../../specs/003-production-ai-inference-runtime/tasks.md', import.meta.url),
-  contract: new URL('../../specs/003-production-ai-inference-runtime/contracts/ai-inference-runtime.md', import.meta.url),
-  checklist: new URL('../../specs/003-production-ai-inference-runtime/checklists/requirements.md', import.meta.url),
+  quickstart: new URL('../../specs/004-production-runtime-infrastructure/quickstart.md', import.meta.url),
+  spec: new URL('../../specs/004-production-runtime-infrastructure/spec.md', import.meta.url),
+  plan: new URL('../../specs/004-production-runtime-infrastructure/plan.md', import.meta.url),
+  research: new URL('../../specs/004-production-runtime-infrastructure/research.md', import.meta.url),
+  dataModel: new URL('../../specs/004-production-runtime-infrastructure/data-model.md', import.meta.url),
+  tasks: new URL('../../specs/004-production-runtime-infrastructure/tasks.md', import.meta.url),
+  contract: new URL('../../specs/004-production-runtime-infrastructure/contracts/runtime-infrastructure.md', import.meta.url),
+  checklist: new URL('../../specs/004-production-runtime-infrastructure/checklists/requirements.md', import.meta.url),
+  completedAiQuickstart: new URL('../../specs/003-production-ai-inference-runtime/quickstart.md', import.meta.url),
+  completedAiTasks: new URL('../../specs/003-production-ai-inference-runtime/tasks.md', import.meta.url),
+  completedAiChecklist: new URL('../../specs/003-production-ai-inference-runtime/checklists/requirements.md', import.meta.url),
   completedArchitectureQuickstart: new URL('../../specs/002-production-scan-architecture/quickstart.md', import.meta.url),
   completedArchitectureTasks: new URL('../../specs/002-production-scan-architecture/tasks.md', import.meta.url),
   completedArchitectureChecklist: new URL('../../specs/002-production-scan-architecture/checklists/requirements.md', import.meta.url)
@@ -22,7 +25,7 @@ const files = {
 
 const readNormalizedText = (fileUrl) => readFileSync(fileUrl, 'utf8').replace(/\r\n/g, '\n');
 
-test('production AI inference runtime is the active feature package', () => {
+test('production runtime infrastructure is the active feature package', () => {
   for (const [name, fileUrl] of Object.entries(files)) {
     assert.equal(existsSync(fileUrl), true, `Expected ${name} file to exist at ${fileUrl.pathname}`);
   }
@@ -35,31 +38,33 @@ test('production AI inference runtime is the active feature package', () => {
   const plan = readNormalizedText(files.plan);
   const contract = readNormalizedText(files.contract);
 
-  assert.match(agents, /003-production-ai-inference-runtime/);
+  assert.match(agents, /004-production-runtime-infrastructure/);
   assert.match(agents, /Security Scan SaaS Final Specification\.docx/);
-  assert.match(readme, /003-production-ai-inference-runtime/);
-  assert.match(conventions, /SPECIFY_FEATURE = "003-production-ai-inference-runtime"/);
+  assert.match(readme, /004-production-runtime-infrastructure/);
+  assert.match(conventions, /SPECIFY_FEATURE = "004-production-runtime-infrastructure"/);
 
   assert.match(quickstart, /Security Scan SaaS Final Specification\.docx/);
+  assert.match(quickstart, /Kubernetes/i);
   assert.match(quickstart, /AI Plane/);
-  assert.match(quickstart, /reduced evidence/i);
+  assert.match(quickstart, /microVM/i);
   assert.match(quickstart, /advisory-only/i);
+  assert.match(quickstart, /003-production-ai-inference-runtime/);
   assert.match(quickstart, /002-production-scan-architecture/);
 
-  assert.match(spec, /trained production AI detector\/planner inference/i);
-  assert.match(spec, /MUST NOT create authoritative findings/i);
-  assert.match(spec, /MUST NOT receive SCM credentials/i);
+  assert.match(spec, /Kubernetes production AI Plane/i);
+  assert.match(spec, /microVM-backed scanner provisioning/i);
+  assert.match(spec, /MUST NOT execute customer code outside hardened scan isolation/i);
 
-  assert.match(plan, /model gateway/i);
-  assert.match(plan, /fallback/i);
-  assert.match(plan, /observability/i);
+  assert.match(plan, /deployment manifests/i);
+  assert.match(plan, /runtime autoscaling/i);
+  assert.match(plan, /scanner sandbox/i);
 
-  assert.match(contract, /AiInferenceRequest/);
-  assert.match(contract, /AiInferenceResponse/);
-  assert.match(contract, /ReducedEvidence/);
+  assert.match(contract, /AiPlaneDeployment/);
+  assert.match(contract, /RuntimeAutoscalingPolicy/);
+  assert.match(contract, /ScannerSandboxProvisioning/);
 });
 
-test('production AI inference runtime completion gate stays synchronized between quickstart and CI', () => {
+test('production runtime infrastructure completion gate stays synchronized between quickstart and CI', () => {
   const readme = readNormalizedText(files.readme);
   const ci = readNormalizedText(files.ci);
   const quickstart = readNormalizedText(files.quickstart);
@@ -79,12 +84,33 @@ test('production AI inference runtime completion gate stays synchronized between
     assert.match(ci, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 
-  assert.match(readme, /specs\/003-production-ai-inference-runtime\/quickstart\.md/);
+  assert.match(readme, /specs\/004-production-runtime-infrastructure\/quickstart\.md/);
   assert.match(readme, /\.github\/workflows\/ci\.yml/);
   assert.doesNotMatch(readme, /`corepack pnpm/);
-  assert.doesNotMatch(tasks, /Mirror the 003 completion gate in README/);
-  assert.match(tasks, /Point README completion guidance at the 003 quickstart and CI workflow without duplicating command checklists/);
+  assert.doesNotMatch(tasks, /Mirror the 004 completion gate in README/);
+  assert.match(tasks, /Point README completion guidance at the 004 quickstart and CI workflow without duplicating command checklists/);
   assert.match(ci, /DATABASE_URL:\s*postgresql:\/\/postgres:postgres@localhost:5432\/aegisai/);
+});
+
+test('completed production AI inference baseline hands infrastructure follow-up to 004', () => {
+  const tasks = readNormalizedText(files.completedAiTasks);
+  const checklist = readNormalizedText(files.completedAiChecklist);
+  const quickstart = readNormalizedText(files.completedAiQuickstart);
+  const activeTaskSection = tasks.split('\n## Deferred')[0];
+
+  const openActiveTasks = activeTaskSection
+    .split('\n')
+    .filter((line) => /^- \[ \]/.test(line));
+  assert.deepEqual(openActiveTasks, []);
+
+  const openChecklistItems = checklist
+    .split('\n')
+    .filter((line) => /^- \[ \]/.test(line));
+  assert.deepEqual(openChecklistItems, []);
+
+  assert.match(quickstart, /004-production-runtime-infrastructure/);
+  assert.match(tasks, /Kubernetes production AI Plane deployment manifests and runtime autoscaling moved to `004-production-runtime-infrastructure`/);
+  assert.match(tasks, /microVM-backed scanner provisioning moved to `004-production-runtime-infrastructure`/);
 });
 
 test('completed production scan architecture baseline keeps only the AI inference follow-up deferred', () => {


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/224-004-runtime-infra-package`
- 이슈: Closes #224

## 🔎 주요 변경 사항

- `specs/004-production-runtime-infrastructure` feature package 골격 추가
- `AGENTS.md`, `README.md`, `docs/github-conventions.md` active feature 기준을 004로 전환
- 003 AI inference runtime은 완료 baseline으로 보존하고 Kubernetes/microVM 후속 작업을 004로 이관
- active feature 계약 테스트를 004 entrypoint와 003/002 baseline 보존 기준으로 갱신

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`