### PR TITLE
feat: 004 AI Plane 런타임 오토스케일링 정책 구현

### DIFF
--- a/deploy/kubernetes/ai-plane/autoscaling-policy.json
+++ b/deploy/kubernetes/ai-plane/autoscaling-policy.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": {
+    "name": "aegisai-ai-plane-autoscaling-policy",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    }
+  },
+  "data": {
+    "RUNTIME_AUTOSCALING_POLICY": "advisory-infrastructure-only",
+    "LATENCY_P95_MS_TARGET": "750",
+    "QUEUE_DEPTH_TARGET": "25",
+    "PROVIDER_ERROR_RATE_TARGET": "5",
+    "FALLBACK_RATE_TARGET": "10",
+    "CPU_UTILIZATION_TARGET": "70",
+    "MEMORY_UTILIZATION_TARGET": "75",
+    "AI_POLICY_AUTHORITY": "none",
+    "AI_FINDING_AUTHORITY": "none",
+    "AI_WAIVER_SUPPRESSION_AUTHORITY": "none"
+  }
+}

--- a/deploy/kubernetes/ai-plane/horizontal-pod-autoscaler.json
+++ b/deploy/kubernetes/ai-plane/horizontal-pod-autoscaler.json
@@ -1,0 +1,117 @@
+{
+  "apiVersion": "autoscaling/v2",
+  "kind": "HorizontalPodAutoscaler",
+  "metadata": {
+    "name": "aegisai-ai",
+    "namespace": "aegisai-ai-plane",
+    "labels": {
+      "app.kubernetes.io/name": "aegisai-ai",
+      "app.kubernetes.io/part-of": "aegisai",
+      "aegisai.io/plane": "ai"
+    },
+    "annotations": {
+      "aegisai.io/authority-boundary": "infrastructure-scaling-only"
+    }
+  },
+  "spec": {
+    "scaleTargetRef": {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "name": "aegisai-ai"
+    },
+    "minReplicas": 2,
+    "maxReplicas": 10,
+    "behavior": {
+      "scaleUp": {
+        "stabilizationWindowSeconds": 60,
+        "policies": [
+          {
+            "type": "Percent",
+            "value": 100,
+            "periodSeconds": 60
+          }
+        ]
+      },
+      "scaleDown": {
+        "stabilizationWindowSeconds": 300,
+        "policies": [
+          {
+            "type": "Percent",
+            "value": 50,
+            "periodSeconds": 60
+          }
+        ]
+      }
+    },
+    "metrics": [
+      {
+        "type": "Resource",
+        "resource": {
+          "name": "cpu",
+          "target": {
+            "type": "Utilization",
+            "averageUtilization": 70
+          }
+        }
+      },
+      {
+        "type": "Resource",
+        "resource": {
+          "name": "memory",
+          "target": {
+            "type": "Utilization",
+            "averageUtilization": 75
+          }
+        }
+      },
+      {
+        "type": "Pods",
+        "pods": {
+          "metric": {
+            "name": "ai_request_latency_p95_ms"
+          },
+          "target": {
+            "type": "AverageValue",
+            "averageValue": "750"
+          }
+        }
+      },
+      {
+        "type": "Pods",
+        "pods": {
+          "metric": {
+            "name": "ai_queue_depth"
+          },
+          "target": {
+            "type": "AverageValue",
+            "averageValue": "25"
+          }
+        }
+      },
+      {
+        "type": "Pods",
+        "pods": {
+          "metric": {
+            "name": "ai_provider_error_rate"
+          },
+          "target": {
+            "type": "AverageValue",
+            "averageValue": "5"
+          }
+        }
+      },
+      {
+        "type": "Pods",
+        "pods": {
+          "metric": {
+            "name": "ai_fallback_rate"
+          },
+          "target": {
+            "type": "AverageValue",
+            "averageValue": "10"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/specs/004-production-runtime-infrastructure/tasks.md
+++ b/specs/004-production-runtime-infrastructure/tasks.md
@@ -14,8 +14,8 @@
 
 ## Phase 3: Runtime Autoscaling Slice
 
-- [ ] T007 Add runtime autoscaling policy skeleton for latency, queue pressure, provider health, fallback, CPU, and memory signals
-- [ ] T008 Add autoscaling tests proving policy cannot grant finding or policy authority
+- [x] T007 Add runtime autoscaling policy skeleton for latency, queue pressure, provider health, fallback, CPU, and memory signals
+- [x] T008 Add autoscaling tests proving policy cannot grant finding or policy authority
 
 ## Phase 4: Scanner Sandbox Provisioning Slice
 

--- a/test/github-actions/kubernetes-ai-plane-autoscaling.test.mjs
+++ b/test/github-actions/kubernetes-ai-plane-autoscaling.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const manifestFiles = {
+  hpa: new URL('../../deploy/kubernetes/ai-plane/horizontal-pod-autoscaler.json', import.meta.url),
+  policy: new URL('../../deploy/kubernetes/ai-plane/autoscaling-policy.json', import.meta.url)
+};
+
+const forbiddenAuthorityFields =
+  /enforcementAction|blockRequested|policyOverride|findingOverride|waiverApplied|staleSuppressed|createFinding|authoritativeFinding|suppressionOverride/i;
+
+const readJson = (fileUrl) => JSON.parse(readFileSync(fileUrl, 'utf8'));
+
+test('AI Plane runtime autoscaling manifests cover latency, queue, provider, fallback, CPU, and memory signals', () => {
+  for (const [name, fileUrl] of Object.entries(manifestFiles)) {
+    assert.equal(existsSync(fileUrl), true, `Expected ${name} manifest to exist at ${fileUrl.pathname}`);
+  }
+
+  const hpa = readJson(manifestFiles.hpa);
+  const policy = readJson(manifestFiles.policy);
+  const metricNames = hpa.spec.metrics.map((metric) => {
+    if (metric.type === 'Resource') {
+      return metric.resource.name;
+    }
+
+    return metric.pods.metric.name;
+  });
+
+  assert.equal(hpa.apiVersion, 'autoscaling/v2');
+  assert.equal(hpa.kind, 'HorizontalPodAutoscaler');
+  assert.equal(hpa.metadata.namespace, 'aegisai-ai-plane');
+  assert.deepEqual(hpa.spec.scaleTargetRef, {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    name: 'aegisai-ai'
+  });
+  assert.equal(hpa.spec.minReplicas, 2);
+  assert.equal(hpa.spec.maxReplicas, 10);
+  assert.deepEqual(metricNames, [
+    'cpu',
+    'memory',
+    'ai_request_latency_p95_ms',
+    'ai_queue_depth',
+    'ai_provider_error_rate',
+    'ai_fallback_rate'
+  ]);
+
+  assert.equal(policy.kind, 'ConfigMap');
+  assert.equal(policy.metadata.name, 'aegisai-ai-plane-autoscaling-policy');
+  assert.equal(policy.metadata.namespace, 'aegisai-ai-plane');
+  assert.equal(policy.data.RUNTIME_AUTOSCALING_POLICY, 'advisory-infrastructure-only');
+  assert.equal(policy.data.LATENCY_P95_MS_TARGET, '750');
+  assert.equal(policy.data.QUEUE_DEPTH_TARGET, '25');
+  assert.equal(policy.data.PROVIDER_ERROR_RATE_TARGET, '5');
+  assert.equal(policy.data.FALLBACK_RATE_TARGET, '10');
+});
+
+test('AI Plane runtime autoscaling policy cannot grant finding or policy authority', () => {
+  const combinedManifestText = Object.values(manifestFiles)
+    .map((fileUrl) => readFileSync(fileUrl, 'utf8'))
+    .join('\n');
+  const policy = readJson(manifestFiles.policy);
+  const hpa = readJson(manifestFiles.hpa);
+
+  assert.doesNotMatch(combinedManifestText, forbiddenAuthorityFields);
+  assert.equal(policy.data.AI_POLICY_AUTHORITY, 'none');
+  assert.equal(policy.data.AI_FINDING_AUTHORITY, 'none');
+  assert.equal(policy.data.AI_WAIVER_SUPPRESSION_AUTHORITY, 'none');
+  assert.equal(hpa.metadata.labels['aegisai.io/plane'], 'ai');
+  assert.equal(hpa.metadata.annotations['aegisai.io/authority-boundary'], 'infrastructure-scaling-only');
+});


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/228-004-ai-plane-autoscaling`
- 이슈: Closes #228

## 🔎 주요 변경 사항

- AI Plane `HorizontalPodAutoscaler` skeleton 추가
- latency p95, queue depth, provider error rate, fallback rate, CPU, memory scaling signal 정의
- autoscaling policy ConfigMap으로 infrastructure-only authority boundary 명시
- autoscaling 계약 테스트로 finding/policy/waiver/suppression authority 필드 부재 검증
- `specs/004-production-runtime-infrastructure/tasks.md`의 T007/T008 완료 처리

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `node --test test/github-actions/kubernetes-ai-plane-autoscaling.test.mjs` RED/GREEN 확인
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`