### PR TITLE
feat: 005 운영 클러스터 프로비저닝 계약 구현

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './types/dashboard';
 export * from './types/report';
 export * from './types/production-architecture';
 export * from './types/ai-inference-runtime';
+export * from './types/deployment-operations';

--- a/packages/shared/src/types/deployment-operations.ts
+++ b/packages/shared/src/types/deployment-operations.ts
@@ -1,0 +1,87 @@
+export const PRODUCTION_DEPLOYMENT_OPERATIONS_FEATURE_ID = '005-production-deployment-operations';
+
+export const DEPLOYMENT_ENVIRONMENTS = ['PRODUCTION'] as const;
+export type DeploymentEnvironment = (typeof DEPLOYMENT_ENVIRONMENTS)[number];
+
+export const DEPLOYMENT_CREDENTIAL_SCOPES = [
+  'CLUSTER_ADMIN',
+  'MICROVM_PLATFORM_ADMIN',
+  'SECRET_MANAGER_ADMIN'
+] as const;
+export type DeploymentCredentialScope = (typeof DEPLOYMENT_CREDENTIAL_SCOPES)[number];
+
+export const DEPLOYMENT_CREDENTIAL_ALLOWED_USES = ['EXPLICIT_DEPLOYMENT_OPERATION'] as const;
+export type DeploymentCredentialAllowedUse = (typeof DEPLOYMENT_CREDENTIAL_ALLOWED_USES)[number];
+
+export const DEPLOYMENT_OPERATION_ACTORS = [
+  'DEPLOYMENT_OPERATOR',
+  'CONTROL_PLANE',
+  'DATA_SECURITY_PLANE'
+] as const;
+export type DeploymentOperationActor = (typeof DEPLOYMENT_OPERATION_ACTORS)[number];
+
+export interface ProductionClusterProvisioning {
+  environment: 'PRODUCTION';
+  provider: string;
+  region: string;
+  clusterName: string;
+  controlPlaneNamespace: string;
+  scanPlaneNamespace: string;
+  aiPlaneNamespace: string;
+  dataSecurityNamespace: string;
+  networkBoundaryRefs: string[];
+  auditSinkRef: string;
+}
+
+export interface DeploymentCredentialBoundary {
+  credentialProvider: string;
+  credentialScope: DeploymentCredentialScope;
+  allowedUse: 'EXPLICIT_DEPLOYMENT_OPERATION';
+  localDevelopmentDefault: false;
+  repositoryPersisted: false;
+  rotationRequired: true;
+  auditRequired: true;
+}
+
+export interface DeploymentOperationAuditSignal {
+  environment: 'PRODUCTION';
+  provider: string;
+  operationId: string;
+  actor: DeploymentOperationActor;
+  targetType: string;
+  targetId: string;
+  eventType: string;
+  metadata?: Record<string, unknown>;
+  occurredAt: string;
+}
+
+export function isProductionClusterProvisioningBoundaryValid(
+  input: ProductionClusterProvisioning
+): boolean {
+  const namespaces = [
+    input.controlPlaneNamespace,
+    input.scanPlaneNamespace,
+    input.aiPlaneNamespace,
+    input.dataSecurityNamespace
+  ];
+
+  return (
+    input.environment === 'PRODUCTION' &&
+    namespaces.every((namespace) => namespace.length > 0) &&
+    new Set(namespaces).size === namespaces.length &&
+    input.networkBoundaryRefs.length > 0 &&
+    input.auditSinkRef.length > 0
+  );
+}
+
+export function isDeploymentCredentialBoundaryCompliant(
+  input: DeploymentCredentialBoundary
+): boolean {
+  return (
+    input.allowedUse === 'EXPLICIT_DEPLOYMENT_OPERATION' &&
+    input.localDevelopmentDefault === false &&
+    input.repositoryPersisted === false &&
+    input.rotationRequired === true &&
+    input.auditRequired === true
+  );
+}

--- a/packages/shared/test/deployment-operations.test.mjs
+++ b/packages/shared/test/deployment-operations.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const contractFile = new URL('../src/types/deployment-operations.ts', import.meta.url);
+
+const readContract = () => readFileSync(contractFile, 'utf8');
+
+test('production deployment operations shared contracts define cluster provisioning boundaries', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  for (const exportName of [
+    'PRODUCTION_DEPLOYMENT_OPERATIONS_FEATURE_ID',
+    'ProductionClusterProvisioning',
+    'DeploymentCredentialBoundary',
+    'DeploymentOperationAuditSignal',
+    'isProductionClusterProvisioningBoundaryValid',
+    'isDeploymentCredentialBoundaryCompliant'
+  ]) {
+    assert.match(contract, new RegExp(`export (interface|const|type|function) ${exportName}\\b`));
+  }
+
+  for (const requiredField of [
+    'controlPlaneNamespace',
+    'scanPlaneNamespace',
+    'aiPlaneNamespace',
+    'dataSecurityNamespace',
+    'networkBoundaryRefs',
+    'auditSinkRef'
+  ]) {
+    assert.match(contract, new RegExp(`\\b${requiredField}\\b`));
+  }
+
+  assert.match(contract, /environment:\s*'PRODUCTION'/);
+});
+
+test('deployment credential contracts cannot become local defaults or repository-persisted secrets', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  assert.match(contract, /allowedUse:\s*'EXPLICIT_DEPLOYMENT_OPERATION'/);
+  assert.match(contract, /localDevelopmentDefault:\s*false/);
+  assert.match(contract, /repositoryPersisted:\s*false/);
+  assert.match(contract, /rotationRequired:\s*true/);
+  assert.match(contract, /auditRequired:\s*true/);
+
+  for (const forbiddenField of [
+    'credentialValue',
+    'providerSecretValue',
+    'accessKey',
+    'secretAccessKey',
+    'privateKey',
+    'kubeconfig',
+    'token'
+  ]) {
+    assert.doesNotMatch(contract, new RegExp(`\\b${forbiddenField}\\b`, 'i'));
+  }
+});

--- a/packages/shared/test/shared-contract-exports.test.mjs
+++ b/packages/shared/test/shared-contract-exports.test.mjs
@@ -11,6 +11,7 @@ const files = {
   dashboard: new URL('../src/types/dashboard.ts', import.meta.url),
   report: new URL('../src/types/report.ts', import.meta.url),
   aiInferenceRuntime: new URL('../src/types/ai-inference-runtime.ts', import.meta.url),
+  deploymentOperations: new URL('../src/types/deployment-operations.ts', import.meta.url),
   index: new URL('../src/index.ts', import.meta.url)
 };
 
@@ -29,7 +30,8 @@ test('shared contract modules exist and are re-exported from the package root', 
     'vulnerability',
     'dashboard',
     'report',
-    'ai-inference-runtime'
+    'ai-inference-runtime',
+    'deployment-operations'
   ]) {
     assert.match(
       indexContent,

--- a/specs/005-production-deployment-operations/tasks.md
+++ b/specs/005-production-deployment-operations/tasks.md
@@ -9,8 +9,8 @@
 
 ## Phase 2: Production Cluster Provisioning Contract Slice
 
-- [ ] T005 Add provider-neutral production cluster provisioning contract in shared package
-- [ ] T006 Add tests proving provider credentials are not local development defaults
+- [x] T005 Add provider-neutral production cluster provisioning contract in shared package
+- [x] T006 Add tests proving provider credentials are not local development defaults
 
 ## Phase 3: Provider microVM Rollout Contract Slice
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/234-005-cluster-provisioning-contract`
- 이슈: #234

## 🔎 주요 변경 사항

- `packages/shared`에 production deployment operations 계약 타입 추가
- `ProductionClusterProvisioning`과 plane namespace boundary helper 추가
- `DeploymentCredentialBoundary`와 local-default/repository-persisted guardrail helper 추가
- shared contract export/test 갱신
- 005 tasks T005/T006 완료 표시

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

Closes #234