### PR TITLE
feat: 005 운영 microVM 롤아웃 격리 계약 구현

### DIFF
--- a/packages/shared/src/types/deployment-operations.ts
+++ b/packages/shared/src/types/deployment-operations.ts
@@ -20,6 +20,27 @@ export const DEPLOYMENT_OPERATION_ACTORS = [
 ] as const;
 export type DeploymentOperationActor = (typeof DEPLOYMENT_OPERATION_ACTORS)[number];
 
+export const MICROVM_ISOLATION_CLASSES = ['HARDENED', 'RESTRICTED'] as const;
+export type MicroVmIsolationClass = (typeof MICROVM_ISOLATION_CLASSES)[number];
+
+export const SCANNER_SANDBOX_FORBIDDEN_CAPABILITIES = [
+  'PACKAGE_INSTALL',
+  'CUSTOMER_REPOSITORY_BUILD',
+  'DYNAMIC_TEST_EXECUTION',
+  'DIRECT_SOURCE_UPLOAD',
+  'AUTO_FIX_PULL_REQUEST'
+] as const;
+export type ScannerSandboxForbiddenCapability =
+  (typeof SCANNER_SANDBOX_FORBIDDEN_CAPABILITIES)[number];
+
+export const AI_PLANE_FORBIDDEN_DIRECT_INPUTS = [
+  'SCM_CREDENTIAL',
+  'FULL_REPOSITORY',
+  'SOURCE_ARCHIVE',
+  'RAW_SCANNER_PAYLOAD'
+] as const;
+export type AiPlaneForbiddenDirectInput = (typeof AI_PLANE_FORBIDDEN_DIRECT_INPUTS)[number];
+
 export interface ProductionClusterProvisioning {
   environment: 'PRODUCTION';
   provider: string;
@@ -55,6 +76,25 @@ export interface DeploymentOperationAuditSignal {
   occurredAt: string;
 }
 
+export interface MicroVmPlatformRollout {
+  provider: string;
+  region: string;
+  platformName: string;
+  isolationClass: MicroVmIsolationClass;
+  scannerSandboxProfileRef: string;
+  tokenBrokerRef: string;
+  evidenceStorageRef: string;
+  egressPolicyRef: string;
+  ttlSeconds: number;
+  forbiddenScannerCapabilities: ScannerSandboxForbiddenCapability[];
+}
+
+export interface AiPlaneRepositoryAccessBoundary {
+  advisoryOnly: true;
+  receivesReducedEvidenceOnly: true;
+  requestedDirectInputs: string[];
+}
+
 export function isProductionClusterProvisioningBoundaryValid(
   input: ProductionClusterProvisioning
 ): boolean {
@@ -83,5 +123,40 @@ export function isDeploymentCredentialBoundaryCompliant(
     input.repositoryPersisted === false &&
     input.rotationRequired === true &&
     input.auditRequired === true
+  );
+}
+
+export function isMicroVmPlatformRolloutBoundaryValid(input: MicroVmPlatformRollout): boolean {
+  const requiredRefs = [
+    input.scannerSandboxProfileRef,
+    input.tokenBrokerRef,
+    input.evidenceStorageRef,
+    input.egressPolicyRef
+  ];
+
+  const includesForbiddenCapability = SCANNER_SANDBOX_FORBIDDEN_CAPABILITIES.every((capability) =>
+    input.forbiddenScannerCapabilities.includes(capability)
+  );
+
+  return (
+    MICROVM_ISOLATION_CLASSES.includes(input.isolationClass) &&
+    requiredRefs.every((ref) => ref.length > 0) &&
+    input.ttlSeconds > 0 &&
+    includesForbiddenCapability
+  );
+}
+
+export function doesAiPlaneInputRespectRepositoryGuardrails(
+  input: AiPlaneRepositoryAccessBoundary
+): boolean {
+  return (
+    input.advisoryOnly === true &&
+    input.receivesReducedEvidenceOnly === true &&
+    input.requestedDirectInputs.every(
+      (requestedInput) =>
+        !AI_PLANE_FORBIDDEN_DIRECT_INPUTS.some(
+          (forbiddenInput) => forbiddenInput === requestedInput
+        )
+    )
   );
 }

--- a/packages/shared/test/deployment-operations.test.mjs
+++ b/packages/shared/test/deployment-operations.test.mjs
@@ -59,3 +59,68 @@ test('deployment credential contracts cannot become local defaults or repository
     assert.doesNotMatch(contract, new RegExp(`\\b${forbiddenField}\\b`, 'i'));
   }
 });
+
+test('microVM rollout contracts preserve scanner sandbox isolation boundaries', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  for (const exportName of [
+    'MICROVM_ISOLATION_CLASSES',
+    'SCANNER_SANDBOX_FORBIDDEN_CAPABILITIES',
+    'MicroVmPlatformRollout',
+    'isMicroVmPlatformRolloutBoundaryValid'
+  ]) {
+    assert.match(contract, new RegExp(`export (interface|const|type|function) ${exportName}\\b`));
+  }
+
+  for (const requiredField of [
+    'scannerSandboxProfileRef',
+    'tokenBrokerRef',
+    'evidenceStorageRef',
+    'egressPolicyRef',
+    'ttlSeconds'
+  ]) {
+    assert.match(contract, new RegExp(`\\b${requiredField}\\b`));
+  }
+
+  assert.match(contract, /isolationClass:\s*MicroVmIsolationClass/);
+  assert.match(contract, /'HARDENED'/);
+  assert.match(contract, /'RESTRICTED'/);
+
+  for (const forbiddenCapability of [
+    'PACKAGE_INSTALL',
+    'CUSTOMER_REPOSITORY_BUILD',
+    'DYNAMIC_TEST_EXECUTION',
+    'DIRECT_SOURCE_UPLOAD',
+    'AUTO_FIX_PULL_REQUEST'
+  ]) {
+    assert.match(contract, new RegExp(`'${forbiddenCapability}'`));
+  }
+});
+
+test('microVM rollout contracts keep AI plane away from repository and raw scanner inputs', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  for (const exportName of [
+    'AI_PLANE_FORBIDDEN_DIRECT_INPUTS',
+    'AiPlaneRepositoryAccessBoundary',
+    'doesAiPlaneInputRespectRepositoryGuardrails'
+  ]) {
+    assert.match(contract, new RegExp(`export (interface|const|type|function) ${exportName}\\b`));
+  }
+
+  for (const forbiddenInput of [
+    'SCM_CREDENTIAL',
+    'FULL_REPOSITORY',
+    'SOURCE_ARCHIVE',
+    'RAW_SCANNER_PAYLOAD'
+  ]) {
+    assert.match(contract, new RegExp(`'${forbiddenInput}'`));
+  }
+
+  assert.match(contract, /advisoryOnly:\s*true/);
+  assert.match(contract, /receivesReducedEvidenceOnly:\s*true/);
+});

--- a/specs/005-production-deployment-operations/tasks.md
+++ b/specs/005-production-deployment-operations/tasks.md
@@ -14,8 +14,8 @@
 
 ## Phase 3: Provider microVM Rollout Contract Slice
 
-- [ ] T007 Add provider-neutral microVM platform rollout contract in shared package
-- [ ] T008 Add tests proving scanner isolation and AI repository access guardrails remain enforced
+- [x] T007 Add provider-neutral microVM platform rollout contract in shared package
+- [x] T008 Add tests proving scanner isolation and AI repository access guardrails remain enforced
 
 ## Deferred
 


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/236-005-microvm-rollout-guardrails`
- 이슈: #236

## 🔎 주요 변경 사항

- `packages/shared`에 provider-neutral `MicroVmPlatformRollout` 계약 추가
- scanner sandbox forbidden capability와 hardened/restricted isolation guardrail 추가
- AI Plane이 SCM credential, full repository, source archive, raw scanner payload를 직접 받지 않도록 shared guardrail 추가
- 005 tasks T007/T008 완료 표시

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

Closes #236

Local validation:

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment operation boundaries and guardrails for microVM platform rollout and AI plane repository access isolation.

* **Tests**
  * Added test coverage for deployment operation contract validation and guardrails enforcement.

* **Chores**
  * Completed microVM rollout contract specification tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
