### PR TITLE
feat: 005 운영 배포 핸드오프 매니페스트 검증 구현

### DIFF
--- a/packages/shared/src/types/deployment-operations.ts
+++ b/packages/shared/src/types/deployment-operations.ts
@@ -49,6 +49,13 @@ export const DEPLOYMENT_PREFLIGHT_REQUIRED_APPROVALS = [
 export type DeploymentPreflightRequiredApproval =
   (typeof DEPLOYMENT_PREFLIGHT_REQUIRED_APPROVALS)[number];
 
+export const DEPLOYMENT_CREDENTIAL_HANDOFF_MODES = [
+  'EXTERNAL_SECRET_MANAGER_REFERENCE',
+  'EPHEMERAL_OIDC_FEDERATION'
+] as const;
+export type DeploymentCredentialHandoffMode =
+  (typeof DEPLOYMENT_CREDENTIAL_HANDOFF_MODES)[number];
+
 export interface ProductionClusterProvisioning {
   environment: 'PRODUCTION';
   provider: string;
@@ -113,6 +120,21 @@ export interface DeploymentOperationPreflight {
   secretManagerRef: string;
   objectStorageRef: string;
   dnsZoneRef: string;
+}
+
+export interface DeploymentExecutionWindow {
+  startsAt: string;
+  endsAt: string;
+}
+
+export interface DeploymentOperationHandoffManifest {
+  preflight: DeploymentOperationPreflight;
+  credentialHandoffMode: DeploymentCredentialHandoffMode;
+  executionWindow: DeploymentExecutionWindow;
+  rollbackPlanRef: string;
+  incidentChannelRef: string;
+  dryRunEvidenceRef: string;
+  changeTicketRef: string;
 }
 
 export function isProductionClusterProvisioningBoundaryValid(
@@ -203,5 +225,24 @@ export function isDeploymentOperationPreflightReady(
     input.auditSignal.environment === 'PRODUCTION' &&
     requiredRefs.every((ref) => ref.length > 0) &&
     hasRequiredApprovals
+  );
+}
+
+export function isDeploymentOperationHandoffManifestReady(
+  input: DeploymentOperationHandoffManifest
+): boolean {
+  const requiredRefs = [
+    input.rollbackPlanRef,
+    input.incidentChannelRef,
+    input.dryRunEvidenceRef,
+    input.changeTicketRef
+  ];
+
+  return (
+    isDeploymentOperationPreflightReady(input.preflight) &&
+    DEPLOYMENT_CREDENTIAL_HANDOFF_MODES.includes(input.credentialHandoffMode) &&
+    input.executionWindow.startsAt.length > 0 &&
+    input.executionWindow.endsAt.length > 0 &&
+    requiredRefs.every((ref) => ref.length > 0)
   );
 }

--- a/packages/shared/test/deployment-operations.test.mjs
+++ b/packages/shared/test/deployment-operations.test.mjs
@@ -186,3 +186,62 @@ test('deployment operation preflight contracts reject persisted secrets and forb
   assert.match(contract, /isMicroVmPlatformRolloutBoundaryValid/);
   assert.match(contract, /allowedUse\s*===\s*'EXPLICIT_DEPLOYMENT_OPERATION'/);
 });
+
+test('deployment handoff manifests connect preflight evidence to live operation controls', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  for (const exportName of [
+    'DEPLOYMENT_CREDENTIAL_HANDOFF_MODES',
+    'DeploymentOperationHandoffManifest',
+    'isDeploymentOperationHandoffManifestReady'
+  ]) {
+    assert.match(contract, new RegExp(`export (interface|const|type|function) ${exportName}\\b`));
+  }
+
+  for (const requiredField of [
+    'preflight',
+    'credentialHandoffMode',
+    'executionWindow',
+    'startsAt',
+    'endsAt',
+    'rollbackPlanRef',
+    'incidentChannelRef',
+    'dryRunEvidenceRef',
+    'changeTicketRef'
+  ]) {
+    assert.match(contract, new RegExp(`\\b${requiredField}\\b`));
+  }
+
+  for (const handoffMode of [
+    'EXTERNAL_SECRET_MANAGER_REFERENCE',
+    'EPHEMERAL_OIDC_FEDERATION'
+  ]) {
+    assert.match(contract, new RegExp(`'${handoffMode}'`));
+  }
+});
+
+test('deployment handoff manifests remain reference-only and cannot carry secrets or repositories', () => {
+  assert.equal(existsSync(contractFile), true);
+
+  const contract = readContract();
+
+  for (const forbiddenField of [
+    'credentialValue',
+    'providerSecretValue',
+    'accessKey',
+    'secretAccessKey',
+    'privateKey',
+    'kubeconfig',
+    'scmToken',
+    'fullRepository',
+    'sourceArchive',
+    'rawScannerPayload'
+  ]) {
+    assert.doesNotMatch(contract, new RegExp(`\\b${forbiddenField}\\b`, 'i'));
+  }
+
+  assert.match(contract, /isDeploymentOperationPreflightReady/);
+  assert.match(contract, /DEPLOYMENT_CREDENTIAL_HANDOFF_MODES\.includes/);
+});

--- a/specs/005-production-deployment-operations/contracts/deployment-operations.md
+++ b/specs/005-production-deployment-operations/contracts/deployment-operations.md
@@ -107,3 +107,33 @@ Preflight inputs must remain references only. They must not contain provider
 secret values, kubeconfigs, SCM tokens, full repositories, source archives, or
 raw scanner payloads. Passing preflight does not execute live Kubernetes
 provisioning or provider-specific microVM rollout.
+
+## DeploymentOperationHandoffManifest
+
+```ts
+interface DeploymentOperationHandoffManifest {
+  preflight: DeploymentOperationPreflight;
+  credentialHandoffMode:
+    | "EXTERNAL_SECRET_MANAGER_REFERENCE"
+    | "EPHEMERAL_OIDC_FEDERATION";
+  executionWindow: {
+    startsAt: string;
+    endsAt: string;
+  };
+  rollbackPlanRef: string;
+  incidentChannelRef: string;
+  dryRunEvidenceRef: string;
+  changeTicketRef: string;
+}
+```
+
+The handoff manifest is the operator-facing readiness envelope for live
+execution. It binds a passing preflight contract to an execution window,
+rollback reference, incident channel, dry-run evidence reference, change ticket,
+and credential handoff mode.
+
+Credential handoff must be reference-only. Supported modes are external secret
+manager reference and ephemeral OIDC federation. The manifest must not contain
+provider secret values, kubeconfigs, SCM tokens, full repositories, source
+archives, or raw scanner payloads. Passing handoff validation still does not
+execute live Kubernetes provisioning or provider-specific microVM rollout.

--- a/specs/005-production-deployment-operations/tasks.md
+++ b/specs/005-production-deployment-operations/tasks.md
@@ -22,6 +22,11 @@
 - [x] T009 Add deployment operation preflight contract in shared package
 - [x] T010 Add tests proving live execution inputs do not persist provider credentials or forbidden payloads
 
+## Phase 5: Live Operation Handoff Manifest Slice
+
+- [x] T011 Add deployment operation handoff manifest contract in shared package
+- [x] T012 Add tests proving credential handoff remains reference-only before live execution
+
 ## Deferred
 
 - [ ] Execute live production Kubernetes cluster provisioning


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/240-005-deployment-handoff-manifest`
- 이슈: #240

## 🔎 주요 변경 사항

- `DeploymentOperationHandoffManifest` shared contract 추가
- preflight, execution window, rollback plan, incident channel, dry-run evidence, change ticket refs 연결
- credential handoff mode를 external secret manager reference 또는 ephemeral OIDC federation으로 제한
- handoff manifest가 provider secrets, kubeconfig, SCM token, repositories, source archives, raw scanner payload를 담지 않도록 테스트 추가
- 005 contracts/tasks에 handoff manifest slice 반영

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

Closes #240

Local validation:

- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `git diff --check`
