### PR TITLE
feat: 004 쿠버네티스 AI Plane 배포 서비스 매니페스트 구현

### DIFF
--- a/deploy/kubernetes/ai-plane/configmap.json
+++ b/deploy/kubernetes/ai-plane/configmap.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "aegisai-ai-plane-config",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  },
+  "data": {
+    "AI_ADVISORY_ONLY": "true",
+    "AI_REDUCED_EVIDENCE_ONLY": "true",
+    "AI_HEALTH_PATH": "/health",
+    "AI_INPUT_BOUNDARY": "normalized-findings-and-reduced-evidence-only",
+    "AI_POLICY_AUTHORITY": "none",
+    "AI_FINDING_AUTHORITY": "none"
+  }
+}

--- a/deploy/kubernetes/ai-plane/deployment.json
+++ b/deploy/kubernetes/ai-plane/deployment.json
@@ -1,0 +1,97 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "aegisai-ai",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  },
+  "spec": {
+    "replicas": 2,
+    "selector": {
+      "matchLabels": {
+        "app.kubernetes.io/name": "aegisai-ai",
+        "aegisai.io/plane": "ai"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app.kubernetes.io/name": "aegisai-ai",
+          "app.kubernetes.io/part-of": "aegisai",
+          "aegisai.io/plane": "ai"
+        }
+      },
+      "spec": {
+        "automountServiceAccountToken": false,
+        "containers": [
+          {
+            "name": "aegisai-ai",
+            "image": "ghcr.io/aigisai/aegisai-ai:latest",
+            "imagePullPolicy": "IfNotPresent",
+            "ports": [
+              {
+                "name": "http",
+                "containerPort": 8000
+              }
+            ],
+            "env": [
+              {
+                "name": "AI_PORT",
+                "value": "8000"
+              }
+            ],
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "aegisai-ai-plane-config"
+                }
+              }
+            ],
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": "http"
+              },
+              "initialDelaySeconds": 10,
+              "periodSeconds": 30
+            },
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": "http"
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 10
+            },
+            "resources": {
+              "requests": {
+                "cpu": "250m",
+                "memory": "512Mi"
+              },
+              "limits": {
+                "cpu": "1000m",
+                "memory": "1Gi"
+              }
+            },
+            "securityContext": {
+              "allowPrivilegeEscalation": false,
+              "readOnlyRootFilesystem": true,
+              "runAsNonRoot": true,
+              "runAsUser": 10001,
+              "capabilities": {
+                "drop": [
+                  "ALL"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/kubernetes/ai-plane/namespace.json
+++ b/deploy/kubernetes/ai-plane/namespace.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  }
+}

--- a/deploy/kubernetes/ai-plane/network-policy.json
+++ b/deploy/kubernetes/ai-plane/network-policy.json
@@ -1,0 +1,63 @@
+{
+  "apiVersion": "networking.k8s.io/v1",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "aegisai-ai-plane-boundary",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  },
+  "spec": {
+    "podSelector": {
+      "matchLabels": {
+        "app.kubernetes.io/name": "aegisai-ai",
+        "aegisai.io/plane": "ai"
+      }
+    },
+    "policyTypes": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "from": [
+          {
+            "namespaceSelector": {
+              "matchLabels": {
+                "aegisai.io/plane": "control"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 8000
+          }
+        ]
+      }
+    ],
+    "egress": [
+      {
+        "to": [
+          {
+            "namespaceSelector": {
+              "matchLabels": {
+                "aegisai.io/plane": "data-security"
+              }
+            }
+          }
+        ],
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 443
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/deploy/kubernetes/ai-plane/service.json
+++ b/deploy/kubernetes/ai-plane/service.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "aegisai-ai",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  },
+  "spec": {
+    "type": "ClusterIP",
+    "selector": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "aegisai.io/plane": "ai"
+    },
+    "ports": [
+      {
+        "name": "http",
+        "port": 8000,
+        "targetPort": "http"
+      }
+    ]
+  }
+}

--- a/specs/004-production-runtime-infrastructure/tasks.md
+++ b/specs/004-production-runtime-infrastructure/tasks.md
@@ -9,8 +9,8 @@
 
 ## Phase 2: Kubernetes AI Plane Manifest Slice
 
-- [ ] T005 Add Kubernetes AI Plane deployment and service manifest skeletons
-- [ ] T006 Add manifest tests proving AI containers do not receive SCM credentials, repository archives, full repositories, source archives, or raw scanner payloads
+- [x] T005 Add Kubernetes AI Plane deployment and service manifest skeletons
+- [x] T006 Add manifest tests proving AI containers do not receive SCM credentials, repository archives, full repositories, source archives, or raw scanner payloads
 
 ## Phase 3: Runtime Autoscaling Slice
 

--- a/test/github-actions/kubernetes-ai-plane.test.mjs
+++ b/test/github-actions/kubernetes-ai-plane.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const manifestFiles = {
+  namespace: new URL('../../deploy/kubernetes/ai-plane/namespace.json', import.meta.url),
+  configMap: new URL('../../deploy/kubernetes/ai-plane/configmap.json', import.meta.url),
+  deployment: new URL('../../deploy/kubernetes/ai-plane/deployment.json', import.meta.url),
+  service: new URL('../../deploy/kubernetes/ai-plane/service.json', import.meta.url),
+  networkPolicy: new URL('../../deploy/kubernetes/ai-plane/network-policy.json', import.meta.url)
+};
+
+const forbiddenBoundaryFields =
+  /scmCredential|githubToken|gitlabToken|accessToken|refreshToken|tokenValue|secretValue|repositoryArchive|fullRepository|sourceArchive|rawScannerPayload|policyOverride|findingOverride|waiverApplied|staleSuppressed/i;
+
+const readJson = (fileUrl) => JSON.parse(readFileSync(fileUrl, 'utf8'));
+
+test('Kubernetes AI Plane manifests exist and describe the expected resource boundary', () => {
+  for (const [name, fileUrl] of Object.entries(manifestFiles)) {
+    assert.equal(existsSync(fileUrl), true, `Expected ${name} manifest to exist at ${fileUrl.pathname}`);
+  }
+
+  const namespace = readJson(manifestFiles.namespace);
+  const configMap = readJson(manifestFiles.configMap);
+  const deployment = readJson(manifestFiles.deployment);
+  const service = readJson(manifestFiles.service);
+  const networkPolicy = readJson(manifestFiles.networkPolicy);
+
+  assert.equal(namespace.kind, 'Namespace');
+  assert.equal(namespace.metadata.name, 'aegisai-ai-plane');
+
+  assert.equal(configMap.kind, 'ConfigMap');
+  assert.equal(configMap.metadata.namespace, 'aegisai-ai-plane');
+  assert.equal(configMap.data.AI_ADVISORY_ONLY, 'true');
+  assert.equal(configMap.data.AI_REDUCED_EVIDENCE_ONLY, 'true');
+  assert.equal(configMap.data.AI_HEALTH_PATH, '/health');
+
+  assert.equal(deployment.kind, 'Deployment');
+  assert.equal(deployment.metadata.namespace, 'aegisai-ai-plane');
+  assert.equal(deployment.spec.selector.matchLabels['app.kubernetes.io/name'], 'aegisai-ai');
+  assert.equal(deployment.spec.template.spec.automountServiceAccountToken, false);
+
+  const container = deployment.spec.template.spec.containers.find((candidate) => candidate.name === 'aegisai-ai');
+  assert.ok(container, 'Expected aegisai-ai container to be present');
+  assert.equal(container.image, 'ghcr.io/aigisai/aegisai-ai:latest');
+  assert.deepEqual(container.ports, [{ name: 'http', containerPort: 8000 }]);
+  assert.deepEqual(container.livenessProbe.httpGet, { path: '/health', port: 'http' });
+  assert.deepEqual(container.readinessProbe.httpGet, { path: '/health', port: 'http' });
+  assert.equal(container.securityContext.runAsNonRoot, true);
+  assert.equal(container.securityContext.readOnlyRootFilesystem, true);
+  assert.equal(container.envFrom[0].configMapRef.name, 'aegisai-ai-plane-config');
+
+  assert.equal(service.kind, 'Service');
+  assert.equal(service.metadata.namespace, 'aegisai-ai-plane');
+  assert.equal(service.spec.type, 'ClusterIP');
+  assert.deepEqual(service.spec.selector, deployment.spec.selector.matchLabels);
+  assert.deepEqual(service.spec.ports, [{ name: 'http', port: 8000, targetPort: 'http' }]);
+
+  assert.equal(networkPolicy.kind, 'NetworkPolicy');
+  assert.equal(networkPolicy.metadata.namespace, 'aegisai-ai-plane');
+  assert.deepEqual(networkPolicy.spec.podSelector.matchLabels, deployment.spec.selector.matchLabels);
+  assert.deepEqual(networkPolicy.spec.policyTypes, ['Ingress', 'Egress']);
+});
+
+test('Kubernetes AI Plane manifests do not expose repository or policy authority inputs', () => {
+  const combinedManifestText = Object.values(manifestFiles)
+    .map((fileUrl) => readFileSync(fileUrl, 'utf8'))
+    .join('\n');
+  const deployment = readJson(manifestFiles.deployment);
+  const configMap = readJson(manifestFiles.configMap);
+  const container = deployment.spec.template.spec.containers.find((candidate) => candidate.name === 'aegisai-ai');
+  const envNames = (container.env ?? []).map((entry) => entry.name);
+  const volumeNames = (deployment.spec.template.spec.volumes ?? []).map((entry) => entry.name);
+  const mounts = (container.volumeMounts ?? []).map((entry) => entry.mountPath);
+
+  assert.doesNotMatch(combinedManifestText, forbiddenBoundaryFields);
+  assert.deepEqual(envNames, ['AI_PORT']);
+  assert.deepEqual(volumeNames, []);
+  assert.deepEqual(mounts, []);
+  assert.equal(configMap.data.AI_INPUT_BOUNDARY, 'normalized-findings-and-reduced-evidence-only');
+  assert.equal(configMap.data.AI_POLICY_AUTHORITY, 'none');
+  assert.equal(configMap.data.AI_FINDING_AUTHORITY, 'none');
+});


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/226-004-ai-plane-k8s-manifests`
- 이슈: Closes #226

## 🔎 주요 변경 사항

- `deploy/kubernetes/ai-plane`에 Namespace, ConfigMap, Deployment, Service, NetworkPolicy JSON manifest skeleton 추가
- AI Plane Deployment를 `/health` probe, ClusterIP service, non-root/read-only root filesystem, service account token 비활성화 경계로 정의
- manifest 계약 테스트로 SCM credential, repository archive, full repository, source archive, raw scanner payload, policy/finding authority 입력이 없는지 검증
- `specs/004-production-runtime-infrastructure/tasks.md`의 T005/T006 완료 처리

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `node --test test/github-actions/kubernetes-ai-plane.test.mjs` RED/GREEN 확인
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes infrastructure configuration for the AI plane component, including namespace, deployment, service, and network policy definitions with security hardening (read-only filesystem, non-root user, capability restrictions).
  * Configured AI plane with advisory-only and reduced-evidence modes, health monitoring endpoints, and network boundary controls.

* **Tests**
  * Added validation tests for Kubernetes manifest integrity and configuration compliance.

* **Documentation**
  * Marked production runtime infrastructure tasks as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->