### PR TITLE
docs: add domain class and scan lifecycle UML diagrams

### DIFF
--- a/docs/reports/uml/aegisai-domain-class.puml
+++ b/docs/reports/uml/aegisai-domain-class.puml
@@ -1,0 +1,71 @@
+@startuml aegisai-domain-class
+' AegisAI 도메인 클래스 다이어그램 (정적 구조 모델)
+hide circle
+skinparam classAttributeIconSize 0
+skinparam linetype polyline
+
+class Tenant {
+  + id
+  + name
+  + plan
+}
+class Integration {
+  + id
+  + provider
+  + repoRef
+  + status
+}
+class ScanJob {
+  + id
+  + commitRef
+  + status
+  + createdAt
+}
+class Finding {
+  + id
+  + scanner
+  + severity
+  + cwe
+  + location
+}
+class EvidencePack {
+  + id
+  + abridged
+  + deidentified
+}
+class AdvisoryResult {
+  + id
+  + priority
+  + suggestion
+}
+class SecurityOntology <<Neo4j>> {
+  + concept (CWE, CAPEC)
+  + relation
+  + mitigation
+  + source
+}
+class PolicyDecision {
+  + id
+  + verdict
+  + reason
+}
+class AuditLog {
+  + id
+  + action
+  + actor
+  + timestamp
+}
+
+Tenant "1" *-- "0..*" Integration
+Tenant "1" *-- "0..*" ScanJob
+ScanJob "1" *-- "0..*" Finding
+ScanJob "1" *-- "1" EvidencePack
+ScanJob "1" *-- "1" PolicyDecision
+EvidencePack "1" *-- "0..*" AdvisoryResult
+AdvisoryResult ..> SecurityOntology : grounded via GraphRAG
+ScanJob ..> AuditLog : logs actions
+note top of AuditLog
+  주요 행위(통합, 스캔, 정책 판단)는
+  AuditLog에 기록된다
+end note
+@enduml

--- a/docs/reports/uml/aegisai-scan-state.puml
+++ b/docs/reports/uml/aegisai-scan-state.puml
@@ -1,0 +1,20 @@
+@startuml aegisai-scan-state
+' 스캔 작업(ScanJob) 생애주기 상태 다이어그램
+[*] --> Requested
+Requested --> Authorized : authz ok
+Requested --> Failed : authz denied
+Authorized --> Scanning : sandbox up
+Scanning --> Analyzed : scanners done\n+ evidence reduced
+Scanning --> Failed : scan error /\nsandbox timeout
+Analyzed --> PolicyReview : advisory ready
+PolicyReview --> Published : approved
+PolicyReview --> Suppressed : blocked by policy
+Published --> [*]
+Suppressed --> [*]
+Failed --> [*]
+
+state Authorized : short-lived token
+state Scanning : isolated sandbox
+state Analyzed : evidence + AI advisory
+state PolicyReview : policy gate
+@enduml


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈
- 브랜치: feat/242-uml-class-state
- 이슈: #242

## 🔎 주요 변경 사항
- 도메인 클래스 다이어그램(aegisai-domain-class.puml)과 스캔 생애주기 상태 다이어그램(aegisai-scan-state.puml)을 docs/reports/uml/에 추가

## ✅ 컨벤션 확인
- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation of the AegisAI domain model, describing key entities and their relationships within the system
  * Added scan job lifecycle documentation, detailing state transitions and workflow from request through publication or suppression

<!-- end of auto-generated comment: release notes by coderabbit.ai -->