### PR TITLE
feat: 006 artifact schema 및 payload validation 구현

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^10.4.15",
     "@nestjs/throttler": "^5.2.0",
     "@prisma/client": "5",
+    "@streamparser/json": "0.0.22",
     "axios": "^1.13.2",
     "bullmq": "^5.61.0",
     "class-transformer": "0.5.1",

--- a/apps/api/prisma/migrations/20260724210000_sast_artifact_validation/migration.sql
+++ b/apps/api/prisma/migrations/20260724210000_sast_artifact_validation/migration.sql
@@ -1,0 +1,9 @@
+-- Nullable columns preserve rolling-deployment compatibility. The application writes
+-- all three fields for every new runtime record. The mandatory online schema step
+-- validates ScannerRun_runtime_metadata_v3_check before removing v1/v2 constraints.
+ALTER TABLE "ScannerRun"
+  ADD COLUMN "schemaBundleDigest" TEXT,
+  ADD COLUMN "normalizerBundleDigest" TEXT;
+
+ALTER TABLE "SastArtifactIngestion"
+  ADD COLUMN "envelope" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -579,6 +579,8 @@ model ScannerRun {
   ruleBundleDigest                String?
   databaseDigest                  String?
   scannerSetDigest                String?
+  schemaBundleDigest              String?
+  normalizerBundleDigest          String?
   profileId                       String?
   profileDigest                   String?
   preflightAttestationRef         String?
@@ -630,6 +632,7 @@ model SastArtifactIngestion {
   scannerRunId          String                      @unique
   workloadIdentityRef   String
   idempotencyKey        String
+  envelope              Json?
   envelopeDigest        String
   declaredContentDigest String
   observedContentDigest String?

--- a/apps/api/scripts/apply-online-sast-runtime-schema.mjs
+++ b/apps/api/scripts/apply-online-sast-runtime-schema.mjs
@@ -59,7 +59,7 @@ const constraints = [
   },
   {
     table: 'ScannerRun',
-    name: 'ScannerRun_runtime_metadata_v2_check',
+    name: 'ScannerRun_runtime_metadata_v3_check',
     type: 'c',
     definition: `CHECK (
       "attemptId" IS NULL
@@ -100,7 +100,22 @@ const constraints = [
               AND "artifactSchema" = 'CYCLONEDX_JSON'
             )
           )
-          AND "artifactSchemaVersion" ~ '^sha256:[a-f0-9]{64}$'
+          AND (
+            (
+              "schemaBundleDigest" IS NULL
+              AND "normalizerBundleDigest" IS NULL
+              AND "artifactSchemaVersion" ~ '^sha256:[a-f0-9]{64}$'
+            )
+            OR (
+              "schemaBundleDigest" ~ '^sha256:[a-f0-9]{64}$'
+              AND "normalizerBundleDigest" ~ '^sha256:[a-f0-9]{64}$'
+              AND (
+                ("scanner" = 'OPENGREP' AND "artifactSchemaVersion" = '2.1.0')
+                OR ("scanner" = 'TRIVY' AND "artifactSchemaVersion" = '2')
+                OR ("scanner" = 'SYFT' AND "artifactSchemaVersion" = '1.6')
+              )
+            )
+          )
           AND "startedAt" IS NOT NULL
           AND (
             (
@@ -171,7 +186,12 @@ const supersededConstraints = [
   {
     table: 'ScannerRun',
     name: 'ScannerRun_runtime_metadata_check',
-    replacement: 'ScannerRun_runtime_metadata_v2_check'
+    replacement: 'ScannerRun_runtime_metadata_v3_check'
+  },
+  {
+    table: 'ScannerRun',
+    name: 'ScannerRun_runtime_metadata_v2_check',
+    replacement: 'ScannerRun_runtime_metadata_v3_check'
   }
 ];
 

--- a/apps/api/src/scan-plane/prisma-sast-artifact-ingress.store.ts
+++ b/apps/api/src/scan-plane/prisma-sast-artifact-ingress.store.ts
@@ -161,6 +161,8 @@ export class PrismaSastArtifactIngressStore
               scannerRunId: input.expected.scannerRunId,
               workloadIdentityRef: input.expected.workloadIdentityRef,
               idempotencyKey: input.idempotencyKey,
+              envelope:
+                input.envelope as unknown as Prisma.InputJsonValue,
               envelopeDigest: input.envelopeDigest,
               declaredContentDigest: input.declaredContentDigest,
               declaredByteSize: input.declaredByteSize,
@@ -273,7 +275,9 @@ export class PrismaSastArtifactIngressStore
           receivedAt: new Date(input.receivedAt),
           validationMetadata: {
             workloadIdentityValidated: true,
-            transportByteCountValidated: true
+            transportByteCountValidated: true,
+            artifactValidation:
+              input.validation as unknown as Prisma.InputJsonValue
           }
         }
       });
@@ -311,6 +315,9 @@ export class PrismaSastArtifactIngressStore
               scannerRunId: ingestion.scannerRunId,
               observedContentDigest: input.observedContentDigest,
               observedByteSize: input.observedByteSize,
+              validationOutcome: input.validation.outcome,
+              validationResultDigest: input.validation.resultDigest,
+              validationReasonCodes: [...input.validation.reasonCodes],
               nextState: 'PENDING_VALIDATION'
             }
           }

--- a/apps/api/src/scan-plane/prisma-sast-scanner-runtime.store.ts
+++ b/apps/api/src/scan-plane/prisma-sast-scanner-runtime.store.ts
@@ -352,6 +352,8 @@ export class PrismaSastScannerRuntimeStore extends SastScannerRuntimeStore {
           ruleBundleDigest: invocation.ruleBundleDigest,
           databaseDigest: invocation.vulnerabilityDatabaseDigest,
           scannerSetDigest: invocation.scannerSetDigest,
+          schemaBundleDigest: invocation.schemaBundleDigest,
+          normalizerBundleDigest: invocation.normalizerBundleDigest,
           profileId: invocation.profileId,
           profileDigest: invocation.profileDigest,
           preflightAttestationRef: invocation.preflightAttestationRef,

--- a/apps/api/src/scan-plane/sast-artifact-ingress.service.ts
+++ b/apps/api/src/scan-plane/sast-artifact-ingress.service.ts
@@ -34,6 +34,7 @@ import {
   SastArtifactObjectStore,
   SastArtifactObjectStoreUnavailableError
 } from './sast-artifact-object-store';
+import { SastArtifactValidationService } from './sast-artifact-validation.service';
 
 const MAX_BASE64URL_ENVELOPE_BYTES =
   Math.ceil((SAST_MAX_ARTIFACT_ENVELOPE_BYTES * 4) / 3) + 4;
@@ -64,7 +65,8 @@ class SastArtifactTransportError extends Error {
 export class SastArtifactIngressService {
   constructor(
     private readonly store: SastArtifactIngressStore,
-    private readonly objectStore: SastArtifactObjectStore
+    private readonly objectStore: SastArtifactObjectStore,
+    private readonly validation: SastArtifactValidationService
   ) {}
 
   async ingest(
@@ -124,6 +126,7 @@ export class SastArtifactIngressService {
     try {
       reservation = await this.store.reserve({
         ingestionId,
+        envelope,
         envelopeDigest,
         idempotencyKey: requiredIdempotencyKey,
         expected,
@@ -170,6 +173,11 @@ export class SastArtifactIngressService {
     };
     let objectKey: string | undefined;
     try {
+      const validationSession = await this.validation.createSession({
+        envelope,
+        envelopeDigest,
+        expected
+      });
       const write = await this.objectStore.put({
         ingestionId,
         tenantId: envelope.tenantId,
@@ -177,7 +185,9 @@ export class SastArtifactIngressService {
         scanRequestId: envelope.scanRequestId,
         attemptId: envelope.attemptId,
         scannerRunId: envelope.scannerRunId,
-        body: this.observeBody(input.body, envelope.byteSize, observation)
+        body: validationSession.observe(
+          this.observeBody(input.body, envelope.byteSize, observation)
+        )
       });
       objectKey = this.validateObjectKey(write.objectKey);
       if (observation.byteSize !== envelope.byteSize) {
@@ -189,11 +199,21 @@ export class SastArtifactIngressService {
       const receivedAt = new Date().toISOString();
       const observedContentDigest =
         `sha256:${observation.hash.digest('hex')}` as const;
+      const validationResult = validationSession.finish();
+      if (
+        validationResult.observedContentDigest !==
+          observedContentDigest ||
+        validationResult.statistics.observedByteSize !==
+          observation.byteSize
+      ) {
+        throw new Error('Artifact validation observation mismatch.');
+      }
       await this.store.complete({
         ingestionId,
         objectKey,
         observedContentDigest,
         observedByteSize: observation.byteSize,
+        validation: validationResult,
         receivedAt
       });
 
@@ -343,6 +363,8 @@ export class SastArtifactIngressService {
       isScannerArtifactEnvelopeBoundToPlan(envelope, expected.plan, {
         attemptId: expected.attemptId,
         scannerRunId: expected.scannerRunId,
+        scanner: expected.scanner,
+        artifactRef: expected.artifactRef,
         workloadIdentityRef: identity.identityRef,
         preflightAttestationRef: expected.preflightAttestationRef,
         preflightInventoryDigest: expected.preflightInventoryDigest

--- a/apps/api/src/scan-plane/sast-artifact-ingress.store.ts
+++ b/apps/api/src/scan-plane/sast-artifact-ingress.store.ts
@@ -1,4 +1,6 @@
 import type {
+  ScannerArtifactEnvelope,
+  SastArtifactValidationResult,
   SastArtifactIngestionState,
   SastScannerKind,
   SastScanPlan
@@ -20,6 +22,7 @@ export interface SastArtifactIngressExpectedBinding {
 
 export interface ReserveSastArtifactIngressInput {
   ingestionId: string;
+  envelope: Readonly<ScannerArtifactEnvelope>;
   envelopeDigest: `sha256:${string}`;
   idempotencyKey: string;
   expected: Readonly<SastArtifactIngressExpectedBinding>;
@@ -40,6 +43,7 @@ export interface CompleteSastArtifactIngressInput {
   objectKey: string;
   observedContentDigest: `sha256:${string}`;
   observedByteSize: number;
+  validation: Readonly<SastArtifactValidationResult>;
   receivedAt: string;
 }
 

--- a/apps/api/src/scan-plane/sast-artifact-stream-validator.ts
+++ b/apps/api/src/scan-plane/sast-artifact-stream-validator.ts
@@ -1,0 +1,2178 @@
+import { createHash } from 'node:crypto';
+import { TextDecoder } from 'node:util';
+
+import {
+  SAST_ARTIFACT_SCHEMA_VERSIONS,
+  SAST_ARTIFACT_VALIDATION_LIMITS,
+  SAST_ARTIFACT_VALIDATION_REASON_CODES,
+  SAST_ARTIFACT_VALIDATION_VERSION,
+  SAST_MAX_COORDINATE_VALUE,
+  canonicalizeSastArtifactValidationResult,
+  deriveSastArtifactValidationChecks,
+  isSastFindingLocationValid,
+  isScannerArtifactEnvelopeBoundToPlan,
+  type ExpectedScannerArtifactBinding,
+  type SastArtifactValidationReasonCode,
+  type SastArtifactValidationResult,
+  type SastArtifactValidationResultCore,
+  type SastFileCoordinateMetadata,
+  type SastScanPlan,
+  type ScannerArtifactEnvelope
+} from '@aegisai/shared';
+import { Tokenizer, TokenType } from '@streamparser/json';
+
+import type { SastFileCoordinateAttestation } from './sast-file-coordinate-attestation.provider';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonPath = readonly (string | number)[];
+type ContainerKind = 'OBJECT' | 'ARRAY';
+
+interface ArtifactValidationFault extends Error {
+  reasonCode: SastArtifactValidationReasonCode;
+}
+
+interface ArtifactValidationCallbacks {
+  onContainer(path: JsonPath, kind: ContainerKind): void;
+  onContainerEnd(path: JsonPath, kind: ContainerKind): void;
+  onKey(objectPath: JsonPath, key: string): void;
+  onPrimitive(path: JsonPath, value: JsonPrimitive): void;
+}
+
+interface ObjectFrame {
+  kind: 'OBJECT';
+  path: JsonPath;
+  keys: Set<string>;
+  state: 'KEY_OR_END' | 'KEY' | 'COLON' | 'VALUE' | 'COMMA_OR_END';
+  currentKey?: string;
+}
+
+interface ArrayFrame {
+  kind: 'ARRAY';
+  path: JsonPath;
+  state: 'VALUE_OR_END' | 'VALUE' | 'COMMA_OR_END';
+  nextIndex: number;
+}
+
+type JsonFrame = ObjectFrame | ArrayFrame;
+
+interface ParsedToken {
+  token: TokenType;
+  value: JsonPrimitive;
+  partial?: boolean;
+}
+
+interface LocationState {
+  path?: string;
+  lineStart?: number;
+  lineEnd?: number;
+  columnStart?: number;
+  columnEnd?: number;
+}
+
+interface RecordState extends LocationState {
+  kind: string;
+  keys: Set<string>;
+  trivyResultIndex?: number;
+}
+
+interface RequiredObjectState {
+  kind: 'SARIF_TOOL' | 'SARIF_DRIVER' | 'SARIF_RESULT_MESSAGE';
+  keys: Set<string>;
+}
+
+const SARIF_ROOT_FIELDS = new Set([
+  '$schema',
+  'version',
+  'runs',
+  'inlineExternalProperties',
+  'properties'
+]);
+const SARIF_RUN_FIELDS = new Set([
+  'tool',
+  'invocations',
+  'conversion',
+  'language',
+  'versionControlProvenance',
+  'originalUriBaseIds',
+  'artifacts',
+  'logicalLocations',
+  'graphs',
+  'results',
+  'automationDetails',
+  'baselineGuid',
+  'redactionTokens',
+  'defaultEncoding',
+  'defaultSourceLanguage',
+  'newlineSequences',
+  'columnKind',
+  'externalPropertyFileReferences',
+  'threadFlowLocations',
+  'taxonomies',
+  'addresses',
+  'translations',
+  'policies',
+  'webRequests',
+  'webResponses',
+  'specialLocations',
+  'properties'
+]);
+const SARIF_RESULT_FIELDS = new Set([
+  'ruleId',
+  'ruleIndex',
+  'rule',
+  'kind',
+  'level',
+  'message',
+  'analysisTarget',
+  'locations',
+  'guid',
+  'correlationGuid',
+  'occurrenceCount',
+  'partialFingerprints',
+  'fingerprints',
+  'stacks',
+  'codeFlows',
+  'graphs',
+  'graphTraversals',
+  'relatedLocations',
+  'suppressions',
+  'baselineState',
+  'rank',
+  'attachments',
+  'hostedViewerUri',
+  'workItemUris',
+  'provenance',
+  'fixes',
+  'taxa',
+  'webRequest',
+  'webResponse',
+  'properties'
+]);
+const TRIVY_ROOT_FIELDS = new Set([
+  'SchemaVersion',
+  'CreatedAt',
+  'ArtifactName',
+  'ArtifactType',
+  'Metadata',
+  'Results'
+]);
+const TRIVY_RESULT_FIELDS = new Set([
+  'Target',
+  'Class',
+  'Type',
+  'Packages',
+  'Vulnerabilities',
+  'MisconfSummary',
+  'Misconfigurations',
+  'Secrets',
+  'Licenses',
+  'CustomResources',
+  'ExperimentalModifiedFindings'
+]);
+const TRIVY_VULNERABILITY_FIELDS = new Set([
+  'VulnerabilityID',
+  'VendorIDs',
+  'PkgID',
+  'PkgName',
+  'PkgPath',
+  'PkgIdentifier',
+  'InstalledVersion',
+  'FixedVersion',
+  'Status',
+  'Layer',
+  'SeveritySource',
+  'PrimaryURL',
+  'DataSource',
+  'Custom',
+  'Title',
+  'Description',
+  'Severity',
+  'CweIDs',
+  'VendorSeverity',
+  'CVSS',
+  'References',
+  'PublishedDate',
+  'LastModifiedDate'
+]);
+const TRIVY_MISCONFIGURATION_FIELDS = new Set([
+  'Type',
+  'ID',
+  'AVDID',
+  'Title',
+  'Description',
+  'Message',
+  'Namespace',
+  'Query',
+  'Resolution',
+  'Severity',
+  'PrimaryURL',
+  'References',
+  'Status',
+  'Layer',
+  'CauseMetadata',
+  'Traces'
+]);
+const TRIVY_SECRET_FIELDS = new Set([
+  'RuleID',
+  'Category',
+  'Severity',
+  'Title',
+  'StartLine',
+  'EndLine',
+  'Code',
+  'Match',
+  'Layer',
+  'Offset'
+]);
+const CYCLONEDX_ROOT_FIELDS = new Set([
+  '$schema',
+  'bomFormat',
+  'specVersion',
+  'serialNumber',
+  'version',
+  'metadata',
+  'components',
+  'services',
+  'externalReferences',
+  'dependencies',
+  'compositions',
+  'vulnerabilities',
+  'annotations',
+  'properties',
+  'formulation',
+  'declarations',
+  'definitions'
+]);
+const CYCLONEDX_COMPONENT_FIELDS = new Set([
+  'type',
+  'mime-type',
+  'bom-ref',
+  'supplier',
+  'manufacturer',
+  'authors',
+  'author',
+  'publisher',
+  'group',
+  'name',
+  'version',
+  'description',
+  'scope',
+  'hashes',
+  'licenses',
+  'copyright',
+  'cpe',
+  'purl',
+  'swid',
+  'modified',
+  'pedigree',
+  'externalReferences',
+  'properties',
+  'components',
+  'evidence',
+  'releaseNotes',
+  'modelCard',
+  'data',
+  'cryptoProperties',
+  'tags',
+  'signature',
+  'omniborId',
+  'swhid'
+]);
+const TRIVY_RECORD_ARRAYS = new Set([
+  'Vulnerabilities',
+  'Misconfigurations',
+  'Secrets'
+]);
+const SARIF_RESULT_KINDS = new Set([
+  'notApplicable',
+  'pass',
+  'fail',
+  'review',
+  'open',
+  'informational'
+]);
+const SARIF_LEVELS = new Set(['none', 'note', 'warning', 'error']);
+const SARIF_COLUMN_KINDS = new Set([
+  'utf16CodeUnits',
+  'unicodeCodePoints'
+]);
+const SARIF_BASELINE_STATES = new Set([
+  'new',
+  'unchanged',
+  'updated',
+  'absent'
+]);
+const CYCLONEDX_COMPONENT_TYPES = new Set([
+  'application',
+  'framework',
+  'library',
+  'container',
+  'platform',
+  'operating-system',
+  'device',
+  'device-driver',
+  'firmware',
+  'file',
+  'machine-learning-model',
+  'data',
+  'cryptographic-asset'
+]);
+const CYCLONEDX_COMPONENT_SCOPES = new Set([
+  'required',
+  'optional',
+  'excluded'
+]);
+const TRIVY_SEVERITIES = new Set([
+  'UNKNOWN',
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'CRITICAL'
+]);
+const TRIVY_RESULT_CLASSES = new Set([
+  'unknown',
+  'os-pkgs',
+  'lang-pkgs',
+  'config',
+  'secret',
+  'license',
+  'license-file',
+  'custom'
+]);
+const TRIVY_VULNERABILITY_STATUSES = new Set([
+  'unknown',
+  'not_affected',
+  'affected',
+  'fixed',
+  'under_investigation',
+  'will_not_fix',
+  'fix_deferred',
+  'end_of_life'
+]);
+const TRIVY_MISCONFIGURATION_STATUSES = new Set([
+  'PASS',
+  'FAIL',
+  'EXCEPTION'
+]);
+
+export interface SastArtifactStreamValidationInput {
+  envelope: Readonly<ScannerArtifactEnvelope>;
+  plan: Readonly<SastScanPlan>;
+  expectedBinding: Readonly<ExpectedScannerArtifactBinding>;
+  envelopeDigest: `sha256:${string}`;
+  coordinateAttestation: Readonly<SastFileCoordinateAttestation> | null;
+}
+
+export class SastArtifactStreamValidationSession {
+  private readonly reasons = new Set<SastArtifactValidationReasonCode>();
+  private readonly observedContentHash = createHash('sha256');
+  private readonly decoder = new TextDecoder('utf-8', { fatal: true });
+  private readonly tokenizer = new Tokenizer({ emitPartialTokens: false });
+  private readonly rawLimiter = new RawJsonTokenLimiter();
+  private readonly parserPending = Buffer.alloc(
+    SAST_ARTIFACT_VALIDATION_LIMITS.parserSliceBytes
+  );
+  private readonly schemaInspector: SastArtifactSchemaInspector;
+  private readonly structure: BoundedJsonStructureTracker;
+  private parsingActive = true;
+  private decoderActive = true;
+  private observedByteSize = 0;
+  private parserPendingLength = 0;
+  private finished = false;
+
+  constructor(private readonly input: Readonly<SastArtifactStreamValidationInput>) {
+    const fileCoordinates = this.loadFileCoordinates(
+      input.coordinateAttestation
+    );
+    this.schemaInspector = new SastArtifactSchemaInspector(
+      input.envelope,
+      input.plan,
+      fileCoordinates,
+      this.reasons
+    );
+    this.structure = new BoundedJsonStructureTracker(
+      this.schemaInspector,
+      this.reasons
+    );
+    this.tokenizer.onToken = (token) => this.acceptToken(token);
+    this.tokenizer.onError = (error) => {
+      throw isValidationFault(error)
+        ? error
+        : validationFault('ARTIFACT_JSON_MALFORMED');
+    };
+
+    if (
+      !isScannerArtifactEnvelopeBoundToPlan(
+        input.envelope,
+        input.plan,
+        input.expectedBinding
+      )
+    ) {
+      this.reasons.add('ARTIFACT_PLAN_BINDING_MISMATCH');
+    }
+    if (
+      input.envelope.artifactSchemaVersion !==
+      SAST_ARTIFACT_SCHEMA_VERSIONS[input.envelope.artifactSchema]
+    ) {
+      this.reasons.add('ARTIFACT_SCHEMA_VERSION_MISMATCH');
+    }
+  }
+
+  async *observe(
+    body: AsyncIterable<Uint8Array>
+  ): AsyncGenerator<Uint8Array> {
+    for await (const chunk of body) {
+      const bytes = Buffer.from(chunk);
+      this.observedContentHash.update(bytes);
+      this.observedByteSize += bytes.byteLength;
+      this.validateEncoding(bytes);
+      this.acceptParserBytes(bytes);
+      yield bytes;
+    }
+  }
+
+  finish(): SastArtifactValidationResult {
+    if (this.finished) {
+      throw new Error('Artifact validation session is already finished.');
+    }
+    this.finished = true;
+    const observedContentDigest =
+      `sha256:${this.observedContentHash.digest('hex')}` as const;
+    const observedByteSize = this.observedByteSize;
+    if (this.decoderActive) {
+      try {
+        this.decoder.decode();
+      } catch {
+        this.reasons.add('ARTIFACT_INVALID_UTF8');
+      }
+    }
+    this.flushParserPending();
+    if (this.parsingActive) {
+      try {
+        this.rawLimiter.end();
+        this.tokenizer.end();
+        this.structure.finish();
+      } catch (error) {
+        this.recordFault(error);
+      }
+    }
+    this.schemaInspector.finish();
+
+    if (observedContentDigest !== this.input.envelope.contentDigest) {
+      this.reasons.add('ARTIFACT_CONTENT_DIGEST_MISMATCH');
+    }
+    if (
+      observedByteSize !== this.input.envelope.byteSize ||
+      observedByteSize > this.input.plan.profile.limits.maxArtifactBytes
+    ) {
+      this.reasons.add('ARTIFACT_BYTE_SIZE_MISMATCH');
+    }
+    if (
+      this.schemaInspector.recordCount !== this.input.envelope.recordCount
+    ) {
+      this.reasons.add('ARTIFACT_RECORD_COUNT_MISMATCH');
+    }
+    if (
+      this.schemaInspector.recordCount >
+      (this.input.envelope.artifactSchema === 'CYCLONEDX_JSON'
+        ? this.input.plan.profile.limits.maxArtifactRecords
+        : Math.min(
+            this.input.plan.profile.limits.maxArtifactRecords,
+            this.input.plan.profile.limits.maxFindings
+          ))
+    ) {
+      this.reasons.add('ARTIFACT_RECORD_LIMIT_EXCEEDED');
+    }
+
+    const reasonCodes = SAST_ARTIFACT_VALIDATION_REASON_CODES.filter(
+      (reasonCode) => this.reasons.has(reasonCode)
+    );
+    const checks = deriveSastArtifactValidationChecks(reasonCodes);
+    const core: SastArtifactValidationResultCore = {
+      version: SAST_ARTIFACT_VALIDATION_VERSION,
+      outcome: reasonCodes.length === 0 ? 'PASSED' : 'FAILED',
+      artifactSchema: this.input.envelope.artifactSchema,
+      envelopeDigest: this.input.envelopeDigest,
+      observedContentDigest,
+      checks,
+      reasonCodes,
+      statistics: {
+        observedByteSize,
+        observedRecordCount: this.schemaInspector.recordCount,
+        maximumObservedDepth: this.structure.maximumObservedDepth,
+        maximumObservedStringBytes:
+          this.structure.maximumObservedStringBytes,
+        normalizedPathCount: this.schemaInspector.normalizedPathCount,
+        coordinateCount: this.schemaInspector.coordinateCount
+      }
+    };
+
+    return {
+      ...core,
+      resultDigest: digest(canonicalizeSastArtifactValidationResult(core))
+    };
+  }
+
+  private validateEncoding(bytes: Buffer): void {
+    if (!this.decoderActive) return;
+    try {
+      this.decoder.decode(bytes, { stream: true });
+    } catch {
+      this.decoderActive = false;
+      this.reasons.add('ARTIFACT_INVALID_UTF8');
+    }
+  }
+
+  private acceptToken(token: ParsedToken): void {
+    this.structure.accept(token);
+  }
+
+  private acceptParserBytes(bytes: Buffer): void {
+    if (!this.parsingActive) return;
+    const sliceBytes = SAST_ARTIFACT_VALIDATION_LIMITS.parserSliceBytes;
+    let offset = 0;
+
+    if (this.parserPendingLength > 0) {
+      const take = Math.min(
+        sliceBytes - this.parserPendingLength,
+        bytes.byteLength
+      );
+      bytes.copy(
+        this.parserPending,
+        this.parserPendingLength,
+        0,
+        take
+      );
+      this.parserPendingLength += take;
+      offset = take;
+      if (this.parserPendingLength === sliceBytes) {
+        this.parserPendingLength = 0;
+        this.processParserSlice(this.parserPending);
+      }
+    }
+
+    while (
+      this.parsingActive &&
+      offset + sliceBytes <= bytes.byteLength
+    ) {
+      this.processParserSlice(
+        bytes.subarray(offset, offset + sliceBytes)
+      );
+      offset += sliceBytes;
+    }
+
+    if (this.parsingActive && offset < bytes.byteLength) {
+      const remaining = bytes.byteLength - offset;
+      bytes.copy(this.parserPending, 0, offset);
+      this.parserPendingLength = remaining;
+    }
+  }
+
+  private flushParserPending(): void {
+    if (!this.parsingActive || this.parserPendingLength === 0) return;
+    const length = this.parserPendingLength;
+    this.parserPendingLength = 0;
+    this.processParserSlice(this.parserPending.subarray(0, length));
+  }
+
+  private processParserSlice(slice: Buffer): void {
+    try {
+      this.rawLimiter.write(slice);
+      this.tokenizer.write(slice);
+    } catch (error) {
+      this.recordFault(error);
+    }
+  }
+
+  private recordFault(error: unknown): void {
+    const reasonCode =
+      isValidationFault(error)
+        ? error.reasonCode
+        : 'ARTIFACT_JSON_MALFORMED';
+    this.reasons.add(reasonCode);
+    this.parsingActive = false;
+    this.parserPendingLength = 0;
+  }
+
+  private loadFileCoordinates(
+    attestation: Readonly<SastFileCoordinateAttestation> | null
+  ): ReadonlyMap<string, Readonly<SastFileCoordinateMetadata>> | null {
+    if (
+      !attestation ||
+      attestation.verified !== true ||
+      attestation.attestationRef !==
+        this.input.expectedBinding.preflightAttestationRef ||
+      attestation.inventoryDigest !==
+        this.input.expectedBinding.preflightInventoryDigest ||
+      !Array.isArray(attestation.files) ||
+      attestation.files.length > this.input.plan.profile.limits.maxFileCount
+    ) {
+      return null;
+    }
+
+    const coordinates = new Map<
+      string,
+      Readonly<SastFileCoordinateMetadata>
+    >();
+    const foldedPaths = new Set<string>();
+    let totalLineCount = 0;
+    for (const rawFile of attestation.files as readonly unknown[]) {
+      if (
+        !rawFile ||
+        typeof rawFile !== 'object' ||
+        Array.isArray(rawFile) ||
+        !hasOnlyObjectKeys(rawFile, [
+          'normalizedPath',
+          'lineCount',
+          'maxColumnByLine'
+        ])
+      ) {
+        return null;
+      }
+      const file = rawFile as Record<string, unknown>;
+      const normalizedPath = normalizeArtifactPath(
+        file.normalizedPath,
+        this.input.plan.profile.limits.maxPathDepth
+      );
+      const foldedPath = normalizedPath
+        ?.toLocaleLowerCase('en-US')
+        .normalize('NFC');
+      if (
+        !normalizedPath ||
+        normalizedPath !== file.normalizedPath ||
+        !foldedPath ||
+        foldedPaths.has(foldedPath) ||
+        typeof file.lineCount !== 'number' ||
+        !Number.isSafeInteger(file.lineCount) ||
+        file.lineCount <= 0 ||
+        file.lineCount > SAST_MAX_COORDINATE_VALUE ||
+        !Array.isArray(file.maxColumnByLine) ||
+        file.maxColumnByLine.length !== file.lineCount ||
+        !file.maxColumnByLine.every(
+          (column: unknown) =>
+            typeof column === 'number' &&
+            Number.isSafeInteger(column) &&
+            column > 0 &&
+            column <= SAST_MAX_COORDINATE_VALUE
+        ) ||
+        coordinates.has(normalizedPath)
+      ) {
+        return null;
+      }
+      totalLineCount += file.lineCount;
+      if (
+        totalLineCount >
+        SAST_ARTIFACT_VALIDATION_LIMITS.maximumCoordinateAttestationLines
+      ) {
+        return null;
+      }
+      foldedPaths.add(foldedPath);
+      coordinates.set(normalizedPath, {
+        normalizedPath,
+        lineCount: file.lineCount,
+        maxColumnByLine: file.maxColumnByLine
+      });
+    }
+    return coordinates;
+  }
+
+}
+
+class BoundedJsonStructureTracker {
+  private readonly stack: JsonFrame[] = [];
+  private rootState: 'VALUE' | 'CONTAINER' | 'END' = 'VALUE';
+  private tokenCount = 0;
+  maximumObservedDepth = 0;
+  maximumObservedStringBytes = 0;
+
+  constructor(
+    private readonly callbacks: ArtifactValidationCallbacks,
+    private readonly reasons: Set<SastArtifactValidationReasonCode>
+  ) {}
+
+  accept(token: ParsedToken): void {
+    if (token.partial === true) {
+      if (token.token === TokenType.STRING) {
+        this.checkString(token.value);
+      }
+      return;
+    }
+
+    this.tokenCount += 1;
+    if (
+      this.tokenCount >
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumTokenCount
+    ) {
+      throw validationFault('ARTIFACT_JSON_TOKEN_LIMIT_EXCEEDED');
+    }
+
+    if (token.token === TokenType.STRING) {
+      this.checkString(token.value);
+      const frame = this.stack.at(-1);
+      if (
+        frame?.kind === 'OBJECT' &&
+        (frame.state === 'KEY_OR_END' || frame.state === 'KEY')
+      ) {
+        this.acceptKey(frame, token.value as string);
+        return;
+      }
+    }
+
+    switch (token.token) {
+      case TokenType.LEFT_BRACE:
+        this.startContainer('OBJECT');
+        return;
+      case TokenType.LEFT_BRACKET:
+        this.startContainer('ARRAY');
+        return;
+      case TokenType.RIGHT_BRACE:
+        this.endObject();
+        return;
+      case TokenType.RIGHT_BRACKET:
+        this.endArray();
+        return;
+      case TokenType.COLON:
+        this.acceptColon();
+        return;
+      case TokenType.COMMA:
+        this.acceptComma();
+        return;
+      case TokenType.STRING:
+      case TokenType.NUMBER:
+      case TokenType.TRUE:
+      case TokenType.FALSE:
+      case TokenType.NULL:
+        this.acceptPrimitive(token.value);
+        return;
+      default:
+        throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+  }
+
+  finish(): void {
+    if (this.stack.length !== 0 || this.rootState !== 'END') {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+  }
+
+  private startContainer(kind: ContainerKind): void {
+    const path = this.startValue(true);
+    const frame: JsonFrame =
+      kind === 'OBJECT'
+        ? {
+            kind,
+            path,
+            keys: new Set<string>(),
+            state: 'KEY_OR_END'
+          }
+        : {
+            kind,
+            path,
+            state: 'VALUE_OR_END',
+            nextIndex: 0
+          };
+    this.stack.push(frame);
+    this.maximumObservedDepth = Math.max(
+      this.maximumObservedDepth,
+      this.stack.length
+    );
+    if (
+      this.stack.length >
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumJsonDepth
+    ) {
+      throw validationFault('ARTIFACT_JSON_DEPTH_LIMIT_EXCEEDED');
+    }
+    this.callbacks.onContainer(path, kind);
+  }
+
+  private endObject(): void {
+    const frame = this.stack.at(-1);
+    if (
+      frame?.kind !== 'OBJECT' ||
+      !(
+        frame.state === 'KEY_OR_END' ||
+        frame.state === 'COMMA_OR_END'
+      )
+    ) {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+    this.stack.pop();
+    this.callbacks.onContainerEnd(frame.path, frame.kind);
+    this.completeRootContainer();
+  }
+
+  private endArray(): void {
+    const frame = this.stack.at(-1);
+    if (
+      frame?.kind !== 'ARRAY' ||
+      !(
+        frame.state === 'VALUE_OR_END' ||
+        frame.state === 'COMMA_OR_END'
+      )
+    ) {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+    this.stack.pop();
+    this.callbacks.onContainerEnd(frame.path, frame.kind);
+    this.completeRootContainer();
+  }
+
+  private acceptKey(frame: ObjectFrame, key: string): void {
+    if (
+      Buffer.byteLength(key, 'utf8') >
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumKeyBytes
+    ) {
+      throw validationFault('ARTIFACT_JSON_KEY_LIMIT_EXCEEDED');
+    }
+    if (hasUnpairedSurrogate(key)) {
+      throw validationFault('ARTIFACT_INVALID_UTF8');
+    }
+    if (frame.keys.has(key)) {
+      throw validationFault('ARTIFACT_JSON_DUPLICATE_KEY');
+    }
+    if (
+      frame.keys.size >=
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumObjectKeys
+    ) {
+      throw validationFault(
+        'ARTIFACT_JSON_KEY_COUNT_LIMIT_EXCEEDED'
+      );
+    }
+    frame.keys.add(key);
+    frame.currentKey = key;
+    frame.state = 'COLON';
+    this.callbacks.onKey(frame.path, key);
+  }
+
+  private acceptColon(): void {
+    const frame = this.stack.at(-1);
+    if (frame?.kind !== 'OBJECT' || frame.state !== 'COLON') {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+    frame.state = 'VALUE';
+  }
+
+  private acceptComma(): void {
+    const frame = this.stack.at(-1);
+    if (!frame || frame.state !== 'COMMA_OR_END') {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+    if (frame.kind === 'OBJECT') {
+      frame.state = 'KEY';
+      frame.currentKey = undefined;
+    } else {
+      frame.state = 'VALUE';
+    }
+  }
+
+  private acceptPrimitive(value: JsonPrimitive): void {
+    const path = this.startValue(false);
+    if (
+      typeof value === 'number' &&
+      (!Number.isFinite(value) ||
+        Math.abs(value) > Number.MAX_SAFE_INTEGER)
+    ) {
+      this.reasons.add('ARTIFACT_SCHEMA_FIELD_INVALID');
+    }
+    this.callbacks.onPrimitive(path, value);
+  }
+
+  private startValue(container: boolean): JsonPath {
+    const frame = this.stack.at(-1);
+    let path: JsonPath;
+    if (!frame) {
+      if (this.rootState !== 'VALUE') {
+        throw validationFault('ARTIFACT_JSON_MALFORMED');
+      }
+      path = [];
+      this.rootState = container ? 'CONTAINER' : 'END';
+      return path;
+    }
+
+    if (frame.kind === 'OBJECT') {
+      if (frame.state !== 'VALUE' || frame.currentKey === undefined) {
+        throw validationFault('ARTIFACT_JSON_MALFORMED');
+      }
+      path = [...frame.path, frame.currentKey];
+      frame.state = 'COMMA_OR_END';
+    } else {
+      if (
+        frame.state !== 'VALUE_OR_END' &&
+        frame.state !== 'VALUE'
+      ) {
+        throw validationFault('ARTIFACT_JSON_MALFORMED');
+      }
+      path = [...frame.path, frame.nextIndex];
+      frame.nextIndex += 1;
+      frame.state = 'COMMA_OR_END';
+    }
+    return path;
+  }
+
+  private completeRootContainer(): void {
+    if (this.stack.length === 0) {
+      if (this.rootState !== 'CONTAINER') {
+        throw validationFault('ARTIFACT_JSON_MALFORMED');
+      }
+      this.rootState = 'END';
+    }
+  }
+
+  private checkString(value: JsonPrimitive): void {
+    if (typeof value !== 'string') return;
+    const byteLength = Buffer.byteLength(value, 'utf8');
+    this.maximumObservedStringBytes = Math.max(
+      this.maximumObservedStringBytes,
+      byteLength
+    );
+    if (
+      byteLength >
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumStringBytes
+    ) {
+      throw validationFault('ARTIFACT_JSON_STRING_LIMIT_EXCEEDED');
+    }
+    if (hasUnpairedSurrogate(value)) {
+      throw validationFault('ARTIFACT_INVALID_UTF8');
+    }
+  }
+}
+
+class RawJsonTokenLimiter {
+  private offset = 0;
+  private readonly prefix: number[] = [];
+  private inString = false;
+  private escaped = false;
+  private unicodeDigitsRemaining = 0;
+  private rawStringBytes = 0;
+  private inNumber = false;
+  private numberBytes = 0;
+
+  write(bytes: Uint8Array): void {
+    for (const byte of bytes) {
+      if (this.offset < 3) {
+        this.prefix.push(byte);
+        if (
+          this.prefix.length === 3 &&
+          this.prefix[0] === 0xef &&
+          this.prefix[1] === 0xbb &&
+          this.prefix[2] === 0xbf
+        ) {
+          throw validationFault('ARTIFACT_INVALID_UTF8');
+        }
+      }
+      this.offset += 1;
+
+      if (this.inString) {
+        this.rawStringBytes += 1;
+        if (
+          this.rawStringBytes >
+          SAST_ARTIFACT_VALIDATION_LIMITS.maximumStringBytes * 6 + 2
+        ) {
+          throw validationFault('ARTIFACT_JSON_STRING_LIMIT_EXCEEDED');
+        }
+        if (this.unicodeDigitsRemaining > 0) {
+          this.unicodeDigitsRemaining -= 1;
+        } else if (this.escaped) {
+          this.escaped = false;
+          if (byte === 0x75) this.unicodeDigitsRemaining = 4;
+        } else if (byte === 0x5c) {
+          this.escaped = true;
+        } else if (byte === 0x22) {
+          this.inString = false;
+        }
+        continue;
+      }
+
+      if (this.inNumber) {
+        if (isJsonDelimiter(byte)) {
+          this.inNumber = false;
+          this.numberBytes = 0;
+        } else {
+          this.numberBytes += 1;
+          if (
+            this.numberBytes >
+            SAST_ARTIFACT_VALIDATION_LIMITS.maximumNumberTokenBytes
+          ) {
+            throw validationFault('ARTIFACT_JSON_NUMBER_LIMIT_EXCEEDED');
+          }
+          continue;
+        }
+      }
+
+      if (byte === 0x22) {
+        this.inString = true;
+        this.rawStringBytes = 0;
+      } else if (byte === 0x2d || (byte >= 0x30 && byte <= 0x39)) {
+        this.inNumber = true;
+        this.numberBytes = 1;
+      }
+    }
+  }
+
+  end(): void {
+    if (this.inString || this.escaped || this.unicodeDigitsRemaining > 0) {
+      throw validationFault('ARTIFACT_JSON_MALFORMED');
+    }
+  }
+}
+
+class SastArtifactSchemaInspector implements ArtifactValidationCallbacks {
+  private readonly rootKeys = new Set<string>();
+  private readonly runKeys = new Map<string, Set<string>>();
+  private readonly requiredObjects = new Map<string, RequiredObjectState>();
+  private readonly recordStates = new Map<string, RecordState>();
+  private readonly physicalLocations = new Map<string, LocationState>();
+  private readonly trivyTargets = new Map<number, string>();
+  private readonly trivyResultKeys = new Map<number, Set<string>>();
+  private readonly pendingTrivyLocations = new Map<
+    number,
+    LocationState[]
+  >();
+  private readonly exactPathHashes = new Set<string>();
+  private readonly foldedPathHashes = new Map<string, string>();
+  private rootKind?: ContainerKind;
+  private runsSeen = false;
+  private trivyResultsSeen = false;
+  private cyclonedxComponentsSeen = false;
+  private sarifVersionValid = false;
+  private trivyVersionValid = false;
+  private cyclonedxFormatValid = false;
+  private cyclonedxVersionValid = false;
+  private sarifRunCount = 0;
+  recordCount = 0;
+  coordinateCount = 0;
+
+  constructor(
+    private readonly envelope: Readonly<ScannerArtifactEnvelope>,
+    private readonly plan: Readonly<SastScanPlan>,
+    private readonly fileCoordinates:
+      | ReadonlyMap<string, Readonly<SastFileCoordinateMetadata>>
+      | null,
+    private readonly reasons: Set<SastArtifactValidationReasonCode>
+  ) {}
+
+  get normalizedPathCount(): number {
+    return this.exactPathHashes.size;
+  }
+
+  onContainer(path: JsonPath, kind: ContainerKind): void {
+    if (path.length === 0) {
+      this.rootKind = kind;
+      if (kind !== 'OBJECT') this.schemaInvalid();
+      return;
+    }
+    if (
+      this.isRequiredScalarField(path) ||
+      this.isPinnedEnumField(path)
+    ) {
+      this.schemaInvalid();
+    }
+    if (this.isArtifactPathField(path)) {
+      this.reasons.add('ARTIFACT_PATH_INVALID');
+    }
+    if (this.isCoordinateField(path)) {
+      this.coordinateCount += 1;
+      this.reasons.add('ARTIFACT_COORDINATE_INVALID');
+    }
+
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      this.onSarifContainer(path, kind);
+    } else if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      this.onTrivyContainer(path, kind);
+    } else {
+      this.onCycloneDxContainer(path, kind);
+    }
+  }
+
+  onContainerEnd(path: JsonPath, kind: ContainerKind): void {
+    if (kind !== 'OBJECT') return;
+    const pathKey = keyForPath(path);
+    const runKeys = this.runKeys.get(pathKey);
+    if (runKeys) {
+      if (!runKeys.has('tool') || !runKeys.has('results')) {
+        this.requiredFieldMissing();
+      }
+      this.runKeys.delete(pathKey);
+    }
+
+    const requiredObject = this.requiredObjects.get(pathKey);
+    if (requiredObject) {
+      const missing =
+        requiredObject.kind === 'SARIF_TOOL'
+          ? !requiredObject.keys.has('driver')
+          : requiredObject.kind === 'SARIF_DRIVER'
+            ? !requiredObject.keys.has('name')
+            : !requiredObject.keys.has('text') &&
+              !requiredObject.keys.has('id');
+      if (missing) this.requiredFieldMissing();
+      this.requiredObjects.delete(pathKey);
+    }
+
+    const record = this.recordStates.get(pathKey);
+    if (record) {
+      this.validateRecord(record);
+      this.recordStates.delete(pathKey);
+    }
+
+    const location = this.physicalLocations.get(pathKey);
+    if (location) {
+      this.validateLocation(location);
+      this.physicalLocations.delete(pathKey);
+    }
+
+    if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      isTrivyResultPath(path)
+    ) {
+      this.finishTrivyResult(path[1] as number);
+    }
+  }
+
+  onKey(objectPath: JsonPath, key: string): void {
+    if (objectPath.length === 0) {
+      this.rootKeys.add(key);
+      const allowed = this.allowedRootFields();
+      if (!allowed.has(key)) this.unknownField();
+      return;
+    }
+
+    const pathKey = keyForPath(objectPath);
+    this.runKeys.get(pathKey)?.add(key);
+    this.requiredObjects.get(pathKey)?.keys.add(key);
+    this.recordStates.get(pathKey)?.keys.add(key);
+    if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      isTrivyResultPath(objectPath)
+    ) {
+      this.trivyResultKeys.get(objectPath[1] as number)?.add(key);
+    }
+
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      isSarifRunPath(objectPath) &&
+      !SARIF_RUN_FIELDS.has(key)
+    ) {
+      this.unknownField();
+    }
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      isSarifRecordPath(objectPath) &&
+      !SARIF_RESULT_FIELDS.has(key)
+    ) {
+      this.unknownField();
+    }
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      objectPath.at(-1) === 'artifactLocation' &&
+      objectPath.includes('physicalLocation') &&
+      (key === 'uriBaseId' || key === 'index')
+    ) {
+      this.reasons.add('ARTIFACT_PATH_INVALID');
+    }
+    if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      isTrivyResultPath(objectPath) &&
+      !TRIVY_RESULT_FIELDS.has(key)
+    ) {
+      this.unknownField();
+    }
+
+    const trivyKind = trivyRecordKind(objectPath);
+    if (trivyKind && !this.allowedTrivyRecordFields(trivyKind).has(key)) {
+      this.unknownField();
+    }
+    if (
+      this.envelope.artifactSchema === 'CYCLONEDX_JSON' &&
+      isCycloneDxComponentPath(objectPath) &&
+      !CYCLONEDX_COMPONENT_FIELDS.has(key)
+    ) {
+      this.unknownField();
+    }
+  }
+
+  onPrimitive(path: JsonPath, value: JsonPrimitive): void {
+    if (path.length === 0) {
+      this.schemaInvalid();
+      return;
+    }
+    if (this.isRequiredContainerField(path)) this.schemaInvalid();
+    this.captureSchemaVersion(path, value);
+    this.capturePinnedEnum(path, value);
+
+    if (this.isArtifactPathField(path)) {
+      this.capturePath(path, value);
+    }
+    if (this.isCoordinateField(path)) {
+      this.captureCoordinate(path, value);
+    }
+    if (this.isRecordPath(path)) {
+      this.recordCount += 1;
+      this.schemaInvalid();
+    }
+    this.captureRequiredScalar(path, value);
+  }
+
+  finish(): void {
+    if (this.rootKind !== 'OBJECT') {
+      this.schemaInvalid();
+      return;
+    }
+
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      if (
+        !this.rootKeys.has('version') ||
+        !this.rootKeys.has('runs') ||
+        !this.runsSeen ||
+        this.sarifRunCount === 0 ||
+        !this.sarifVersionValid
+      ) {
+        this.requiredFieldMissing();
+      }
+    } else if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      if (
+        !this.rootKeys.has('SchemaVersion') ||
+        !this.rootKeys.has('Results') ||
+        !this.trivyResultsSeen ||
+        !this.trivyVersionValid
+      ) {
+        this.requiredFieldMissing();
+      }
+    } else if (
+      !this.rootKeys.has('bomFormat') ||
+      !this.rootKeys.has('specVersion') ||
+      !this.rootKeys.has('version') ||
+      !this.rootKeys.has('components') ||
+      !this.cyclonedxComponentsSeen ||
+      !this.cyclonedxFormatValid ||
+      !this.cyclonedxVersionValid
+    ) {
+      this.requiredFieldMissing();
+    }
+  }
+
+  private onSarifContainer(path: JsonPath, kind: ContainerKind): void {
+    if (matchesPath(path, ['runs'])) {
+      this.runsSeen = kind === 'ARRAY';
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (isSarifRunPath(path)) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.sarifRunCount += 1;
+        this.runKeys.set(keyForPath(path), new Set());
+      }
+    } else if (matchesPath(path, ['runs', '*', 'tool'])) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.requiredObjects.set(keyForPath(path), {
+          kind: 'SARIF_TOOL',
+          keys: new Set()
+        });
+      }
+    } else if (
+      matchesPath(path, ['runs', '*', 'tool', 'driver'])
+    ) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.requiredObjects.set(keyForPath(path), {
+          kind: 'SARIF_DRIVER',
+          keys: new Set()
+        });
+      }
+    } else if (matchesPath(path, ['runs', '*', 'results'])) {
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (isSarifRecordPath(path)) {
+      this.startRecord(path, kind, 'SARIF_RESULT');
+    } else if (
+      matchesPath(path, ['runs', '*', 'results', '*', 'message'])
+    ) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.requiredObjects.set(keyForPath(path), {
+          kind: 'SARIF_RESULT_MESSAGE',
+          keys: new Set()
+        });
+      }
+    } else if (
+      matchesPath(path, ['runs', '*', 'results', '*', 'locations'])
+    ) {
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (endsWithPath(path, ['physicalLocation'])) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.physicalLocations.set(keyForPath(path), {});
+      }
+    }
+  }
+
+  private onTrivyContainer(path: JsonPath, kind: ContainerKind): void {
+    if (matchesPath(path, ['Results'])) {
+      this.trivyResultsSeen = kind === 'ARRAY';
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (isTrivyResultPath(path)) {
+      if (kind !== 'OBJECT') {
+        this.schemaInvalid();
+      } else {
+        this.trivyResultKeys.set(path[1] as number, new Set());
+      }
+    } else if (isTrivyRecordArrayPath(path)) {
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else {
+      const recordKind = trivyRecordKind(path);
+      if (recordKind) this.startRecord(path, kind, recordKind);
+    }
+  }
+
+  private onCycloneDxContainer(path: JsonPath, kind: ContainerKind): void {
+    if (matchesPath(path, ['components'])) {
+      this.cyclonedxComponentsSeen = kind === 'ARRAY';
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (isCycloneDxComponentArrayPath(path)) {
+      if (kind !== 'ARRAY') this.schemaInvalid();
+    } else if (isCycloneDxComponentPath(path)) {
+      this.startRecord(path, kind, 'CYCLONEDX_COMPONENT');
+    }
+  }
+
+  private startRecord(
+    path: JsonPath,
+    kind: ContainerKind,
+    recordKind: string
+  ): void {
+    this.recordCount += 1;
+    if (this.recordCount > this.maximumRecordCount()) {
+      this.reasons.add('ARTIFACT_RECORD_LIMIT_EXCEEDED');
+      return;
+    }
+    if (kind !== 'OBJECT') {
+      this.schemaInvalid();
+      return;
+    }
+    this.recordStates.set(keyForPath(path), {
+      kind: recordKind,
+      keys: new Set(),
+      ...(recordKind.startsWith('TRIVY_') &&
+      typeof path[1] === 'number'
+        ? { trivyResultIndex: path[1] }
+        : {})
+    });
+  }
+
+  private captureSchemaVersion(path: JsonPath, value: JsonPrimitive): void {
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      matchesPath(path, ['version'])
+    ) {
+      this.sarifVersionValid =
+        value === SAST_ARTIFACT_SCHEMA_VERSIONS.OPENGREP_SARIF;
+      if (!this.sarifVersionValid) this.schemaInvalid();
+    } else if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      matchesPath(path, ['SchemaVersion'])
+    ) {
+      this.trivyVersionValid =
+        value === Number(SAST_ARTIFACT_SCHEMA_VERSIONS.TRIVY_JSON);
+      if (!this.trivyVersionValid) this.schemaInvalid();
+    } else if (
+      this.envelope.artifactSchema === 'CYCLONEDX_JSON' &&
+      matchesPath(path, ['bomFormat'])
+    ) {
+      this.cyclonedxFormatValid = value === 'CycloneDX';
+      if (!this.cyclonedxFormatValid) this.schemaInvalid();
+    } else if (
+      this.envelope.artifactSchema === 'CYCLONEDX_JSON' &&
+      matchesPath(path, ['specVersion'])
+    ) {
+      this.cyclonedxVersionValid =
+        value === SAST_ARTIFACT_SCHEMA_VERSIONS.CYCLONEDX_JSON;
+      if (!this.cyclonedxVersionValid) this.schemaInvalid();
+    } else if (
+      this.envelope.artifactSchema === 'CYCLONEDX_JSON' &&
+      matchesPath(path, ['version']) &&
+      (!Number.isSafeInteger(value) || (value as number) <= 0)
+    ) {
+      this.schemaInvalid();
+    }
+  }
+
+  private capturePinnedEnum(
+    path: JsonPath,
+    value: JsonPrimitive
+  ): void {
+    const allowed = this.pinnedEnumValues(path);
+    if (
+      allowed &&
+      (typeof value !== 'string' || !allowed.has(value))
+    ) {
+      this.schemaInvalid();
+    }
+  }
+
+  private pinnedEnumValues(path: JsonPath): ReadonlySet<string> | null {
+    const key = path.at(-1);
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      matchesPath(path, ['runs', '*', 'columnKind'])
+    ) {
+      return SARIF_COLUMN_KINDS;
+    }
+    if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      matchesPath(path, ['Results', '*', 'Class'])
+    ) {
+      return TRIVY_RESULT_CLASSES;
+    }
+    const record = this.recordStates.get(
+      keyForPath(path.slice(0, -1))
+    );
+    if (record?.kind === 'SARIF_RESULT') {
+      if (key === 'kind') return SARIF_RESULT_KINDS;
+      if (key === 'level') return SARIF_LEVELS;
+      if (key === 'baselineState') return SARIF_BASELINE_STATES;
+    }
+    if (record?.kind === 'CYCLONEDX_COMPONENT') {
+      if (key === 'type') return CYCLONEDX_COMPONENT_TYPES;
+      if (key === 'scope') return CYCLONEDX_COMPONENT_SCOPES;
+    }
+    if (record?.kind.startsWith('TRIVY_')) {
+      if (key === 'Severity') return TRIVY_SEVERITIES;
+      if (
+        record.kind === 'TRIVY_VULNERABILITY' &&
+        key === 'Status'
+      ) {
+        return TRIVY_VULNERABILITY_STATUSES;
+      }
+      if (
+        record.kind === 'TRIVY_MISCONFIGURATION' &&
+        key === 'Status'
+      ) {
+        return TRIVY_MISCONFIGURATION_STATUSES;
+      }
+    }
+    return null;
+  }
+
+  private captureRequiredScalar(
+    path: JsonPath,
+    value: JsonPrimitive
+  ): void {
+    if (
+      this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+      (matchesPath(path, ['runs', '*', 'tool', 'driver', 'name']) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'message',
+          'text'
+        ]) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'message',
+          'id'
+        ])) &&
+      typeof value !== 'string'
+    ) {
+      this.schemaInvalid();
+    }
+
+    if (
+      this.envelope.artifactSchema === 'TRIVY_JSON' &&
+      matchesPath(path, ['Results', '*', 'Target'])
+    ) {
+      if (typeof value !== 'string') {
+        this.schemaInvalid();
+      } else if (value === '.') {
+        this.trivyTargets.delete(path[1] as number);
+      } else {
+        const normalized = this.validatePath(value);
+        if (normalized) this.trivyTargets.set(path[1] as number, normalized);
+      }
+    }
+
+    const recordPath = path.slice(0, -1);
+    const record = this.recordStates.get(keyForPath(recordPath));
+    if (!record) return;
+    const key = path.at(-1);
+    if (
+      (record.kind === 'SARIF_RESULT' && key === 'ruleId') ||
+      (record.kind === 'TRIVY_VULNERABILITY' &&
+        (key === 'VulnerabilityID' || key === 'PkgName')) ||
+      (record.kind === 'TRIVY_MISCONFIGURATION' &&
+        (key === 'ID' || key === 'Title')) ||
+      (record.kind === 'TRIVY_SECRET' &&
+        (key === 'RuleID' || key === 'Title')) ||
+      (record.kind === 'CYCLONEDX_COMPONENT' &&
+        (key === 'type' || key === 'name'))
+    ) {
+      if (
+        typeof value !== 'string' ||
+        value.length === 0 ||
+        value !== value.trim()
+      ) {
+        this.schemaInvalid();
+      }
+    }
+  }
+
+  private capturePath(path: JsonPath, value: JsonPrimitive): void {
+    if (typeof value !== 'string') {
+      this.reasons.add('ARTIFACT_PATH_INVALID');
+      return;
+    }
+    const pathValue =
+      this.envelope.artifactSchema === 'OPENGREP_SARIF'
+        ? decodeSarifArtifactUri(value)
+        : value;
+    if (!pathValue) {
+      this.reasons.add('ARTIFACT_PATH_INVALID');
+      return;
+    }
+    const normalized = this.validatePath(pathValue);
+    if (!normalized) return;
+
+    const physicalPath = path.slice(
+      0,
+      path.lastIndexOf('physicalLocation') + 1
+    );
+    const physical = this.physicalLocations.get(keyForPath(physicalPath));
+    if (physical) {
+      physical.path = normalized;
+      return;
+    }
+
+    const record = this.findRecordState(path);
+    if (record) {
+      record.path = normalized;
+    } else {
+      this.validateLocation({ path: normalized });
+    }
+  }
+
+  private captureCoordinate(path: JsonPath, value: JsonPrimitive): void {
+    this.coordinateCount += 1;
+    const coordinateName = path.at(-1);
+    if (
+      typeof coordinateName !== 'string' ||
+      typeof value !== 'number' ||
+      !Number.isSafeInteger(value) ||
+      value <= 0 ||
+      value > SAST_MAX_COORDINATE_VALUE
+    ) {
+      this.reasons.add('ARTIFACT_COORDINATE_INVALID');
+      return;
+    }
+
+    const location =
+      this.findPhysicalLocation(path) ?? this.findRecordState(path);
+    if (!location) {
+      this.reasons.add('ARTIFACT_COORDINATE_ATTESTATION_MISSING');
+      return;
+    }
+    if (isLineStartKey(coordinateName)) location.lineStart = value;
+    else if (isLineEndKey(coordinateName)) location.lineEnd = value;
+    else if (isColumnStartKey(coordinateName)) {
+      location.columnStart = value;
+    } else if (isColumnEndKey(coordinateName)) {
+      location.columnEnd = value;
+    }
+  }
+
+  private validateRecord(record: RecordState): void {
+    const required =
+      record.kind === 'SARIF_RESULT'
+        ? ['ruleId', 'message']
+        : record.kind === 'TRIVY_VULNERABILITY'
+          ? ['VulnerabilityID', 'PkgName']
+          : record.kind === 'TRIVY_MISCONFIGURATION'
+            ? ['ID', 'Title']
+            : record.kind === 'TRIVY_SECRET'
+              ? ['RuleID', 'Title', 'StartLine', 'EndLine']
+              : ['type', 'name'];
+    if (required.some((key) => !record.keys.has(key))) {
+      this.requiredFieldMissing();
+    }
+
+    if (record.kind.startsWith('TRIVY_')) {
+      const target = this.currentTrivyTarget(record);
+      if (!record.path && target) record.path = target;
+      if (
+        !record.path &&
+        record.trivyResultIndex !== undefined &&
+        !this.trivyResultKeys
+          .get(record.trivyResultIndex)
+          ?.has('Target')
+      ) {
+        const pending =
+          this.pendingTrivyLocations.get(record.trivyResultIndex) ?? [];
+        pending.push({
+          ...(record.lineStart === undefined
+            ? {}
+            : { lineStart: record.lineStart }),
+          ...(record.lineEnd === undefined
+            ? {}
+            : { lineEnd: record.lineEnd }),
+          ...(record.columnStart === undefined
+            ? {}
+            : { columnStart: record.columnStart }),
+          ...(record.columnEnd === undefined
+            ? {}
+            : { columnEnd: record.columnEnd })
+        });
+        this.pendingTrivyLocations.set(
+          record.trivyResultIndex,
+          pending
+        );
+        return;
+      }
+    }
+    if (
+      record.path ||
+      record.lineStart ||
+      record.lineEnd ||
+      record.columnStart ||
+      record.columnEnd
+    ) {
+      this.validateLocation(record);
+    }
+  }
+
+  private currentTrivyTarget(record: RecordState): string | undefined {
+    return record.trivyResultIndex === undefined
+      ? undefined
+      : this.trivyTargets.get(record.trivyResultIndex);
+  }
+
+  private finishTrivyResult(resultIndex: number): void {
+    const keys = this.trivyResultKeys.get(resultIndex);
+    if (!keys?.has('Target')) this.requiredFieldMissing();
+
+    const target = this.trivyTargets.get(resultIndex);
+    if (target) this.validateLocation({ path: target });
+    for (const pending of this.pendingTrivyLocations.get(resultIndex) ??
+      []) {
+      if (target) pending.path = target;
+      if (
+        pending.path ||
+        pending.lineStart ||
+        pending.lineEnd ||
+        pending.columnStart ||
+        pending.columnEnd
+      ) {
+        this.validateLocation(pending);
+      }
+    }
+    this.pendingTrivyLocations.delete(resultIndex);
+    this.trivyResultKeys.delete(resultIndex);
+    this.trivyTargets.delete(resultIndex);
+  }
+
+  private maximumRecordCount(): number {
+    return this.envelope.artifactSchema === 'CYCLONEDX_JSON'
+      ? this.plan.profile.limits.maxArtifactRecords
+      : Math.min(
+          this.plan.profile.limits.maxArtifactRecords,
+          this.plan.profile.limits.maxFindings
+        );
+  }
+
+  private validateLocation(location: LocationState): void {
+    if (!location.path || !this.fileCoordinates) {
+      this.reasons.add('ARTIFACT_COORDINATE_ATTESTATION_MISSING');
+      return;
+    }
+    const metadata = this.fileCoordinates.get(location.path);
+    if (!metadata) {
+      this.reasons.add('ARTIFACT_COORDINATE_ATTESTATION_MISSING');
+      return;
+    }
+    if (
+      location.lineStart === undefined &&
+      location.lineEnd === undefined &&
+      location.columnStart === undefined &&
+      location.columnEnd === undefined
+    ) {
+      return;
+    }
+    if (
+      location.lineStart === undefined ||
+      !isSastFindingLocationValid(
+        {
+          kind: 'FILE',
+          normalizedPath: location.path,
+          lineStart: location.lineStart,
+          ...(location.lineEnd === undefined
+            ? {}
+            : { lineEnd: location.lineEnd }),
+          ...(location.columnStart === undefined
+            ? {}
+            : { columnStart: location.columnStart }),
+          ...(location.columnEnd === undefined
+            ? {}
+            : { columnEnd: location.columnEnd })
+        },
+        metadata
+      )
+    ) {
+      this.reasons.add('ARTIFACT_COORDINATE_INVALID');
+    }
+  }
+
+  private validatePath(value: string): string | null {
+    const normalized = normalizeArtifactPath(
+      value,
+      this.plan.profile.limits.maxPathDepth
+    );
+    if (!normalized || normalized !== value) {
+      this.reasons.add('ARTIFACT_PATH_INVALID');
+      return null;
+    }
+
+    const exactHash = digest(normalized);
+    const foldedHash = digest(
+      normalized.toLocaleLowerCase('en-US').normalize('NFC')
+    );
+    if (
+      !this.exactPathHashes.has(exactHash) &&
+      this.exactPathHashes.size >=
+        Math.min(
+          this.plan.profile.limits.maxFileCount,
+          this.plan.profile.limits.maxArtifactRecords
+        )
+    ) {
+      this.reasons.add('ARTIFACT_PATH_LIMIT_EXCEEDED');
+      return null;
+    }
+    const previous = this.foldedPathHashes.get(foldedHash);
+    if (previous && previous !== exactHash) {
+      this.reasons.add('ARTIFACT_PATH_COLLISION');
+    }
+    this.foldedPathHashes.set(foldedHash, exactHash);
+    this.exactPathHashes.add(exactHash);
+    return normalized;
+  }
+
+  private findPhysicalLocation(path: JsonPath): LocationState | undefined {
+    const index = path.lastIndexOf('physicalLocation');
+    return index < 0
+      ? undefined
+      : this.physicalLocations.get(
+          keyForPath(path.slice(0, index + 1))
+        );
+  }
+
+  private findRecordState(path: JsonPath): RecordState | undefined {
+    for (let length = path.length - 1; length > 0; length -= 1) {
+      const record = this.recordStates.get(
+        keyForPath(path.slice(0, length))
+      );
+      if (record) return record;
+    }
+    return undefined;
+  }
+
+  private isArtifactPathField(path: JsonPath): boolean {
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      return (
+        path.at(-1) === 'uri' &&
+        path.includes('artifactLocation') &&
+        path.includes('physicalLocation')
+      );
+    }
+    if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      return ['PkgPath', 'FilePath'].includes(
+        String(path.at(-1))
+      );
+    }
+    return false;
+  }
+
+  private isCoordinateField(path: JsonPath): boolean {
+    const key = String(path.at(-1));
+    const coordinateKey =
+      isLineStartKey(key) ||
+      isLineEndKey(key) ||
+      isColumnStartKey(key) ||
+      isColumnEndKey(key);
+    if (!coordinateKey) return false;
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      return (
+        path.includes('physicalLocation') &&
+        path.includes('region') &&
+        (key === 'startLine' ||
+          key === 'endLine' ||
+          key === 'startColumn' ||
+          key === 'endColumn')
+      );
+    }
+    if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      const recordPath = path.slice(0, 4);
+      const recordKind = trivyRecordKind(recordPath);
+      if (!recordKind) return false;
+      return (
+        recordKind === 'TRIVY_SECRET' ||
+        path.includes('CauseMetadata')
+      );
+    }
+    return false;
+  }
+
+  private isPinnedEnumField(path: JsonPath): boolean {
+    return this.pinnedEnumValues(path) !== null;
+  }
+
+  private isRequiredScalarField(path: JsonPath): boolean {
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      return (
+        matchesPath(path, ['version']) ||
+        matchesPath(path, ['runs', '*', 'tool', 'driver', 'name']) ||
+        matchesPath(path, ['runs', '*', 'results', '*', 'ruleId']) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'message',
+          'text'
+        ]) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'message',
+          'id'
+        ])
+      );
+    }
+    if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      if (
+        matchesPath(path, ['SchemaVersion']) ||
+        matchesPath(path, ['Results', '*', 'Target'])
+      ) {
+        return true;
+      }
+      const record = this.findRecordState(path);
+      const key = path.at(-1);
+      return Boolean(
+        record &&
+          ((record.kind === 'TRIVY_VULNERABILITY' &&
+            (key === 'VulnerabilityID' || key === 'PkgName')) ||
+            (record.kind === 'TRIVY_MISCONFIGURATION' &&
+              (key === 'ID' || key === 'Title')) ||
+            (record.kind === 'TRIVY_SECRET' &&
+              (key === 'RuleID' || key === 'Title')))
+      );
+    }
+    const component = this.findRecordState(path);
+    return (
+      matchesPath(path, ['bomFormat']) ||
+      matchesPath(path, ['specVersion']) ||
+      matchesPath(path, ['version']) ||
+      Boolean(
+        component?.kind === 'CYCLONEDX_COMPONENT' &&
+          (path.at(-1) === 'type' || path.at(-1) === 'name')
+      )
+    );
+  }
+
+  private isRequiredContainerField(path: JsonPath): boolean {
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      return (
+        matchesPath(path, ['runs']) ||
+        isSarifRunPath(path) ||
+        matchesPath(path, ['runs', '*', 'tool']) ||
+        matchesPath(path, ['runs', '*', 'tool', 'driver']) ||
+        matchesPath(path, ['runs', '*', 'results']) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'message'
+        ]) ||
+        matchesPath(path, [
+          'runs',
+          '*',
+          'results',
+          '*',
+          'locations'
+        ])
+      );
+    }
+    if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      return (
+        matchesPath(path, ['Results']) ||
+        isTrivyResultPath(path) ||
+        isTrivyRecordArrayPath(path)
+      );
+    }
+    return isCycloneDxComponentArrayPath(path);
+  }
+
+  private isRecordPath(path: JsonPath): boolean {
+    return (
+      (this.envelope.artifactSchema === 'OPENGREP_SARIF' &&
+        isSarifRecordPath(path)) ||
+      (this.envelope.artifactSchema === 'TRIVY_JSON' &&
+        trivyRecordKind(path) !== null) ||
+      (this.envelope.artifactSchema === 'CYCLONEDX_JSON' &&
+        isCycloneDxComponentPath(path))
+    );
+  }
+
+  private allowedRootFields(): ReadonlySet<string> {
+    if (this.envelope.artifactSchema === 'OPENGREP_SARIF') {
+      return SARIF_ROOT_FIELDS;
+    }
+    if (this.envelope.artifactSchema === 'TRIVY_JSON') {
+      return TRIVY_ROOT_FIELDS;
+    }
+    return CYCLONEDX_ROOT_FIELDS;
+  }
+
+  private allowedTrivyRecordFields(kind: string): ReadonlySet<string> {
+    if (kind === 'TRIVY_VULNERABILITY') {
+      return TRIVY_VULNERABILITY_FIELDS;
+    }
+    if (kind === 'TRIVY_MISCONFIGURATION') {
+      return TRIVY_MISCONFIGURATION_FIELDS;
+    }
+    return TRIVY_SECRET_FIELDS;
+  }
+
+  private requiredFieldMissing(): void {
+    this.reasons.add('ARTIFACT_SCHEMA_REQUIRED_FIELD_MISSING');
+  }
+
+  private unknownField(): void {
+    this.reasons.add('ARTIFACT_SCHEMA_UNKNOWN_FIELD');
+  }
+
+  private schemaInvalid(): void {
+    this.reasons.add('ARTIFACT_SCHEMA_FIELD_INVALID');
+  }
+}
+
+function decodeSarifArtifactUri(value: string): string | null {
+  if (
+    value.includes('?') ||
+    value.includes('#') ||
+    /%(?:2F|5C)/u.test(value) ||
+    /%(?:3[0-9]|[46][1-9A-F]|5[0-9A]|7[0-9A])/u.test(value) ||
+    /%(?:2D|2E|5F|7E)/u.test(value)
+  ) {
+    return null;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== '%') continue;
+    if (!/^[0-9A-F]{2}$/u.test(value.slice(index + 1, index + 3))) {
+      return null;
+    }
+    index += 2;
+  }
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeArtifactPath(
+  value: unknown,
+  maximumDepth: number
+): string | null {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value !== value.normalize('NFC') ||
+    Buffer.byteLength(value, 'utf8') > 1024 ||
+    value.includes('\\') ||
+    value.startsWith('/') ||
+    value.startsWith('//') ||
+    /^[A-Za-z]:/u.test(value) ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/u.test(value) ||
+    [...value].some((character) => {
+      const codePoint = character.codePointAt(0)!;
+      return codePoint <= 31 || codePoint === 127;
+    })
+  ) {
+    return null;
+  }
+  const segments = value.split('/');
+  if (
+    segments.length > maximumDepth ||
+    segments.some(
+      (segment) =>
+        segment.length === 0 || segment === '.' || segment === '..'
+    )
+  ) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function isSarifRunPath(path: JsonPath): boolean {
+  return matchesPath(path, ['runs', '*']);
+}
+
+function isSarifRecordPath(path: JsonPath): boolean {
+  return matchesPath(path, ['runs', '*', 'results', '*']);
+}
+
+function isTrivyResultPath(path: JsonPath): boolean {
+  return matchesPath(path, ['Results', '*']);
+}
+
+function isTrivyRecordArrayPath(path: JsonPath): boolean {
+  return (
+    matchesPath(path, ['Results', '*', '*']) &&
+    TRIVY_RECORD_ARRAYS.has(String(path[2]))
+  );
+}
+
+function trivyRecordKind(path: JsonPath): string | null {
+  if (
+    path.length !== 4 ||
+    path[0] !== 'Results' ||
+    typeof path[1] !== 'number' ||
+    typeof path[3] !== 'number'
+  ) {
+    return null;
+  }
+  return path[2] === 'Vulnerabilities'
+    ? 'TRIVY_VULNERABILITY'
+    : path[2] === 'Misconfigurations'
+      ? 'TRIVY_MISCONFIGURATION'
+      : path[2] === 'Secrets'
+        ? 'TRIVY_SECRET'
+        : null;
+}
+
+function isCycloneDxComponentArrayPath(path: JsonPath): boolean {
+  return path.at(-1) === 'components';
+}
+
+function isCycloneDxComponentPath(path: JsonPath): boolean {
+  return (
+    path.length >= 2 &&
+    path.at(-2) === 'components' &&
+    typeof path.at(-1) === 'number'
+  );
+}
+
+function matchesPath(
+  path: JsonPath,
+  pattern: readonly (string | '*')[]
+): boolean {
+  return (
+    path.length === pattern.length &&
+    pattern.every(
+      (segment, index) =>
+        segment === '*' || path[index] === segment
+    )
+  );
+}
+
+function endsWithPath(
+  path: JsonPath,
+  suffix: readonly string[]
+): boolean {
+  return (
+    suffix.length <= path.length &&
+    suffix.every(
+      (segment, index) =>
+        path[path.length - suffix.length + index] === segment
+    )
+  );
+}
+
+function keyForPath(path: JsonPath): string {
+  return JSON.stringify(path);
+}
+
+function hasOnlyObjectKeys(
+  value: object,
+  expected: readonly string[]
+): boolean {
+  const keys = Object.keys(value);
+  return (
+    keys.length === expected.length &&
+    keys.every((key) => expected.includes(key))
+  );
+}
+
+function isLineStartKey(key: string): boolean {
+  return key === 'startLine' || key === 'StartLine';
+}
+
+function isLineEndKey(key: string): boolean {
+  return key === 'endLine' || key === 'EndLine';
+}
+
+function isColumnStartKey(key: string): boolean {
+  return key === 'startColumn' || key === 'StartColumn';
+}
+
+function isColumnEndKey(key: string): boolean {
+  return key === 'endColumn' || key === 'EndColumn';
+}
+
+function isJsonDelimiter(byte: number): boolean {
+  return (
+    byte === 0x20 ||
+    byte === 0x09 ||
+    byte === 0x0a ||
+    byte === 0x0d ||
+    byte === 0x2c ||
+    byte === 0x5d ||
+    byte === 0x7d
+  );
+}
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function validationFault(
+  reasonCode: SastArtifactValidationReasonCode
+): ArtifactValidationFault {
+  const error = new Error(reasonCode) as ArtifactValidationFault;
+  error.name = 'ArtifactValidationFault';
+  error.reasonCode = reasonCode;
+  return error;
+}
+
+function isValidationFault(
+  error: unknown
+): error is ArtifactValidationFault {
+  return (
+    error instanceof Error &&
+    'reasonCode' in error &&
+    SAST_ARTIFACT_VALIDATION_REASON_CODES.includes(
+      (error as ArtifactValidationFault).reasonCode
+    )
+  );
+}
+
+function digest(value: string): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}

--- a/apps/api/src/scan-plane/sast-artifact-stream-validator.ts
+++ b/apps/api/src/scan-plane/sast-artifact-stream-validator.ts
@@ -637,39 +637,41 @@ export class SastArtifactStreamValidationSession {
       const foldedPath = normalizedPath
         ?.toLocaleLowerCase('en-US')
         .normalize('NFC');
+      const lineCount = file.lineCount;
       if (
         !normalizedPath ||
         normalizedPath !== file.normalizedPath ||
         !foldedPath ||
         foldedPaths.has(foldedPath) ||
-        typeof file.lineCount !== 'number' ||
-        !Number.isSafeInteger(file.lineCount) ||
-        file.lineCount <= 0 ||
-        file.lineCount > SAST_MAX_COORDINATE_VALUE ||
+        typeof lineCount !== 'number' ||
+        !Number.isSafeInteger(lineCount) ||
+        lineCount <= 0 ||
+        lineCount > SAST_MAX_COORDINATE_VALUE ||
+        lineCount >
+          SAST_ARTIFACT_VALIDATION_LIMITS.maximumCoordinateAttestationLines -
+            totalLineCount ||
+        coordinates.has(normalizedPath)
+      ) {
+        return null;
+      }
+      if (
         !Array.isArray(file.maxColumnByLine) ||
-        file.maxColumnByLine.length !== file.lineCount ||
+        file.maxColumnByLine.length !== lineCount ||
         !file.maxColumnByLine.every(
           (column: unknown) =>
             typeof column === 'number' &&
             Number.isSafeInteger(column) &&
             column > 0 &&
             column <= SAST_MAX_COORDINATE_VALUE
-        ) ||
-        coordinates.has(normalizedPath)
+        )
       ) {
         return null;
       }
-      totalLineCount += file.lineCount;
-      if (
-        totalLineCount >
-        SAST_ARTIFACT_VALIDATION_LIMITS.maximumCoordinateAttestationLines
-      ) {
-        return null;
-      }
+      totalLineCount += lineCount;
       foldedPaths.add(foldedPath);
       coordinates.set(normalizedPath, {
         normalizedPath,
-        lineCount: file.lineCount,
+        lineCount,
         maxColumnByLine: file.maxColumnByLine
       });
     }

--- a/apps/api/src/scan-plane/sast-artifact-validation.service.ts
+++ b/apps/api/src/scan-plane/sast-artifact-validation.service.ts
@@ -1,0 +1,72 @@
+import type {
+  ExpectedScannerArtifactBinding,
+  ScannerArtifactEnvelope
+} from '@aegisai/shared';
+import { Injectable } from '@nestjs/common';
+
+import type { SastArtifactIngressExpectedBinding } from './sast-artifact-ingress.store';
+import {
+  SastArtifactStreamValidationSession,
+  type SastArtifactStreamValidationInput
+} from './sast-artifact-stream-validator';
+import { SastFileCoordinateAttestationProvider } from './sast-file-coordinate-attestation.provider';
+
+export interface CreateSastArtifactValidationSessionInput {
+  envelope: Readonly<ScannerArtifactEnvelope>;
+  envelopeDigest: `sha256:${string}`;
+  expected: Readonly<SastArtifactIngressExpectedBinding>;
+}
+
+@Injectable()
+export class SastArtifactValidationService {
+  constructor(
+    private readonly coordinateAttestations:
+      SastFileCoordinateAttestationProvider
+  ) {}
+
+  async createSession(
+    input: Readonly<CreateSastArtifactValidationSessionInput>
+  ): Promise<SastArtifactStreamValidationSession> {
+    const expectedBinding: ExpectedScannerArtifactBinding = {
+      attemptId: input.expected.attemptId,
+      scannerRunId: input.expected.scannerRunId,
+      scanner: input.expected.scanner,
+      artifactRef: input.expected.artifactRef,
+      workloadIdentityRef: input.expected.workloadIdentityRef,
+      preflightAttestationRef:
+        input.expected.preflightAttestationRef,
+      preflightInventoryDigest:
+        input.expected.preflightInventoryDigest
+    };
+    const coordinateAttestation =
+      await this.loadCoordinateAttestation(input.expected);
+    const validationInput: SastArtifactStreamValidationInput = {
+      envelope: input.envelope,
+      plan: input.expected.plan,
+      expectedBinding,
+      envelopeDigest: input.envelopeDigest,
+      coordinateAttestation
+    };
+    return new SastArtifactStreamValidationSession(validationInput);
+  }
+
+  private async loadCoordinateAttestation(
+    expected: Readonly<SastArtifactIngressExpectedBinding>
+  ) {
+    try {
+      return await this.coordinateAttestations.load({
+        tenantId: expected.plan.tenantId,
+        repositoryBindingId:
+          expected.plan.repositoryState.repositoryBindingId,
+        scanRequestId: expected.plan.scanRequestId,
+        attemptId: expected.attemptId,
+        preflightAttestationRef: expected.preflightAttestationRef,
+        preflightInventoryDigest:
+          expected.preflightInventoryDigest
+      });
+    } catch {
+      // A missing or unavailable attestation never relaxes coordinate checks.
+      return null;
+    }
+  }
+}

--- a/apps/api/src/scan-plane/sast-artifact-validation.service.ts
+++ b/apps/api/src/scan-plane/sast-artifact-validation.service.ts
@@ -2,7 +2,7 @@ import type {
   ExpectedScannerArtifactBinding,
   ScannerArtifactEnvelope
 } from '@aegisai/shared';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import type { SastArtifactIngressExpectedBinding } from './sast-artifact-ingress.store';
 import {
@@ -19,6 +19,8 @@ export interface CreateSastArtifactValidationSessionInput {
 
 @Injectable()
 export class SastArtifactValidationService {
+  private readonly logger = new Logger(SastArtifactValidationService.name);
+
   constructor(
     private readonly coordinateAttestations:
       SastFileCoordinateAttestationProvider
@@ -65,6 +67,9 @@ export class SastArtifactValidationService {
           expected.preflightInventoryDigest
       });
     } catch {
+      this.logger.warn(
+        'Coordinate attestation provider call failed; validation remains fail closed.'
+      );
       // A missing or unavailable attestation never relaxes coordinate checks.
       return null;
     }

--- a/apps/api/src/scan-plane/sast-file-coordinate-attestation.provider.ts
+++ b/apps/api/src/scan-plane/sast-file-coordinate-attestation.provider.ts
@@ -1,0 +1,39 @@
+import type { SastFileCoordinateMetadata } from '@aegisai/shared';
+import { Injectable } from '@nestjs/common';
+
+export interface SastFileCoordinateAttestationRequest {
+  tenantId: string;
+  repositoryBindingId: string;
+  scanRequestId: string;
+  attemptId: string;
+  preflightAttestationRef: string;
+  preflightInventoryDigest: `sha256:${string}`;
+}
+
+export interface SastFileCoordinateAttestation {
+  attestationRef: string;
+  inventoryDigest: `sha256:${string}`;
+  verified: true;
+  files: readonly Readonly<SastFileCoordinateMetadata>[];
+}
+
+export abstract class SastFileCoordinateAttestationProvider {
+  /**
+   * Returns only provisioner-attested metadata for the exact tenant and attempt.
+   * Implementations must not return source bytes or accept caller-supplied paths.
+   * They must apply the shared file and aggregate-line caps before materializing
+   * the result so provider memory use remains bounded.
+   */
+  abstract load(
+    input: Readonly<SastFileCoordinateAttestationRequest>
+  ): Promise<Readonly<SastFileCoordinateAttestation> | null>;
+}
+
+@Injectable()
+export class UnavailableSastFileCoordinateAttestationProvider
+  extends SastFileCoordinateAttestationProvider
+{
+  load(): Promise<null> {
+    return Promise.resolve(null);
+  }
+}

--- a/apps/api/src/scan-plane/scan-plane.module.ts
+++ b/apps/api/src/scan-plane/scan-plane.module.ts
@@ -16,6 +16,11 @@ import {
   SastArtifactObjectStore,
   UnavailableSastArtifactObjectStore
 } from './sast-artifact-object-store';
+import { SastArtifactValidationService } from './sast-artifact-validation.service';
+import {
+  SastFileCoordinateAttestationProvider,
+  UnavailableSastFileCoordinateAttestationProvider
+} from './sast-file-coordinate-attestation.provider';
 import {
   DirectMtlsSastWorkloadIdentityAuthenticator,
   SastWorkloadIdentityAuthenticator
@@ -63,6 +68,12 @@ import {
   providers: [
     ScanPlaneService,
     SastArtifactIngressService,
+    SastArtifactValidationService,
+    UnavailableSastFileCoordinateAttestationProvider,
+    {
+      provide: SastFileCoordinateAttestationProvider,
+      useExisting: UnavailableSastFileCoordinateAttestationProvider
+    },
     SastWorkloadIdentityGuard,
     DirectMtlsSastWorkloadIdentityAuthenticator,
     {

--- a/apps/api/src/scan-plane/scanner-sandbox-adapter.service.ts
+++ b/apps/api/src/scan-plane/scanner-sandbox-adapter.service.ts
@@ -1,4 +1,5 @@
 import {
+  SAST_ARTIFACT_SCHEMA_VERSIONS,
   SAST_SCANNER_ASSET_ROOT,
   SAST_SCANNER_OUTPUT_ROOT,
   SAST_SCANNER_SELECTED_WORKSPACE_ROOT,
@@ -9,6 +10,7 @@ import {
   isSastScannerWrapperExecutionRequestValid,
   scannerRuntimeLimits,
   type RuleBundleDescriptor,
+  type SastArtifactSchema,
   type SastSandboxRuntimePolicy,
   type SastScannerInvocation,
   type SastScannerKind,
@@ -105,6 +107,7 @@ export class ScannerSandboxAdapterService {
         : this.requiredRuleBundle(plan, scanner);
     const outputPath = this.outputPath(scanner);
     const scannerInputPath = this.scannerInputPath(plan, preflight);
+    const artifactSchema = this.artifactSchema(scanner);
 
     return {
       wrapperSchemaVersion: SAST_SCANNER_WRAPPER_SCHEMA_VERSION,
@@ -122,13 +125,11 @@ export class ScannerSandboxAdapterService {
       workingDirectory: SAST_SCANNER_WORKING_DIRECTORY,
       scannerInputPath,
       outputPath,
-      artifactSchema:
-        scanner === 'OPENGREP'
-          ? 'OPENGREP_SARIF'
-          : scanner === 'TRIVY'
-            ? 'TRIVY_JSON'
-            : 'CYCLONEDX_JSON',
-      artifactSchemaVersion: plan.scannerSet.schemaBundle.digest,
+      artifactSchema,
+      artifactSchemaVersion:
+        SAST_ARTIFACT_SCHEMA_VERSIONS[artifactSchema],
+      schemaBundleDigest: plan.scannerSet.schemaBundle.digest,
+      normalizerBundleDigest: plan.scannerSet.normalizerBundle.digest,
       scannerVersion: descriptor.version,
       scannerImageDigest: descriptor.digest,
       wrapperDigest: descriptor.wrapper.digest,
@@ -303,6 +304,14 @@ export class ScannerSandboxAdapterService {
       return `${SAST_SCANNER_OUTPUT_ROOT}/trivy.json`;
     }
     return `${SAST_SCANNER_OUTPUT_ROOT}/syft.cdx.json`;
+  }
+
+  private artifactSchema(scanner: SastScannerKind): SastArtifactSchema {
+    return scanner === 'OPENGREP'
+      ? 'OPENGREP_SARIF'
+      : scanner === 'TRIVY'
+        ? 'TRIVY_JSON'
+        : 'CYCLONEDX_JSON';
   }
 
   private digestId(digest: `sha256:${string}`): string {

--- a/apps/api/test/scan-plane/prisma-sast-artifact-ingress.store.e2e-spec.ts
+++ b/apps/api/test/scan-plane/prisma-sast-artifact-ingress.store.e2e-spec.ts
@@ -1,4 +1,9 @@
-import type { SastScanPlan } from '@aegisai/shared';
+import {
+  SAST_ARTIFACT_VALIDATION_VERSION,
+  type ScannerArtifactEnvelope,
+  type SastArtifactValidationResult,
+  type SastScanPlan
+} from '@aegisai/shared';
 
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { PrismaSastArtifactIngressStore } from '../../src/scan-plane/prisma-sast-artifact-ingress.store';
@@ -37,10 +42,12 @@ describe('PrismaSastArtifactIngressStore', () => {
       prisma as unknown as PrismaService
     );
     const now = '2026-07-24T18:00:00.000Z';
+    const envelope = artifactEnvelope();
 
     await expect(
       store.reserve({
         ingestionId: 'ingestion-1',
+        envelope,
         envelopeDigest: DIGEST,
         idempotencyKey: `sast-ingress-v1:scanner-run-1:${DIGEST}`,
         expected: expectedBinding(),
@@ -84,6 +91,7 @@ describe('PrismaSastArtifactIngressStore', () => {
         id: 'ingestion-1',
         scannerRunId: 'scanner-run-1',
         workloadIdentityRef: 'spiffe://aegis/scan/attempt-1',
+        envelope,
         identityValidated: true,
         status: 'RECEIVING'
       })
@@ -130,6 +138,7 @@ describe('PrismaSastArtifactIngressStore', () => {
       objectKey: 'raw-sast/ingestion-1',
       observedContentDigest: DIGEST,
       observedByteSize: 128,
+      validation: validationResult(),
       receivedAt: '2026-07-24T18:00:01.000Z'
     });
 
@@ -145,6 +154,22 @@ describe('PrismaSastArtifactIngressStore', () => {
       data: {
         rawArtifactObjectKey: 'raw-sast/ingestion-1'
       }
+    });
+    expect(
+      transaction.sastArtifactIngestion.updateMany
+    ).toHaveBeenCalledWith({
+      where: {
+        id: 'ingestion-1',
+        status: 'RECEIVING'
+      },
+      data: expect.objectContaining({
+        status: 'PENDING_VALIDATION',
+        validationMetadata: {
+          workloadIdentityValidated: true,
+          transportByteCountValidated: true,
+          artifactValidation: validationResult()
+        }
+      })
     });
     expect(transaction.sastScanAttempt.findFirst).toHaveBeenCalledWith({
       where: {
@@ -199,6 +224,7 @@ describe('PrismaSastArtifactIngressStore', () => {
     await expect(
       store.reserve({
         ingestionId: 'ingestion-2',
+        envelope: artifactEnvelope(),
         envelopeDigest: `sha256:${'b'.repeat(64)}`,
         idempotencyKey: existing.idempotencyKey,
         expected: expectedBinding(),
@@ -229,5 +255,71 @@ function expectedBinding(): SastArtifactIngressExpectedBinding {
     attemptStage: 'SCANNING',
     attemptDeadlineAt: '2026-07-24T18:05:00.000Z',
     scannerRunStatus: 'RUNNING'
+  };
+}
+
+function artifactEnvelope(): ScannerArtifactEnvelope {
+  return {
+    tenantId: 'tenant-1',
+    repositoryBindingId: 'repository-1',
+    scanRequestId: 'scan-1',
+    attemptId: 'attempt-1',
+    scannerRunId: 'scanner-run-1',
+    workloadIdentityRef: 'spiffe://aegis/scan/attempt-1',
+    scanner: 'OPENGREP',
+    scannerVersion: '1.0.0',
+    scannerImageDigest: DIGEST,
+    wrapperDigest: DIGEST,
+    ruleBundleDigest: DIGEST,
+    scannerSetDigest: DIGEST,
+    schemaBundleDigest: DIGEST,
+    normalizerBundleDigest: DIGEST,
+    profileId: 'JAVA_FAST_V1',
+    profileDigest: DIGEST,
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: DIGEST,
+    scannerWorkspaceInventoryDigest: DIGEST,
+    inputCommitSha: 'a'.repeat(40),
+    artifactSchema: 'OPENGREP_SARIF',
+    artifactSchemaVersion: '2.1.0',
+    artifactRef: 'result-ingress://tenant-1/scan-1/opengrep',
+    contentDigest: DIGEST,
+    byteSize: 128,
+    recordCount: 0,
+    truncated: false,
+    exitCode: 0,
+    executionStatus: 'SUCCEEDED',
+    producedAt: '2026-07-24T18:00:00.000Z'
+  };
+}
+
+function validationResult(): SastArtifactValidationResult {
+  return {
+    version: SAST_ARTIFACT_VALIDATION_VERSION,
+    outcome: 'PASSED',
+    artifactSchema: 'OPENGREP_SARIF',
+    envelopeDigest: DIGEST,
+    observedContentDigest: DIGEST,
+    checks: {
+      planBinding: true,
+      schema: true,
+      contentDigest: true,
+      byteSize: true,
+      recordCount: true,
+      encoding: true,
+      jsonStructure: true,
+      path: true,
+      coordinate: true
+    },
+    reasonCodes: [],
+    statistics: {
+      observedByteSize: 128,
+      observedRecordCount: 0,
+      maximumObservedDepth: 4,
+      maximumObservedStringBytes: 8,
+      normalizedPathCount: 0,
+      coordinateCount: 0
+    },
+    resultDigest: DIGEST
   };
 }

--- a/apps/api/test/scan-plane/prisma-sast-scanner-runtime.store.e2e-spec.ts
+++ b/apps/api/test/scan-plane/prisma-sast-scanner-runtime.store.e2e-spec.ts
@@ -3,9 +3,63 @@ import {
   isSastAttemptSequenceEligible,
   PrismaSastScannerRuntimeStore
 } from '../../src/scan-plane/prisma-sast-scanner-runtime.store';
-import type { SastScannerWrapperExecutionRequest } from '@aegisai/shared';
+import type {
+  SastScannerInvocation,
+  SastScannerWrapperExecutionRequest
+} from '@aegisai/shared';
 
 describe('PrismaSastScannerRuntimeStore', () => {
+  it('persists semantic schema and immutable schema/normalizer bundle bindings', async () => {
+    const create = jest.fn().mockResolvedValue({ id: 'scanner-run-1' });
+    const store = new PrismaSastScannerRuntimeStore({
+      scannerRun: { create }
+    } as unknown as PrismaService);
+    const request = {
+      attemptId: 'attempt-1',
+      plan: {
+        tenantId: 'tenant-1',
+        scanRequestId: 'scan-1',
+        repositoryState: {
+          repositoryBindingId: 'repository-1'
+        },
+        resultIngressRef: 'result-ingress://tenant-1/scan-1'
+      }
+    } as unknown as SastScannerWrapperExecutionRequest;
+    const invocation = {
+      scanner: 'OPENGREP',
+      scannerVersion: '1.1.0',
+      required: true,
+      wrapperDigest: digest('1'),
+      scannerImageDigest: digest('2'),
+      ruleBundleDigest: digest('3'),
+      scannerSetDigest: digest('4'),
+      schemaBundleDigest: digest('5'),
+      normalizerBundleDigest: digest('6'),
+      profileId: 'JAVA_FAST_V1',
+      profileDigest: digest('7'),
+      preflightAttestationRef: 'preflight://attempt-1',
+      preflightInventoryDigest: digest('8'),
+      artifactSchema: 'OPENGREP_SARIF',
+      artifactSchemaVersion: '2.1.0'
+    } as unknown as SastScannerInvocation;
+
+    await store.beginScannerRun(
+      request,
+      'scanner-run-1',
+      invocation,
+      '2026-07-24T12:00:00.000Z'
+    );
+
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        artifactSchema: 'OPENGREP_SARIF',
+        artifactSchemaVersion: '2.1.0',
+        schemaBundleDigest: digest('5'),
+        normalizerBundleDigest: digest('6')
+      })
+    });
+  });
+
   it('admits attempt two only after attempt one has a durable retry-eligible infrastructure failure', () => {
     const eligibleAttemptOne = {
       attemptNumber: 1,
@@ -155,3 +209,7 @@ describe('PrismaSastScannerRuntimeStore', () => {
     expect(attemptUpdate).not.toHaveBeenCalled();
   });
 });
+
+function digest(character: string): `sha256:${string}` {
+  return `sha256:${character.repeat(64)}`;
+}

--- a/apps/api/test/scan-plane/sast-artifact-ingress.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-artifact-ingress.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   SAST_SCAN_PROFILES,
   buildSastArtifactIngressIdempotencyKey,
   canonicalizeScannerArtifactEnvelope,
+  SAST_ARTIFACT_SCHEMA_VERSIONS,
   type ScannerArtifactEnvelope,
   type SastScanPlan
 } from '@aegisai/shared';
@@ -19,6 +20,11 @@ import request from 'supertest';
 
 import { SastArtifactIngressController } from '../../src/scan-plane/sast-artifact-ingress.controller';
 import { SastArtifactIngressService } from '../../src/scan-plane/sast-artifact-ingress.service';
+import { SastArtifactValidationService } from '../../src/scan-plane/sast-artifact-validation.service';
+import {
+  SastFileCoordinateAttestationProvider,
+  UnavailableSastFileCoordinateAttestationProvider
+} from '../../src/scan-plane/sast-file-coordinate-attestation.provider';
 import {
   type AbortSastArtifactIngressInput,
   type CompleteSastArtifactIngressInput,
@@ -45,7 +51,10 @@ import { SastWorkloadIdentityGuard } from '../../src/scan-plane/sast-workload-id
 const digest = (value: string): `sha256:${string}` =>
   `sha256:${createHash('sha256').update(value).digest('hex')}`;
 const FIXED_COMMIT = 'a'.repeat(40);
-const ARTIFACT_BYTES = Buffer.from('{"runs":[]}', 'utf8');
+const ARTIFACT_BYTES = Buffer.from(
+  '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"OpenGrep"}},"results":[]}]}',
+  'utf8'
+);
 
 class InMemoryArtifactIngressStore extends SastArtifactIngressStore {
   expected = buildExpectedBinding();
@@ -59,6 +68,7 @@ class InMemoryArtifactIngressStore extends SastArtifactIngressStore {
     }
   >();
   completeError?: Error;
+  lastCompletion?: CompleteSastArtifactIngressInput;
 
   loadExpectedBinding(
     scanRequestId: string,
@@ -114,6 +124,7 @@ class InMemoryArtifactIngressStore extends SastArtifactIngressStore {
       (candidate) => candidate.input.ingestionId === input.ingestionId
     );
     if (!reservation) throw new Error('missing reservation');
+    this.lastCompletion = structuredClone(input);
     reservation.state = 'PENDING_VALIDATION';
     reservation.receivedAt = input.receivedAt;
     return Promise.resolve();
@@ -196,7 +207,13 @@ describe('SAST per-scan write-only artifact ingress', () => {
       controllers: [SastArtifactIngressController],
       providers: [
         SastArtifactIngressService,
+        SastArtifactValidationService,
         SastWorkloadIdentityGuard,
+        UnavailableSastFileCoordinateAttestationProvider,
+        {
+          provide: SastFileCoordinateAttestationProvider,
+          useExisting: UnavailableSastFileCoordinateAttestationProvider
+        },
         {
           provide: SastWorkloadIdentityAuthenticator,
           useValue: authenticator
@@ -244,6 +261,10 @@ describe('SAST per-scan write-only artifact ingress', () => {
     expect(
       ingressStore.reservations.get(envelope.scannerRunId)?.state
     ).toBe('PENDING_VALIDATION');
+    expect(ingressStore.lastCompletion?.validation).toMatchObject({
+      outcome: 'PASSED',
+      reasonCodes: []
+    });
   });
 
   it('has no artifact read route', async () => {
@@ -510,6 +531,8 @@ function buildEnvelope(plan: SastScanPlan): ScannerArtifactEnvelope {
     wrapperDigest: scanner.wrapper.digest,
     ruleBundleDigest: rule.digest,
     scannerSetDigest: plan.scannerSet.scannerSetDigest,
+    schemaBundleDigest: plan.scannerSet.schemaBundle.digest,
+    normalizerBundleDigest: plan.scannerSet.normalizerBundle.digest,
     profileId: plan.profile.id,
     profileDigest: plan.profileDigest,
     preflightAttestationRef: 'preflight://attempt-1',
@@ -517,7 +540,8 @@ function buildEnvelope(plan: SastScanPlan): ScannerArtifactEnvelope {
     scannerWorkspaceInventoryDigest: digest('inventory'),
     inputCommitSha: plan.repositoryState.fixedCommitSha,
     artifactSchema: 'OPENGREP_SARIF',
-    artifactSchemaVersion: plan.scannerSet.schemaBundle.digest,
+    artifactSchemaVersion:
+      SAST_ARTIFACT_SCHEMA_VERSIONS.OPENGREP_SARIF,
     artifactRef: `${plan.resultIngressRef}/opengrep`,
     contentDigest: digest(ARTIFACT_BYTES.toString('utf8')),
     byteSize: ARTIFACT_BYTES.byteLength,

--- a/apps/api/test/scan-plane/sast-artifact-validation.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-artifact-validation.e2e-spec.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import {
   SAST_APPROVED_PROFILE_DIGESTS,
   SAST_ARTIFACT_SCHEMA_VERSIONS,
+  SAST_ARTIFACT_VALIDATION_LIMITS,
   SAST_FORBIDDEN_CAPABILITIES,
   SAST_SCAN_PROFILES,
   canonicalizeScannerArtifactEnvelope,
@@ -142,6 +143,7 @@ describe('SAST bounded artifact validation', () => {
       artifact: Buffer.from(
         '{"bomFormat":"CycloneDX","bomFormat":"CycloneDX","specVersion":"1.6","version":1,"components":[]}'
       ),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_DUPLICATE_KEY'
     },
     {
@@ -149,6 +151,7 @@ describe('SAST bounded artifact validation', () => {
       artifact: Buffer.from(
         '{"bomFormat":"CycloneDX","specVersion":"1.6","version":1,"components":['
       ),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_MALFORMED'
     },
     {
@@ -156,6 +159,7 @@ describe('SAST bounded artifact validation', () => {
       artifact: Buffer.from(
         `${'['.repeat(65)}null${']'.repeat(65)}`
       ),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_DEPTH_LIMIT_EXCEEDED'
     },
     {
@@ -168,6 +172,7 @@ describe('SAST bounded artifact validation', () => {
           ])
         )
       ),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_KEY_COUNT_LIMIT_EXCEEDED'
     },
     {
@@ -180,6 +185,7 @@ describe('SAST bounded artifact validation', () => {
           { type: 'library', name: 'x'.repeat(4097) }
         ]
       }),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_STRING_LIMIT_EXCEEDED'
     },
     {
@@ -189,6 +195,7 @@ describe('SAST bounded artifact validation', () => {
           129
         )},"components":[]}`
       ),
+      recordCount: 0,
       reason: 'ARTIFACT_JSON_NUMBER_LIMIT_EXCEEDED'
     },
     {
@@ -200,6 +207,7 @@ describe('SAST bounded artifact validation', () => {
         components: [],
         unexpected: true
       }),
+      recordCount: 0,
       reason: 'ARTIFACT_SCHEMA_UNKNOWN_FIELD'
     },
     {
@@ -217,7 +225,7 @@ describe('SAST bounded artifact validation', () => {
     const result = await validate({
       schema: 'CYCLONEDX_JSON',
       artifact: fixture.artifact,
-      recordCount: fixture.recordCount ?? 0,
+      recordCount: fixture.recordCount,
       attestation: null,
       chunkSizes: [7]
     });
@@ -466,6 +474,38 @@ describe('SAST bounded artifact validation', () => {
     });
 
     expect(result.validation.reasonCodes).toContain(fixture.reason);
+  });
+
+  it('rejects an oversized attestation before scanning its column array', async () => {
+    const lineCount =
+      SAST_ARTIFACT_VALIDATION_LIMITS.maximumCoordinateAttestationLines + 1;
+    const maxColumnByLine = new Array<number>(lineCount);
+    Object.defineProperty(maxColumnByLine, 0, {
+      get: () => {
+        throw new Error('oversized column array must not be scanned');
+      }
+    });
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(validSarif()),
+      recordCount: 1,
+      attestation: {
+        attestationRef: 'preflight://attempt-1',
+        inventoryDigest: digest('inventory'),
+        verified: true,
+        files: [
+          {
+            normalizedPath: 'src/Café.java',
+            lineCount,
+            maxColumnByLine
+          }
+        ]
+      }
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_COORDINATE_ATTESTATION_MISSING'
+    );
   });
 
   it('produces the same validation digest for every transport chunking', async () => {

--- a/apps/api/test/scan-plane/sast-artifact-validation.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-artifact-validation.e2e-spec.ts
@@ -1,0 +1,832 @@
+import { createHash } from 'node:crypto';
+
+import {
+  SAST_APPROVED_PROFILE_DIGESTS,
+  SAST_ARTIFACT_SCHEMA_VERSIONS,
+  SAST_FORBIDDEN_CAPABILITIES,
+  SAST_SCAN_PROFILES,
+  canonicalizeScannerArtifactEnvelope,
+  isSastArtifactValidationResultShapeValid,
+  type ExpectedScannerArtifactBinding,
+  type ScannerArtifactEnvelope,
+  type SastArtifactSchema,
+  type SastScanPlan
+} from '@aegisai/shared';
+
+import { SastArtifactStreamValidationSession } from '../../src/scan-plane/sast-artifact-stream-validator';
+import type { SastFileCoordinateAttestation } from '../../src/scan-plane/sast-file-coordinate-attestation.provider';
+
+const FIXED_COMMIT = 'a'.repeat(40);
+
+describe('SAST bounded artifact validation', () => {
+  it.each([
+    {
+      schema: 'OPENGREP_SARIF' as const,
+      artifact: validSarif(),
+      recordCount: 1,
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'TRIVY_JSON' as const,
+      artifact: validTrivy(),
+      recordCount: 1,
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'CYCLONEDX_JSON' as const,
+      artifact: validCycloneDx(),
+      recordCount: 1,
+      attestation: null
+    }
+  ])(
+    'accepts a pinned $schema artifact without materializing it',
+    async ({ schema, artifact, recordCount, attestation }) => {
+      const result = await validate({
+        schema,
+        artifact: jsonBytes(artifact),
+        recordCount,
+        attestation,
+        chunkSizes: [1, 2, 3, 5, 8, 13]
+      });
+
+      expect(result.forwarded).toEqual(result.artifact);
+      expect(result.validation).toMatchObject({
+        outcome: 'PASSED',
+        reasonCodes: [],
+        artifactSchema: schema,
+        statistics: {
+          observedRecordCount: recordCount
+        }
+      });
+      expect(
+        isSastArtifactValidationResultShapeValid(result.validation)
+      ).toBe(true);
+    }
+  );
+
+  it.each([
+    {
+      schema: 'OPENGREP_SARIF' as const,
+      artifact: (() => {
+        const artifact = validSarif();
+        Object.assign(artifact.runs[0]!.results[0]!, {
+          kind: 'unsupported'
+        });
+        return artifact;
+      })(),
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'TRIVY_JSON' as const,
+      artifact: (() => {
+        const artifact = validTrivy();
+        artifact.Results[0]!.Vulnerabilities[0]!.Severity = 'SEVERE';
+        return artifact;
+      })(),
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'CYCLONEDX_JSON' as const,
+      artifact: (() => {
+        const artifact = validCycloneDx();
+        artifact.components[0]!.scope = 'runtime';
+        return artifact;
+      })(),
+      attestation: null
+    }
+  ])('rejects an unknown $schema enum value', async (fixture) => {
+    const result = await validate({
+      schema: fixture.schema,
+      artifact: jsonBytes(fixture.artifact),
+      recordCount: 1,
+      attestation: fixture.attestation
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_SCHEMA_FIELD_INVALID'
+    );
+  });
+
+  it.each([
+    {
+      schema: 'OPENGREP_SARIF' as const,
+      artifact: { ...validSarif(), version: '2.0.0' },
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'TRIVY_JSON' as const,
+      artifact: { ...validTrivy(), SchemaVersion: 3 },
+      attestation: coordinateAttestation()
+    },
+    {
+      schema: 'CYCLONEDX_JSON' as const,
+      artifact: { ...validCycloneDx(), specVersion: '1.5' },
+      attestation: null
+    }
+  ])('rejects an unpinned $schema payload version', async (fixture) => {
+    const result = await validate({
+      schema: fixture.schema,
+      artifact: jsonBytes(fixture.artifact),
+      recordCount: 1,
+      attestation: fixture.attestation
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_SCHEMA_FIELD_INVALID'
+    );
+  });
+
+  it.each([
+    {
+      name: 'duplicate keys',
+      artifact: Buffer.from(
+        '{"bomFormat":"CycloneDX","bomFormat":"CycloneDX","specVersion":"1.6","version":1,"components":[]}'
+      ),
+      reason: 'ARTIFACT_JSON_DUPLICATE_KEY'
+    },
+    {
+      name: 'malformed JSON',
+      artifact: Buffer.from(
+        '{"bomFormat":"CycloneDX","specVersion":"1.6","version":1,"components":['
+      ),
+      reason: 'ARTIFACT_JSON_MALFORMED'
+    },
+    {
+      name: 'excessive nesting',
+      artifact: Buffer.from(
+        `${'['.repeat(65)}null${']'.repeat(65)}`
+      ),
+      reason: 'ARTIFACT_JSON_DEPTH_LIMIT_EXCEEDED'
+    },
+    {
+      name: 'excessive object keys',
+      artifact: jsonBytes(
+        Object.fromEntries(
+          Array.from({ length: 4097 }, (_, index) => [
+            `key-${index}`,
+            index
+          ])
+        )
+      ),
+      reason: 'ARTIFACT_JSON_KEY_COUNT_LIMIT_EXCEEDED'
+    },
+    {
+      name: 'overlong strings',
+      artifact: jsonBytes({
+        bomFormat: 'CycloneDX',
+        specVersion: '1.6',
+        version: 1,
+        components: [
+          { type: 'library', name: 'x'.repeat(4097) }
+        ]
+      }),
+      reason: 'ARTIFACT_JSON_STRING_LIMIT_EXCEEDED'
+    },
+    {
+      name: 'overlong numbers',
+      artifact: Buffer.from(
+        `{"bomFormat":"CycloneDX","specVersion":"1.6","version":${'1'.repeat(
+          129
+        )},"components":[]}`
+      ),
+      reason: 'ARTIFACT_JSON_NUMBER_LIMIT_EXCEEDED'
+    },
+    {
+      name: 'unknown schema fields',
+      artifact: jsonBytes({
+        bomFormat: 'CycloneDX',
+        specVersion: '1.6',
+        version: 1,
+        components: [],
+        unexpected: true
+      }),
+      reason: 'ARTIFACT_SCHEMA_UNKNOWN_FIELD'
+    },
+    {
+      name: 'unknown enum values',
+      artifact: jsonBytes({
+        bomFormat: 'CycloneDX',
+        specVersion: '1.6',
+        version: 1,
+        components: [{ type: 'executable', name: 'example' }]
+      }),
+      recordCount: 1,
+      reason: 'ARTIFACT_SCHEMA_FIELD_INVALID'
+    }
+  ])('fails closed for $name and still drains the stream', async (fixture) => {
+    const result = await validate({
+      schema: 'CYCLONEDX_JSON',
+      artifact: fixture.artifact,
+      recordCount: fixture.recordCount ?? 0,
+      attestation: null,
+      chunkSizes: [7]
+    });
+
+    expect(result.forwarded).toEqual(result.artifact);
+    expect(result.validation.outcome).toBe('FAILED');
+    expect(result.validation.reasonCodes).toContain(fixture.reason);
+  });
+
+  it.each([
+    {
+      name: 'SARIF tool driver',
+      mutate: (artifact: ReturnType<typeof validSarif>) => {
+        Reflect.deleteProperty(artifact.runs[0]!.tool, 'driver');
+      }
+    },
+    {
+      name: 'SARIF result message content',
+      mutate: (artifact: ReturnType<typeof validSarif>) => {
+        Reflect.deleteProperty(
+          artifact.runs[0]!.results[0]!.message,
+          'text'
+        );
+      }
+    }
+  ])('rejects a missing required $name structure', async (fixture) => {
+    const artifact = validSarif();
+    fixture.mutate(artifact);
+
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(artifact),
+      recordCount: 1,
+      attestation: coordinateAttestation()
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_SCHEMA_REQUIRED_FIELD_MISSING'
+    );
+  });
+
+  it('rejects invalid UTF-8 independently of JSON tokenization', async () => {
+    const prefix = Buffer.from(
+      '{"bomFormat":"CycloneDX","specVersion":"1.6","version":1,"components":[{"type":"library","name":"'
+    );
+    const suffix = Buffer.from('"}]}');
+    const artifact = Buffer.concat([
+      prefix,
+      Buffer.from([0xc3, 0x28]),
+      suffix
+    ]);
+
+    const result = await validate({
+      schema: 'CYCLONEDX_JSON',
+      artifact,
+      recordCount: 1,
+      attestation: null,
+      chunkSizes: [1]
+    });
+
+    expect(result.forwarded).toEqual(artifact);
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_INVALID_UTF8'
+    );
+  });
+
+  it.each([
+    {
+      name: 'content digest',
+      overrides: {
+        contentDigest: digest('different')
+      },
+      recordCount: 1,
+      reason: 'ARTIFACT_CONTENT_DIGEST_MISMATCH'
+    },
+    {
+      name: 'byte count',
+      overrides: {
+        byteSize: jsonBytes(validSarif()).byteLength + 1
+      },
+      recordCount: 1,
+      reason: 'ARTIFACT_BYTE_SIZE_MISMATCH'
+    },
+    {
+      name: 'record count',
+      overrides: {},
+      recordCount: 2,
+      reason: 'ARTIFACT_RECORD_COUNT_MISMATCH'
+    },
+    {
+      name: 'schema version',
+      overrides: {
+        artifactSchemaVersion: '2.0.0'
+      },
+      recordCount: 1,
+      reason: 'ARTIFACT_SCHEMA_VERSION_MISMATCH'
+    }
+  ])('records a deterministic $name mismatch', async (fixture) => {
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(validSarif()),
+      recordCount: fixture.recordCount,
+      attestation: coordinateAttestation(),
+      envelopeOverrides: fixture.overrides
+    });
+
+    expect(result.validation.outcome).toBe('FAILED');
+    expect(result.validation.reasonCodes).toContain(fixture.reason);
+  });
+
+  it('rebinds the exact durable scanner and artifact reference', async () => {
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(validSarif()),
+      recordCount: 1,
+      attestation: coordinateAttestation(),
+      expectedBindingOverrides: {
+        scanner: 'TRIVY',
+        artifactRef: 'ingress://attempt-1/trivy'
+      }
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_PLAN_BINDING_MISMATCH'
+    );
+  });
+
+  it('rejects traversal paths and case-fold path collisions', async () => {
+    const artifact = validSarif();
+    artifact.runs[0]!.results = [
+      sarifResult('../secrets.txt', 1),
+      sarifResult('Src/App.java', 1),
+      sarifResult('src/app.java', 1)
+    ];
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(artifact),
+      recordCount: 3,
+      attestation: coordinateAttestation([
+        fileCoordinate('Src/App.java'),
+        fileCoordinate('src/app.java')
+      ])
+    });
+
+    expect(result.validation.reasonCodes).toEqual(
+      expect.arrayContaining([
+        'ARTIFACT_PATH_INVALID',
+        'ARTIFACT_PATH_COLLISION'
+      ])
+    );
+    expect(
+      isSastArtifactValidationResultShapeValid({
+        ...result.validation,
+        checks: {
+          ...result.validation.checks,
+          path: true
+        }
+      })
+    ).toBe(false);
+  });
+
+  it('rejects indirect SARIF physical artifact locations', async () => {
+    const artifact = validSarif();
+    Object.assign(
+      artifact.runs[0]!.results[0]!.locations[0]!.physicalLocation
+        .artifactLocation,
+      { uriBaseId: 'WORKSPACE' }
+    );
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(artifact),
+      recordCount: 1,
+      attestation: coordinateAttestation()
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_PATH_INVALID'
+    );
+  });
+
+  it('enforces the finding limit separately from the larger artifact-record limit', async () => {
+    const plan = buildPlan('JAVA_FAST_V1');
+    const findingCount = plan.profile.limits.maxFindings + 1;
+    const artifact = {
+      version: '2.1.0',
+      runs: [
+        {
+          tool: { driver: { name: 'OpenGrep' } },
+          results: Array.from({ length: findingCount }, (_, index) => ({
+            ruleId: `rule-${index}`,
+            message: { text: 'bounded finding' }
+          }))
+        }
+      ]
+    };
+    const result = await validate({
+      plan,
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(artifact),
+      recordCount: findingCount,
+      attestation: null
+    });
+
+    expect(result.validation.reasonCodes).toContain(
+      'ARTIFACT_RECORD_LIMIT_EXCEEDED'
+    );
+  });
+
+  it.each([
+    {
+      name: 'missing attestation',
+      attestation: null,
+      line: 2,
+      reason: 'ARTIFACT_COORDINATE_ATTESTATION_MISSING'
+    },
+    {
+      name: 'out-of-range coordinates',
+      attestation: coordinateAttestation(),
+      line: 4,
+      reason: 'ARTIFACT_COORDINATE_INVALID'
+    },
+    {
+      name: 'malformed coordinate attestation',
+      attestation: {
+        ...coordinateAttestation(),
+        files: [
+          {
+            ...fileCoordinate('src/Café.java'),
+            unboundedProviderField: true
+          }
+        ]
+      } as unknown as SastFileCoordinateAttestation,
+      line: 2,
+      reason: 'ARTIFACT_COORDINATE_ATTESTATION_MISSING'
+    }
+  ])('fails closed for $name', async (fixture) => {
+    const artifact = validSarif();
+    artifact.runs[0]!.results = [
+      sarifResult('src/Caf%C3%A9.java', fixture.line)
+    ];
+    const result = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact: jsonBytes(artifact),
+      recordCount: 1,
+      attestation: fixture.attestation
+    });
+
+    expect(result.validation.reasonCodes).toContain(fixture.reason);
+  });
+
+  it('produces the same validation digest for every transport chunking', async () => {
+    const artifact = jsonBytes(validSarif());
+    const first = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact,
+      recordCount: 1,
+      attestation: coordinateAttestation(),
+      chunkSizes: [artifact.byteLength]
+    });
+    const second = await validate({
+      schema: 'OPENGREP_SARIF',
+      artifact,
+      recordCount: 1,
+      attestation: coordinateAttestation(),
+      chunkSizes: [1]
+    });
+
+    expect(second.validation).toEqual(first.validation);
+  });
+
+  it('keeps invalid-payload statistics deterministic across transport chunking', async () => {
+    const artifact = jsonBytes({
+      bomFormat: 'CycloneDX',
+      specVersion: '1.6',
+      version: 1,
+      components: [
+        { type: 'library', name: 'x'.repeat(4097) }
+      ]
+    });
+    const first = await validate({
+      schema: 'CYCLONEDX_JSON',
+      artifact,
+      recordCount: 1,
+      attestation: null,
+      chunkSizes: [artifact.byteLength]
+    });
+    const second = await validate({
+      schema: 'CYCLONEDX_JSON',
+      artifact,
+      recordCount: 1,
+      attestation: null,
+      chunkSizes: [1]
+    });
+
+    expect(first.validation.reasonCodes).toContain(
+      'ARTIFACT_JSON_STRING_LIMIT_EXCEEDED'
+    );
+    expect(second.validation).toEqual(first.validation);
+  });
+});
+
+interface ValidateInput {
+  plan?: SastScanPlan;
+  schema: SastArtifactSchema;
+  artifact: Buffer;
+  recordCount: number;
+  attestation: Readonly<SastFileCoordinateAttestation> | null;
+  chunkSizes?: readonly number[];
+  envelopeOverrides?: Partial<ScannerArtifactEnvelope>;
+  expectedBindingOverrides?: Partial<ExpectedScannerArtifactBinding>;
+}
+
+async function validate(input: ValidateInput) {
+  const plan = input.plan ?? buildPlan();
+  const envelope = {
+    ...buildEnvelope(
+      plan,
+      input.schema,
+      input.artifact,
+      input.recordCount
+    ),
+    ...input.envelopeOverrides
+  };
+  const session = new SastArtifactStreamValidationSession({
+    envelope,
+    plan,
+    expectedBinding: {
+      attemptId: envelope.attemptId,
+      scannerRunId: envelope.scannerRunId,
+      scanner: envelope.scanner,
+      artifactRef: envelope.artifactRef,
+      workloadIdentityRef: envelope.workloadIdentityRef,
+      preflightAttestationRef: envelope.preflightAttestationRef,
+      preflightInventoryDigest: envelope.preflightInventoryDigest,
+      ...input.expectedBindingOverrides
+    },
+    envelopeDigest: digest(
+      canonicalizeScannerArtifactEnvelope(envelope)
+    ),
+    coordinateAttestation: input.attestation
+  });
+  const chunks: Buffer[] = [];
+  for await (const chunk of session.observe(
+    chunkArtifact(input.artifact, input.chunkSizes ?? [4096])
+  )) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return {
+    artifact: input.artifact,
+    forwarded: Buffer.concat(chunks),
+    validation: session.finish()
+  };
+}
+
+async function* chunkArtifact(
+  artifact: Buffer,
+  chunkSizes: readonly number[]
+): AsyncGenerator<Uint8Array> {
+  let offset = 0;
+  let index = 0;
+  while (offset < artifact.byteLength) {
+    const size = chunkSizes[index % chunkSizes.length] ?? 1;
+    const end = Math.min(artifact.byteLength, offset + Math.max(size, 1));
+    yield artifact.subarray(offset, end);
+    offset = end;
+    index += 1;
+  }
+}
+
+function validSarif() {
+  return {
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'OpenGrep'
+          }
+        },
+        results: [sarifResult('src/Caf%C3%A9.java', 2)]
+      }
+    ]
+  };
+}
+
+function validTrivy() {
+  return {
+    SchemaVersion: 2,
+    ArtifactName: 'repository',
+    ArtifactType: 'filesystem',
+    Results: [
+      {
+        Class: 'lang-pkgs',
+        Type: 'jar',
+        Vulnerabilities: [
+          {
+            VulnerabilityID: 'CVE-2026-0001',
+            PkgName: 'example',
+            InstalledVersion: '1.0.0',
+            Severity: 'HIGH',
+            VendorSeverity: { nvd: 3 }
+          }
+        ],
+        Target: 'pom.xml'
+      }
+    ]
+  };
+}
+
+function validCycloneDx() {
+  return {
+    bomFormat: 'CycloneDX',
+    specVersion: '1.6',
+    version: 1,
+    components: [
+      {
+        type: 'library',
+        name: 'example',
+        version: '1.0.0',
+        scope: 'required',
+        omniborId: ['gitoid:blob:sha256:example'],
+        swhid: ['swh:1:cnt:example']
+      }
+    ]
+  };
+}
+
+function sarifResult(uri: string, line: number) {
+  return {
+    ruleId: 'java.sql-injection',
+    message: {
+      text: 'Potential SQL injection'
+    },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri
+          },
+          region: {
+            startLine: line,
+            endLine: line,
+            startColumn: 2,
+            endColumn: 5
+          }
+        }
+      }
+    ]
+  };
+}
+
+function coordinateAttestation(
+  files = [fileCoordinate('src/Café.java'), fileCoordinate('pom.xml')]
+): SastFileCoordinateAttestation {
+  return {
+    attestationRef: 'preflight://attempt-1',
+    inventoryDigest: digest('inventory'),
+    verified: true,
+    files
+  };
+}
+
+function fileCoordinate(normalizedPath: string) {
+  return {
+    normalizedPath,
+    lineCount: 3,
+    maxColumnByLine: [80, 80, 80]
+  };
+}
+
+function buildEnvelope(
+  plan: SastScanPlan,
+  schema: SastArtifactSchema,
+  artifact: Buffer,
+  recordCount: number
+): ScannerArtifactEnvelope {
+  const scanner =
+    schema === 'OPENGREP_SARIF'
+      ? 'OPENGREP'
+      : schema === 'TRIVY_JSON'
+        ? 'TRIVY'
+        : 'SYFT';
+  const descriptor = plan.scannerSet.scanners[scanner];
+  const rule = plan.scannerSet.ruleBundles.find(
+    (bundle) => bundle.scanner === scanner
+  );
+  return {
+    tenantId: plan.tenantId,
+    repositoryBindingId: plan.repositoryState.repositoryBindingId,
+    scanRequestId: plan.scanRequestId,
+    attemptId: 'attempt-1',
+    scannerRunId: `scanner-run-${scanner.toLowerCase()}`,
+    workloadIdentityRef: 'spiffe://aegis/scan/attempt-1',
+    scanner,
+    scannerVersion: descriptor.version,
+    scannerImageDigest: descriptor.digest,
+    wrapperDigest: descriptor.wrapper.digest,
+    ...(rule ? { ruleBundleDigest: rule.digest } : {}),
+    ...(scanner === 'TRIVY'
+      ? {
+          vulnerabilityDatabaseDigest:
+            plan.scannerSet.vulnerabilityDatabase.digest
+        }
+      : {}),
+    scannerSetDigest: plan.scannerSet.scannerSetDigest,
+    schemaBundleDigest: plan.scannerSet.schemaBundle.digest,
+    normalizerBundleDigest: plan.scannerSet.normalizerBundle.digest,
+    profileId: plan.profile.id,
+    profileDigest: plan.profileDigest,
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: digest('inventory'),
+    scannerWorkspaceInventoryDigest: digest('inventory'),
+    inputCommitSha: plan.repositoryState.fixedCommitSha,
+    artifactSchema: schema,
+    artifactSchemaVersion: SAST_ARTIFACT_SCHEMA_VERSIONS[schema],
+    artifactRef: `${plan.resultIngressRef}/${scanner.toLowerCase()}`,
+    contentDigest: digest(artifact),
+    byteSize: artifact.byteLength,
+    recordCount,
+    truncated: false,
+    exitCode: 0,
+    executionStatus: 'SUCCEEDED',
+    producedAt: '2026-07-24T18:00:00.000Z'
+  };
+}
+
+function buildPlan(
+  profileId: 'JAVA_FAST_V1' | 'JAVA_DEEP_V1' = 'JAVA_DEEP_V1'
+): SastScanPlan {
+  const profile = SAST_SCAN_PROFILES[profileId];
+  const signed = (value: string) => ({
+    digest: digest(value),
+    signatureRef: `signature://${value}`,
+    provenanceRef: `provenance://${value}`
+  });
+  const scanner = (
+    kind: 'OPENGREP' | 'TRIVY' | 'SYFT',
+    version: string
+  ) => ({
+    ...signed(`scanner-${kind}`),
+    scanner: kind,
+    version,
+    sbomRef: `sbom://${kind.toLowerCase()}`,
+    wrapper: signed(`wrapper-${kind}`)
+  });
+  const rule = (kind: 'OPENGREP' | 'TRIVY') => ({
+    ...signed(`rule-${kind}`),
+    bundleId: `${kind.toLowerCase()}-rules`,
+    version: '1',
+    state: 'ACTIVE' as const,
+    compatibilityRef: `compatibility://${kind}`,
+    rolloutPolicyRef: `rollout://${kind}`,
+    killSwitchRef: `kill-switch://${kind}`,
+    scanner: kind,
+    source: 'PLATFORM_MANAGED' as const,
+    immutable: true as const,
+    customerExecutableConfigAllowed: false as const
+  });
+  return {
+    tenantId: 'tenant-1',
+    scanRequestId: 'scan-1',
+    canonicalScanKey: digest('canonical'),
+    profile,
+    profileDigest: SAST_APPROVED_PROFILE_DIGESTS[profile.id],
+    policyVersion: 'policy-v1',
+    repositoryState: {
+      repositoryBindingId: 'repository-1',
+      fixedCommitSha: FIXED_COMMIT,
+      targetRef: 'refs/heads/main',
+      inventoryDigest: digest('inventory'),
+      attestationRef: 'preflight://attempt-1',
+      shallowFetchPreferred: true,
+      submodulesEnabled: false,
+      lfsObjectsFetched: false
+    },
+    scannerSet: {
+      scannerSetVersion: 'scanner-set-v1',
+      scannerSetDigest: digest('scanner-set'),
+      signatureRef: 'signature://scanner-set',
+      provenanceRef: 'provenance://scanner-set',
+      scanners: {
+        OPENGREP: scanner('OPENGREP', '1.1.0'),
+        TRIVY: scanner('TRIVY', '0.66.0'),
+        SYFT: scanner('SYFT', '1.30.0')
+      },
+      ruleBundles: [rule('OPENGREP'), rule('TRIVY')],
+      vulnerabilityDatabase: {
+        ...signed('trivy-db'),
+        databaseVersion: '2026-07-24',
+        publishedAt: '2026-07-24T00:00:00.000Z'
+      },
+      schemaBundle: signed('schema'),
+      normalizerBundle: signed('normalizer'),
+      sbomSchema: 'CYCLONEDX_JSON',
+      rollbackRef: 'rollback://scanner-set-v0'
+    },
+    isolationClass: 'HARDENED',
+    resultIngressRef: 'result-ingress://tenant-1/scan-1',
+    evidenceOutputRef: 'evidence-output://tenant-1/scan-1',
+    auditSinkRef: 'audit-sink://tenant-1/scan-1',
+    forbiddenCapabilities: [...SAST_FORBIDDEN_CAPABILITIES],
+    createdAt: '2026-07-24T17:00:00.000Z'
+  };
+}
+
+function jsonBytes(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(value), 'utf8');
+}
+
+function digest(value: string | Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}

--- a/apps/api/test/scan-plane/sast-scanner-runtime.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-scanner-runtime.e2e-spec.ts
@@ -180,7 +180,10 @@ describe('Pinned scanner wrapper and sandbox lifecycle', () => {
       workingDirectory: '/workspace/output',
       scannerInputPath: '/workspace/repository',
       outputPath: '/workspace/output/opengrep.sarif',
-      artifactSchema: 'OPENGREP_SARIF'
+      artifactSchema: 'OPENGREP_SARIF',
+      artifactSchemaVersion: '2.1.0',
+      schemaBundleDigest: digest('a'),
+      normalizerBundleDigest: digest('b')
     });
     expect(invocations[1]).toMatchObject({
       scanner: 'TRIVY',
@@ -218,7 +221,11 @@ describe('Pinned scanner wrapper and sandbox lifecycle', () => {
         '/workspace/repository'
       ],
       scannerInputPath: '/workspace/repository',
-      artifactSchema: 'TRIVY_JSON'
+      artifactSchema: 'TRIVY_JSON',
+      artifactSchemaVersion: '2',
+      vulnerabilityDatabaseDigest: digest('7'),
+      schemaBundleDigest: digest('a'),
+      normalizerBundleDigest: digest('b')
     });
     expect(invocations[2]).toMatchObject({
       scanner: 'SYFT',
@@ -242,7 +249,10 @@ describe('Pinned scanner wrapper and sandbox lifecycle', () => {
         SYFT_PYTHON_SEARCH_REMOTE_LICENSES: 'false',
         SYFT_FILE_CONTENT_SKIP_FILES_ABOVE_SIZE: '5242880'
       }),
-      artifactSchema: 'CYCLONEDX_JSON'
+      artifactSchema: 'CYCLONEDX_JSON',
+      artifactSchemaVersion: '1.6',
+      schemaBundleDigest: digest('a'),
+      normalizerBundleDigest: digest('b')
     });
 
     for (const invocation of invocations) {

--- a/apps/api/test/scan-plane/scanner-runtime-persistence.e2e-spec.ts
+++ b/apps/api/test/scan-plane/scanner-runtime-persistence.e2e-spec.ts
@@ -30,6 +30,13 @@ describe('Scanner runtime persistence and deployment contract', () => {
       ),
       'utf8'
     );
+    const validationMigration = readFileSync(
+      resolve(
+        __dirname,
+        '../../prisma/migrations/20260724210000_sast_artifact_validation/migration.sql'
+      ),
+      'utf8'
+    );
     const packageJson = JSON.parse(
       readFileSync(resolve(__dirname, '../../package.json'), 'utf8')
     ) as {
@@ -47,6 +54,8 @@ describe('Scanner runtime persistence and deployment contract', () => {
     expect(schema).toMatch(/scannerWorkspaceInventoryDigest\s+String\?/);
     expect(schema).toMatch(/resourceMetadata\s+Json\?/);
     expect(schema).toMatch(/artifactMetadata\s+Json\?/);
+    expect(schema).toMatch(/schemaBundleDigest\s+String\?/);
+    expect(schema).toMatch(/normalizerBundleDigest\s+String\?/);
     expect(schema).toMatch(/@@unique\(\[attemptId, scanner\]\)/);
     expect(schema).toMatch(/model SastArtifactIngestion \{/);
     expect(schema).toMatch(
@@ -55,6 +64,7 @@ describe('Scanner runtime persistence and deployment contract', () => {
     expect(schema).toMatch(
       /status\s+SastArtifactIngestionStatus\s+@default\(RECEIVING\)/
     );
+    expect(schema).toMatch(/envelope\s+Json\?/);
 
     expect(migration).toContain(
       'CONSTRAINT "SastScanAttempt_attempt_number_check"'
@@ -101,7 +111,28 @@ describe('Scanner runtime persistence and deployment contract', () => {
       "name: 'ScannerRun_exit_code_check'"
     );
     expect(onlineSchema).toContain(
-      "name: 'ScannerRun_runtime_metadata_v2_check'"
+      "name: 'ScannerRun_runtime_metadata_v3_check'"
+    );
+    expect(onlineSchema).toContain(
+      `"artifactSchemaVersion" = '2.1.0'`
+    );
+    expect(onlineSchema).toContain(
+      `"artifactSchemaVersion" = '2'`
+    );
+    expect(onlineSchema).toContain(
+      `"artifactSchemaVersion" = '1.6'`
+    );
+    expect(onlineSchema).toContain(
+      `"schemaBundleDigest" IS NULL`
+    );
+    expect(validationMigration).toContain(
+      'ADD COLUMN "schemaBundleDigest" TEXT'
+    );
+    expect(validationMigration).toContain(
+      'ADD COLUMN "normalizerBundleDigest" TEXT'
+    );
+    expect(validationMigration).toContain(
+      'ADD COLUMN "envelope" JSONB'
     );
     expect(onlineSchema).toContain(
       `("artifactMetadata" ->> 'byteSize')::numeric > 0`
@@ -150,12 +181,18 @@ describe('Scanner runtime persistence and deployment contract', () => {
       'DROP CONSTRAINT IF EXISTS "ScannerRun_runtime_metadata_check"'
     );
     expect(onlineSchema).toContain(
-      "replacement: 'ScannerRun_runtime_metadata_v2_check'"
+      "name: 'ScannerRun_runtime_metadata_v2_check'"
+    );
+    expect(onlineSchema).toContain(
+      "replacement: 'ScannerRun_runtime_metadata_v3_check'"
     );
     expect(onlineSchema).toContain(
       'superseded constraint removed:'
     );
     expect(ingressMigration).not.toMatch(
+      /^\s*CREATE (?:UNIQUE )?INDEX CONCURRENTLY/m
+    );
+    expect(validationMigration).not.toMatch(
       /^\s*CREATE (?:UNIQUE )?INDEX CONCURRENTLY/m
     );
     expect(onlineSchema).toMatch(/OR COALESCE\(/);
@@ -259,7 +296,31 @@ describe('Scanner runtime persistence and deployment contract', () => {
         responseObjectKeyAllowed: false,
         acceptedTransportState: 'PENDING_VALIDATION',
         defaultObjectStoreProvider:
-          'FAIL_CLOSED_UNTIL_DATA_SECURITY_ADAPTER_INSTALLED'
+          'FAIL_CLOSED_UNTIL_DATA_SECURITY_ADAPTER_INSTALLED',
+        artifactValidation: {
+          version: 'sast-artifact-validation-v1',
+          mode: 'STREAMING_BOUNDED_TEE',
+          maximumJsonDepth: 64,
+          maximumObjectKeys: 4096,
+          maximumStringBytes: 4096,
+          maximumCoordinateAttestationLines: 5_000_000,
+          transportChunkInvariant: true,
+          duplicateKeysAllowed: false,
+          utf8BomAllowed: false,
+          schemas: {
+            OPENGREP_SARIF: '2.1.0',
+            TRIVY_JSON: '2',
+            CYCLONEDX_JSON: '1.6'
+          },
+          exactScannerArtifactRefBindingRequired: true,
+          pinnedEnumsRequired: true,
+          independentTransportAndValidatorDigestRequired: true,
+          coordinateAttestationRequiredForLocations: true,
+          defaultCoordinateAttestationProvider: 'FAIL_CLOSED',
+          deterministicReasonOrderingRequired: true,
+          rawPayloadInValidationMetadataAllowed: false,
+          finalDispositionOwner: 'T031_QUARANTINE'
+        }
       },
       productionMockAnalysisAllowed: false,
       scannerEntrypoints: {

--- a/deploy/scanner-sandbox/provisioning-contract.json
+++ b/deploy/scanner-sandbox/provisioning-contract.json
@@ -146,7 +146,38 @@
     "readRouteAllowed": false,
     "responseObjectKeyAllowed": false,
     "acceptedTransportState": "PENDING_VALIDATION",
-    "defaultObjectStoreProvider": "FAIL_CLOSED_UNTIL_DATA_SECURITY_ADAPTER_INSTALLED"
+    "defaultObjectStoreProvider": "FAIL_CLOSED_UNTIL_DATA_SECURITY_ADAPTER_INSTALLED",
+    "artifactValidation": {
+      "version": "sast-artifact-validation-v1",
+      "mode": "STREAMING_BOUNDED_TEE",
+      "maximumJsonDepth": 64,
+      "maximumKeyBytes": 256,
+      "maximumObjectKeys": 4096,
+      "maximumStringBytes": 4096,
+      "maximumNumberTokenBytes": 128,
+      "maximumTokenCount": 5000000,
+      "maximumCoordinateAttestationLines": 5000000,
+      "parserSliceBytes": 4096,
+      "transportChunkInvariant": true,
+      "duplicateKeysAllowed": false,
+      "utf8BomAllowed": false,
+      "schemas": {
+        "OPENGREP_SARIF": "2.1.0",
+        "TRIVY_JSON": "2",
+        "CYCLONEDX_JSON": "1.6"
+      },
+      "schemaBundleDigestRequired": true,
+      "normalizerBundleDigestRequired": true,
+      "trivyDatabaseDigestRequired": true,
+      "exactScannerArtifactRefBindingRequired": true,
+      "pinnedEnumsRequired": true,
+      "independentTransportAndValidatorDigestRequired": true,
+      "coordinateAttestationRequiredForLocations": true,
+      "defaultCoordinateAttestationProvider": "FAIL_CLOSED",
+      "deterministicReasonOrderingRequired": true,
+      "rawPayloadInValidationMetadataAllowed": false,
+      "finalDispositionOwner": "T031_QUARANTINE"
+    }
   },
   "allowedOperations": [
     "SCAN_SCOPED_REPOSITORY_FETCH",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './types/production-architecture';
 export * from './types/ai-inference-runtime';
 export * from './types/deployment-operations';
 export * from './types/sast-runtime';
+export * from './types/sast-artifact-validation';
 export * from './types/sast-planning';
 export * from './types/sast-fetch';
 export * from './types/sast-wrapper';

--- a/packages/shared/src/types/sast-artifact-validation.ts
+++ b/packages/shared/src/types/sast-artifact-validation.ts
@@ -1,0 +1,280 @@
+import {
+  SAST_ARTIFACT_SCHEMAS,
+  type SastArtifactSchema
+} from './sast-runtime';
+
+export const SAST_ARTIFACT_VALIDATION_VERSION =
+  'sast-artifact-validation-v1' as const;
+
+export const SAST_ARTIFACT_VALIDATION_LIMITS = Object.freeze({
+  maximumJsonDepth: 64,
+  maximumKeyBytes: 256,
+  maximumObjectKeys: 4096,
+  maximumStringBytes: 4096,
+  maximumNumberTokenBytes: 128,
+  maximumTokenCount: 5_000_000,
+  maximumCoordinateAttestationLines: 5_000_000,
+  parserSliceBytes: 4096
+});
+
+export const SAST_ARTIFACT_VALIDATION_REASON_CODES = [
+  'ARTIFACT_PLAN_BINDING_MISMATCH',
+  'ARTIFACT_SCHEMA_VERSION_MISMATCH',
+  'ARTIFACT_CONTENT_DIGEST_MISMATCH',
+  'ARTIFACT_BYTE_SIZE_MISMATCH',
+  'ARTIFACT_RECORD_COUNT_MISMATCH',
+  'ARTIFACT_RECORD_LIMIT_EXCEEDED',
+  'ARTIFACT_INVALID_UTF8',
+  'ARTIFACT_JSON_MALFORMED',
+  'ARTIFACT_JSON_DUPLICATE_KEY',
+  'ARTIFACT_JSON_DEPTH_LIMIT_EXCEEDED',
+  'ARTIFACT_JSON_KEY_LIMIT_EXCEEDED',
+  'ARTIFACT_JSON_KEY_COUNT_LIMIT_EXCEEDED',
+  'ARTIFACT_JSON_STRING_LIMIT_EXCEEDED',
+  'ARTIFACT_JSON_NUMBER_LIMIT_EXCEEDED',
+  'ARTIFACT_JSON_TOKEN_LIMIT_EXCEEDED',
+  'ARTIFACT_SCHEMA_REQUIRED_FIELD_MISSING',
+  'ARTIFACT_SCHEMA_UNKNOWN_FIELD',
+  'ARTIFACT_SCHEMA_FIELD_INVALID',
+  'ARTIFACT_PATH_INVALID',
+  'ARTIFACT_PATH_COLLISION',
+  'ARTIFACT_PATH_LIMIT_EXCEEDED',
+  'ARTIFACT_COORDINATE_INVALID',
+  'ARTIFACT_COORDINATE_ATTESTATION_MISSING'
+] as const;
+export type SastArtifactValidationReasonCode =
+  (typeof SAST_ARTIFACT_VALIDATION_REASON_CODES)[number];
+
+export interface SastArtifactValidationChecks {
+  planBinding: boolean;
+  schema: boolean;
+  contentDigest: boolean;
+  byteSize: boolean;
+  recordCount: boolean;
+  encoding: boolean;
+  jsonStructure: boolean;
+  path: boolean;
+  coordinate: boolean;
+}
+
+export interface SastArtifactValidationStatistics {
+  observedByteSize: number;
+  observedRecordCount: number;
+  maximumObservedDepth: number;
+  maximumObservedStringBytes: number;
+  normalizedPathCount: number;
+  coordinateCount: number;
+}
+
+export interface SastArtifactValidationResult {
+  version: typeof SAST_ARTIFACT_VALIDATION_VERSION;
+  outcome: 'PASSED' | 'FAILED';
+  artifactSchema: SastArtifactSchema;
+  envelopeDigest: `sha256:${string}`;
+  observedContentDigest: `sha256:${string}`;
+  checks: Readonly<SastArtifactValidationChecks>;
+  reasonCodes: readonly SastArtifactValidationReasonCode[];
+  statistics: Readonly<SastArtifactValidationStatistics>;
+  resultDigest: `sha256:${string}`;
+}
+
+export type SastArtifactValidationResultCore = Omit<
+  SastArtifactValidationResult,
+  'resultDigest'
+>;
+
+export function deriveSastArtifactValidationChecks(
+  reasonCodes: readonly SastArtifactValidationReasonCode[]
+): SastArtifactValidationChecks {
+  const reasons = new Set(reasonCodes);
+  const hasAny = (
+    candidates: readonly SastArtifactValidationReasonCode[]
+  ) => candidates.some((reason) => reasons.has(reason));
+
+  return {
+    planBinding: !reasons.has('ARTIFACT_PLAN_BINDING_MISMATCH'),
+    schema: !hasAny([
+      'ARTIFACT_SCHEMA_VERSION_MISMATCH',
+      'ARTIFACT_SCHEMA_REQUIRED_FIELD_MISSING',
+      'ARTIFACT_SCHEMA_UNKNOWN_FIELD',
+      'ARTIFACT_SCHEMA_FIELD_INVALID'
+    ]),
+    contentDigest: !reasons.has('ARTIFACT_CONTENT_DIGEST_MISMATCH'),
+    byteSize: !reasons.has('ARTIFACT_BYTE_SIZE_MISMATCH'),
+    recordCount: !hasAny([
+      'ARTIFACT_RECORD_COUNT_MISMATCH',
+      'ARTIFACT_RECORD_LIMIT_EXCEEDED'
+    ]),
+    encoding: !reasons.has('ARTIFACT_INVALID_UTF8'),
+    jsonStructure: !hasAny([
+      'ARTIFACT_JSON_MALFORMED',
+      'ARTIFACT_JSON_DUPLICATE_KEY',
+      'ARTIFACT_JSON_DEPTH_LIMIT_EXCEEDED',
+      'ARTIFACT_JSON_KEY_LIMIT_EXCEEDED',
+      'ARTIFACT_JSON_KEY_COUNT_LIMIT_EXCEEDED',
+      'ARTIFACT_JSON_STRING_LIMIT_EXCEEDED',
+      'ARTIFACT_JSON_NUMBER_LIMIT_EXCEEDED',
+      'ARTIFACT_JSON_TOKEN_LIMIT_EXCEEDED'
+    ]),
+    path: !hasAny([
+      'ARTIFACT_PATH_INVALID',
+      'ARTIFACT_PATH_COLLISION',
+      'ARTIFACT_PATH_LIMIT_EXCEEDED'
+    ]),
+    coordinate: !hasAny([
+      'ARTIFACT_COORDINATE_INVALID',
+      'ARTIFACT_COORDINATE_ATTESTATION_MISSING'
+    ])
+  };
+}
+
+export function canonicalizeSastArtifactValidationResult(
+  result: Readonly<SastArtifactValidationResultCore>
+): string {
+  return JSON.stringify({
+    version: result.version,
+    outcome: result.outcome,
+    artifactSchema: result.artifactSchema,
+    envelopeDigest: result.envelopeDigest,
+    observedContentDigest: result.observedContentDigest,
+    checks: {
+      planBinding: result.checks.planBinding,
+      schema: result.checks.schema,
+      contentDigest: result.checks.contentDigest,
+      byteSize: result.checks.byteSize,
+      recordCount: result.checks.recordCount,
+      encoding: result.checks.encoding,
+      jsonStructure: result.checks.jsonStructure,
+      path: result.checks.path,
+      coordinate: result.checks.coordinate
+    },
+    reasonCodes: [...result.reasonCodes],
+    statistics: {
+      observedByteSize: result.statistics.observedByteSize,
+      observedRecordCount: result.statistics.observedRecordCount,
+      maximumObservedDepth: result.statistics.maximumObservedDepth,
+      maximumObservedStringBytes:
+        result.statistics.maximumObservedStringBytes,
+      normalizedPathCount: result.statistics.normalizedPathCount,
+      coordinateCount: result.statistics.coordinateCount
+    }
+  });
+}
+
+export function isSastArtifactValidationResultShapeValid(
+  value: unknown
+): value is SastArtifactValidationResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+
+  const result = value as Record<string, unknown>;
+  const checks = result.checks as Record<string, unknown> | undefined;
+  const statistics = result.statistics as Record<string, unknown> | undefined;
+  const reasonCodes = result.reasonCodes;
+  if (
+    !hasOnlyKeys(result, [
+      'version',
+      'outcome',
+      'artifactSchema',
+      'envelopeDigest',
+      'observedContentDigest',
+      'checks',
+      'reasonCodes',
+      'statistics',
+      'resultDigest'
+    ]) ||
+    result.version !== SAST_ARTIFACT_VALIDATION_VERSION ||
+    (result.outcome !== 'PASSED' && result.outcome !== 'FAILED') ||
+    !SAST_ARTIFACT_SCHEMAS.includes(
+      result.artifactSchema as SastArtifactSchema
+    ) ||
+    !isSha256Digest(result.envelopeDigest) ||
+    !isSha256Digest(result.observedContentDigest) ||
+    !checks ||
+    !statistics ||
+    !Array.isArray(reasonCodes) ||
+    !isSha256Digest(result.resultDigest)
+  ) {
+    return false;
+  }
+
+  const checkKeys: readonly (keyof SastArtifactValidationChecks)[] = [
+    'planBinding',
+    'schema',
+    'contentDigest',
+    'byteSize',
+    'recordCount',
+    'encoding',
+    'jsonStructure',
+    'path',
+    'coordinate'
+  ];
+  const statisticKeys: readonly (keyof SastArtifactValidationStatistics)[] = [
+    'observedByteSize',
+    'observedRecordCount',
+    'maximumObservedDepth',
+    'maximumObservedStringBytes',
+    'normalizedPathCount',
+    'coordinateCount'
+  ];
+  const reasonsValid =
+    reasonCodes.every((reason) =>
+      SAST_ARTIFACT_VALIDATION_REASON_CODES.includes(
+        reason as SastArtifactValidationReasonCode
+      )
+    ) &&
+    reasonCodes.every(
+      (reason, index) =>
+        index === 0 ||
+        SAST_ARTIFACT_VALIDATION_REASON_CODES.indexOf(
+          reasonCodes[index - 1] as SastArtifactValidationReasonCode
+        ) <
+          SAST_ARTIFACT_VALIDATION_REASON_CODES.indexOf(
+            reason as SastArtifactValidationReasonCode
+          )
+    );
+  const checksValid =
+    hasOnlyKeys(checks, checkKeys) &&
+    checkKeys.every((key) => typeof checks[key] === 'boolean');
+  const derivedChecks = reasonsValid
+    ? deriveSastArtifactValidationChecks(
+        reasonCodes as SastArtifactValidationReasonCode[]
+      )
+    : null;
+  const checksConsistent =
+    checksValid &&
+    derivedChecks !== null &&
+    checkKeys.every((key) => checks[key] === derivedChecks[key]);
+  const statisticsValid =
+    hasOnlyKeys(statistics, statisticKeys) &&
+    statisticKeys.every(
+      (key) =>
+        typeof statistics[key] === 'number' &&
+        Number.isSafeInteger(statistics[key]) &&
+        (statistics[key] as number) >= 0
+    );
+  const allChecksPassed =
+    checksValid && checkKeys.every((key) => checks[key] === true);
+
+  return (
+    reasonsValid &&
+    checksConsistent &&
+    statisticsValid &&
+    (result.outcome === 'PASSED'
+      ? allChecksPassed && reasonCodes.length === 0
+      : !allChecksPassed && reasonCodes.length > 0)
+  );
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[]
+): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
+}
+
+function isSha256Digest(value: unknown): value is `sha256:${string}` {
+  return (
+    typeof value === 'string' && /^sha256:[a-f0-9]{64}$/u.test(value)
+  );
+}

--- a/packages/shared/src/types/sast-runtime.ts
+++ b/packages/shared/src/types/sast-runtime.ts
@@ -55,6 +55,19 @@ export const SAST_ARTIFACT_ENVELOPE_HEADER = 'x-aegis-sast-artifact-envelope';
 export const SAST_ARTIFACT_IDEMPOTENCY_HEADER = 'idempotency-key';
 export const SAST_MAX_ARTIFACT_ENVELOPE_BYTES = 8192;
 
+export const SAST_ARTIFACT_SCHEMAS = [
+  'OPENGREP_SARIF',
+  'TRIVY_JSON',
+  'CYCLONEDX_JSON'
+] as const;
+export type SastArtifactSchema = (typeof SAST_ARTIFACT_SCHEMAS)[number];
+
+export const SAST_ARTIFACT_SCHEMA_VERSIONS = {
+  OPENGREP_SARIF: '2.1.0',
+  TRIVY_JSON: '2',
+  CYCLONEDX_JSON: '1.6'
+} as const satisfies Record<SastArtifactSchema, string>;
+
 export const SAST_ARTIFACT_INGESTION_STATES = [
   'RECEIVING',
   'PENDING_VALIDATION',
@@ -431,14 +444,17 @@ export interface ScannerArtifactEnvelope {
   scannerImageDigest: `sha256:${string}`;
   wrapperDigest: `sha256:${string}`;
   ruleBundleDigest?: `sha256:${string}`;
+  vulnerabilityDatabaseDigest?: `sha256:${string}`;
   scannerSetDigest: `sha256:${string}`;
+  schemaBundleDigest: `sha256:${string}`;
+  normalizerBundleDigest: `sha256:${string}`;
   profileId: SastProfileId;
   profileDigest: `sha256:${string}`;
   preflightAttestationRef: string;
   preflightInventoryDigest: `sha256:${string}`;
   scannerWorkspaceInventoryDigest: `sha256:${string}`;
   inputCommitSha: string;
-  artifactSchema: 'OPENGREP_SARIF' | 'TRIVY_JSON' | 'CYCLONEDX_JSON';
+  artifactSchema: SastArtifactSchema;
   artifactSchemaVersion: string;
   artifactRef: string;
   contentDigest: `sha256:${string}`;
@@ -461,6 +477,8 @@ export interface SastArtifactIngressReceipt {
 export interface ExpectedScannerArtifactBinding {
   attemptId: string;
   scannerRunId: string;
+  scanner: SastScannerKind;
+  artifactRef: string;
   workloadIdentityRef: string;
   preflightAttestationRef: string;
   preflightInventoryDigest: `sha256:${string}`;
@@ -981,6 +999,8 @@ export function isScannerArtifactEnvelopeBoundToPlan(
     !SAST_SCANNER_KINDS.includes(envelope.scanner as SastScannerKind) ||
     !isNonBlank(expectedBinding.attemptId) ||
     !isNonBlank(expectedBinding.scannerRunId) ||
+    !SAST_SCANNER_KINDS.includes(expectedBinding.scanner) ||
+    !isNonBlank(expectedBinding.artifactRef) ||
     !isNonBlank(expectedBinding.workloadIdentityRef) ||
     !isNonBlank(expectedBinding.preflightAttestationRef) ||
     !isSha256Digest(expectedBinding.preflightInventoryDigest) ||
@@ -1004,6 +1024,10 @@ export function isScannerArtifactEnvelopeBoundToPlan(
     envelope.scanRequestId === plan.scanRequestId &&
     envelope.attemptId === expectedBinding.attemptId &&
     envelope.scannerRunId === expectedBinding.scannerRunId &&
+    envelope.scanner === expectedBinding.scanner &&
+    envelope.artifactRef === expectedBinding.artifactRef &&
+    envelope.artifactRef ===
+      `${plan.resultIngressRef}/${envelope.scanner.toLowerCase()}` &&
     envelope.workloadIdentityRef === expectedBinding.workloadIdentityRef &&
     envelope.preflightAttestationRef === expectedBinding.preflightAttestationRef &&
     envelope.preflightInventoryDigest === expectedBinding.preflightInventoryDigest &&
@@ -1013,11 +1037,14 @@ export function isScannerArtifactEnvelopeBoundToPlan(
     envelope.scannerImageDigest === scanner.digest &&
     envelope.wrapperDigest === scanner.wrapper.digest &&
     envelope.scannerSetDigest === plan.scannerSet.scannerSetDigest &&
+    envelope.schemaBundleDigest === plan.scannerSet.schemaBundle.digest &&
+    envelope.normalizerBundleDigest === plan.scannerSet.normalizerBundle.digest &&
     envelope.profileId === plan.profile.id &&
     envelope.profileDigest === plan.profileDigest &&
     envelope.inputCommitSha === plan.repositoryState.fixedCommitSha &&
     envelope.artifactSchema === expectedSchema &&
-    isNonBlank(envelope.artifactSchemaVersion) &&
+    envelope.artifactSchemaVersion ===
+      SAST_ARTIFACT_SCHEMA_VERSIONS[expectedSchema] &&
     isNonBlank(envelope.artifactRef) &&
     isSha256Digest(envelope.contentDigest) &&
     Number.isSafeInteger(envelope.byteSize) &&
@@ -1025,13 +1052,24 @@ export function isScannerArtifactEnvelopeBoundToPlan(
     envelope.byteSize <= plan.profile.limits.maxArtifactBytes &&
     Number.isSafeInteger(envelope.recordCount) &&
     envelope.recordCount >= 0 &&
-    envelope.recordCount <= plan.profile.limits.maxArtifactRecords &&
+    envelope.recordCount <=
+      (envelope.artifactSchema === 'CYCLONEDX_JSON'
+        ? plan.profile.limits.maxArtifactRecords
+        : Math.min(
+            plan.profile.limits.maxArtifactRecords,
+            plan.profile.limits.maxFindings
+          )) &&
     Number.isSafeInteger(envelope.exitCode) &&
     SCANNER_EXECUTION_STATUSES.includes(envelope.executionStatus) &&
     isIsoTimestamp(envelope.producedAt) &&
     (envelope.scanner === 'SYFT'
-      ? envelope.ruleBundleDigest === undefined
-      : envelope.ruleBundleDigest === expectedRuleBundle?.digest)
+      ? envelope.ruleBundleDigest === undefined &&
+        envelope.vulnerabilityDatabaseDigest === undefined
+      : envelope.ruleBundleDigest === expectedRuleBundle?.digest &&
+        (envelope.scanner === 'TRIVY'
+          ? envelope.vulnerabilityDatabaseDigest ===
+            plan.scannerSet.vulnerabilityDatabase.digest
+          : envelope.vulnerabilityDatabaseDigest === undefined))
   );
 }
 
@@ -1055,6 +1093,8 @@ export function isScannerArtifactEnvelopeShapeValid(
     'scannerImageDigest',
     'wrapperDigest',
     'scannerSetDigest',
+    'schemaBundleDigest',
+    'normalizerBundleDigest',
     'profileId',
     'profileDigest',
     'preflightAttestationRef',
@@ -1072,7 +1112,10 @@ export function isScannerArtifactEnvelopeShapeValid(
     'executionStatus',
     'producedAt'
   ] as const;
-  const optionalKeys = ['ruleBundleDigest'] as const;
+  const optionalKeys = [
+    'ruleBundleDigest',
+    'vulnerabilityDatabaseDigest'
+  ] as const;
   const actualKeys = Object.keys(envelope);
   if (
     requiredKeys.some((key) => !Object.hasOwn(envelope, key)) ||
@@ -1098,7 +1141,11 @@ export function isScannerArtifactEnvelopeShapeValid(
     isSha256Digest(envelope.wrapperDigest as string) &&
     (envelope.ruleBundleDigest === undefined ||
       isSha256Digest(envelope.ruleBundleDigest as string)) &&
+    (envelope.vulnerabilityDatabaseDigest === undefined ||
+      isSha256Digest(envelope.vulnerabilityDatabaseDigest as string)) &&
     isSha256Digest(envelope.scannerSetDigest as string) &&
+    isSha256Digest(envelope.schemaBundleDigest as string) &&
+    isSha256Digest(envelope.normalizerBundleDigest as string) &&
     SAST_PROFILE_IDS.includes(envelope.profileId as SastProfileId) &&
     isSha256Digest(envelope.profileDigest as string) &&
     isBoundedIngressText(envelope.preflightAttestationRef, 8192) &&
@@ -1106,8 +1153,8 @@ export function isScannerArtifactEnvelopeShapeValid(
     isSha256Digest(envelope.scannerWorkspaceInventoryDigest as string) &&
     typeof envelope.inputCommitSha === 'string' &&
     isGitCommitSha(envelope.inputCommitSha) &&
-    ['OPENGREP_SARIF', 'TRIVY_JSON', 'CYCLONEDX_JSON'].includes(
-      envelope.artifactSchema as string
+    SAST_ARTIFACT_SCHEMAS.includes(
+      envelope.artifactSchema as SastArtifactSchema
     ) &&
     isBoundedIngressText(envelope.artifactSchemaVersion, 255) &&
     isBoundedIngressText(envelope.artifactRef, 2048) &&
@@ -1150,7 +1197,15 @@ export function canonicalizeScannerArtifactEnvelope(
     ...(envelope.ruleBundleDigest === undefined
       ? {}
       : { ruleBundleDigest: envelope.ruleBundleDigest }),
+    ...(envelope.vulnerabilityDatabaseDigest === undefined
+      ? {}
+      : {
+          vulnerabilityDatabaseDigest:
+            envelope.vulnerabilityDatabaseDigest
+        }),
     scannerSetDigest: envelope.scannerSetDigest,
+    schemaBundleDigest: envelope.schemaBundleDigest,
+    normalizerBundleDigest: envelope.normalizerBundleDigest,
     profileId: envelope.profileId,
     profileDigest: envelope.profileDigest,
     preflightAttestationRef: envelope.preflightAttestationRef,

--- a/packages/shared/src/types/sast-wrapper.ts
+++ b/packages/shared/src/types/sast-wrapper.ts
@@ -4,8 +4,10 @@ import type {
   SastRepositoryTreeEntry
 } from './sast-fetch';
 import {
+  SAST_ARTIFACT_SCHEMA_VERSIONS,
   SAST_SCANNER_KINDS,
   isSastScanPlanValid,
+  type SastArtifactSchema,
   type SastProfileId,
   type SastResourceLimits,
   type SastScanPlan,
@@ -152,8 +154,10 @@ export interface SastScannerInvocation {
   workingDirectory: string;
   scannerInputPath: string;
   outputPath: string;
-  artifactSchema: 'OPENGREP_SARIF' | 'TRIVY_JSON' | 'CYCLONEDX_JSON';
+  artifactSchema: SastArtifactSchema;
   artifactSchemaVersion: string;
+  schemaBundleDigest: `sha256:${string}`;
+  normalizerBundleDigest: `sha256:${string}`;
   scannerVersion: string;
   scannerImageDigest: `sha256:${string}`;
   wrapperDigest: `sha256:${string}`;
@@ -477,6 +481,8 @@ export function isSastScannerInvocationBoundToPlan(
       'scanner',
       'scannerInputPath',
       'scannerImageDigest',
+      'schemaBundleDigest',
+      'normalizerBundleDigest',
       'scannerSetDigest',
       'scannerVersion',
       'vulnerabilityDatabaseDigest',
@@ -533,7 +539,10 @@ export function isSastScannerInvocationBoundToPlan(
     invocation.outputPath === expectedOutputPath &&
     invocation.artifactSchema === expectedArtifactSchema &&
     invocation.artifactSchemaVersion ===
-      plan.scannerSet.schemaBundle.digest &&
+      SAST_ARTIFACT_SCHEMA_VERSIONS[expectedArtifactSchema] &&
+    invocation.schemaBundleDigest === plan.scannerSet.schemaBundle.digest &&
+    invocation.normalizerBundleDigest ===
+      plan.scannerSet.normalizerBundle.digest &&
     invocation.scannerVersion === scanner.version &&
     invocation.scannerImageDigest === scanner.digest &&
     invocation.wrapperDigest === scanner.wrapper.digest &&
@@ -664,7 +673,13 @@ export function isSastScannerProcessObservationValid(
         artifact.byteSize <= limits.maxArtifactBytes &&
         Number.isSafeInteger(artifact.recordCount) &&
         artifact.recordCount >= 0 &&
-        artifact.recordCount <= limits.maxArtifactRecords &&
+        artifact.recordCount <=
+          (observation.scanner === 'SYFT'
+            ? limits.maxArtifactRecords
+            : Math.min(
+                limits.maxArtifactRecords,
+                limits.maxFindings
+              )) &&
         typeof artifact.truncated === 'boolean'))
   );
 }

--- a/packages/shared/test/sast-runtime-behavior.test.mjs
+++ b/packages/shared/test/sast-runtime-behavior.test.mjs
@@ -130,6 +130,8 @@ const buildArtifactEnvelope = (plan) => ({
   ruleBundleDigest: plan.scannerSet.ruleBundles.find((bundle) => bundle.scanner === 'OPENGREP')
     .digest,
   scannerSetDigest: plan.scannerSet.scannerSetDigest,
+  schemaBundleDigest: plan.scannerSet.schemaBundle.digest,
+  normalizerBundleDigest: plan.scannerSet.normalizerBundle.digest,
   profileId: plan.profile.id,
   profileDigest: plan.profileDigest,
   preflightAttestationRef: 'attestation://attempt-1/preflight',
@@ -138,7 +140,7 @@ const buildArtifactEnvelope = (plan) => ({
   inputCommitSha: plan.repositoryState.fixedCommitSha,
   artifactSchema: 'OPENGREP_SARIF',
   artifactSchemaVersion: '2.1.0',
-  artifactRef: 'artifact://scanner-run-1',
+  artifactRef: `${plan.resultIngressRef}/opengrep`,
   contentDigest: digest('4'),
   byteSize: 1024,
   recordCount: 10,
@@ -151,6 +153,8 @@ const buildArtifactEnvelope = (plan) => ({
 const expectedArtifactBinding = (envelope) => ({
   attemptId: envelope.attemptId,
   scannerRunId: envelope.scannerRunId,
+  scanner: envelope.scanner,
+  artifactRef: envelope.artifactRef,
   workloadIdentityRef: envelope.workloadIdentityRef,
   preflightAttestationRef: envelope.preflightAttestationRef,
   preflightInventoryDigest: envelope.preflightInventoryDigest
@@ -298,6 +302,22 @@ test('scan plans and artifact envelopes bind fixed intent and reject normalizati
       envelope,
       plan,
       { ...expectedBinding, attemptId: 'attempt-current' }
+    ),
+    false
+  );
+  assert.equal(
+    runtime.isScannerArtifactEnvelopeBoundToPlan(
+      envelope,
+      plan,
+      { ...expectedBinding, scanner: 'TRIVY' }
+    ),
+    false
+  );
+  assert.equal(
+    runtime.isScannerArtifactEnvelopeBoundToPlan(
+      envelope,
+      plan,
+      { ...expectedBinding, artifactRef: 'ingress://other/opengrep' }
     ),
     false
   );

--- a/packages/shared/test/sast-runtime.test.mjs
+++ b/packages/shared/test/sast-runtime.test.mjs
@@ -151,6 +151,9 @@ test('scanner artifacts carry bounded provenance metadata instead of raw reposit
   for (const field of [
     'scannerImageDigest',
     'ruleBundleDigest',
+    'vulnerabilityDatabaseDigest',
+    'schemaBundleDigest',
+    'normalizerBundleDigest',
     'inputCommitSha',
     'artifactSchemaVersion',
     'artifactRef',

--- a/packages/shared/test/shared-contract-exports.test.mjs
+++ b/packages/shared/test/shared-contract-exports.test.mjs
@@ -13,6 +13,10 @@ const files = {
   aiInferenceRuntime: new URL('../src/types/ai-inference-runtime.ts', import.meta.url),
   deploymentOperations: new URL('../src/types/deployment-operations.ts', import.meta.url),
   sastRuntime: new URL('../src/types/sast-runtime.ts', import.meta.url),
+  sastArtifactValidation: new URL(
+    '../src/types/sast-artifact-validation.ts',
+    import.meta.url
+  ),
   sastPlanning: new URL('../src/types/sast-planning.ts', import.meta.url),
   sastFetch: new URL('../src/types/sast-fetch.ts', import.meta.url),
   sastWrapper: new URL('../src/types/sast-wrapper.ts', import.meta.url),
@@ -37,6 +41,7 @@ test('shared contract modules exist and are re-exported from the package root', 
     'ai-inference-runtime',
     'deployment-operations',
     'sast-runtime',
+    'sast-artifact-validation',
     'sast-planning',
     'sast-fetch',
     'sast-wrapper'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@prisma/client':
         specifier: '5'
         version: 5.22.0(prisma@5.22.0)
+      '@streamparser/json':
+        specifier: 0.0.22
+        version: 0.0.22
       axios:
         specifier: ^1.13.2
         version: 1.13.6
@@ -1163,6 +1166,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@streamparser/json@0.0.22':
+    resolution: {integrity: sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==}
 
   '@tanstack/query-core@5.95.2':
     resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
@@ -5032,6 +5038,8 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@streamparser/json@0.0.22': {}
 
   '@tanstack/query-core@5.95.2': {}
 

--- a/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
+++ b/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
@@ -399,6 +399,57 @@ exists and the object key is absent from all ingress responses. The default prod
 adapter remains unavailable until a Data/Security Plane object-store implementation is
 installed, so local filesystem storage cannot become a production fallback.
 
+T030 validates the first upload inline as a bounded tee before the object write completes.
+The parser uses fatal UTF-8 decoding, rejects a BOM and duplicate JSON keys, and caps nesting
+at 64, each key at 256 UTF-8 bytes, each object at 4,096 keys, strings at 4,096 UTF-8 bytes, number tokens at 128 bytes, and
+the document at 5,000,000 tokens. Parsing occurs on globally aligned, at most 4,096-byte slices
+independent of transport chunking and never builds the artifact object graph. A parser or schema
+failure stops further parsing but continues
+draining the already transport-bounded stream to the immutable object so T031 can apply the
+same quarantine policy without a second sandbox upload.
+
+The envelope carries a semantic artifact version separately from immutable supply-chain
+digests:
+
+- OpenGrep emits `OPENGREP_SARIF` version `2.1.0`.
+- Trivy emits `TRIVY_JSON` version `2` and must bind the pinned vulnerability database.
+- Syft emits `CYCLONEDX_JSON` version `1.6`.
+- Every scanner binds the scanner-set, schema-bundle, and normalizer-bundle digests; OpenGrep
+  and Trivy also bind their rule bundle.
+
+Schema-specific streaming inspection enforces root, run/result, finding, and component
+container types; required tool/message structures; pinned enum/version sets; and explicit
+unknown-field sets at security-relevant boundaries. The immutable binding includes the exact
+scanner-run scanner and canonical result-ingress artifact reference in addition to attempt,
+identity, inventory, profile, source, and supply-chain digests. It counts SARIF results, Trivy vulnerabilities/
+misconfigurations/secrets, and nested CycloneDX components independently of the envelope.
+The transport observer and validator independently recompute content SHA-256 and bytes and
+must agree with one another and the envelope; records are independently counted and checked
+against the envelope and immutable profile limits. OpenGrep and Trivy records are additionally capped by the smaller
+`maxFindings` limit, while CycloneDX inventory components use `maxArtifactRecords`.
+
+Artifact paths must be NFC repository-relative canonical paths with bounded length/depth and
+no absolute, drive, UNC, control, empty, dot, or parent segments. Case-fold ambiguity is
+rejected, and unique retained paths cannot exceed the smaller profile file/artifact-record
+limit. SARIF URI references may use only canonical uppercase percent-encoding; encoded
+separators, encoded unreserved characters, and indirect `uriBaseId`/artifact-index resolution
+are rejected, then the decoded direct path must match
+the provisioner-attested inventory exactly. Positive safe-integer lines and columns are
+checked against `2,147,483,647` and, when present, the exact attested file line/column bounds.
+The attestation provider is scoped to tenant, repository, scan, attempt, attestation reference,
+and inventory digest; unavailable, malformed, duplicate, or case-colliding metadata fails
+closed for every reported location. Coordinate metadata is also capped at 5,000,000 attested
+lines in addition to the profile file-count limit; provider implementations must apply the
+same cap before materializing their return value.
+
+The durable validation value is `sast-artifact-validation-v1`: ordered boolean checks, ordered
+reason codes, aggregate byte/record/depth/string/path/coordinate statistics, and a SHA-256
+result digest over its canonical core. Audit metadata receives only the outcome, result digest,
+and bounded reason-code list. Raw artifact bytes, source, secret values, and object keys are
+excluded. Completing T030 does not accept an artifact: all completed transports remain
+`PENDING_VALIDATION`, and T031 alone performs the atomic accept/reject/encrypted-quarantine
+disposition before any normalization adapter can run.
+
 Accepted artifacts become short-lived Data/Security objects. Rejected artifacts record
 metadata only. Security-significant mismatches are encrypted into an access-restricted
 quarantine prefix with the same maximum seven-day retention and no user access.

--- a/specs/006-production-sast-runtime-design/data-model.md
+++ b/specs/006-production-sast-runtime-design/data-model.md
@@ -292,7 +292,7 @@ The envelope never embeds raw artifact bytes.
 Operational write-only intake state before an `ArtifactIngestionDecision`.
 
 - tenant, repository binding, scan, attempt, scanner run, and workload-identity references
-- scanner-run-unique idempotency key and canonical envelope digest
+- scanner-run-unique idempotency key, canonical envelope snapshot, and canonical envelope digest
 - declared and independently observed content digests and byte counts
 - opaque Data/Security Plane object key, never returned by the ingress or user-facing APIs
 - workload-identity validation result
@@ -302,7 +302,17 @@ Operational write-only intake state before an `ArtifactIngestionDecision`.
 Only a directly authenticated, attempt-bound workload can create the row. `RECEIVING` has no
 object key or observed metadata. `PENDING_VALIDATION` has an immutable object key, matching
 transport byte count, observed digest, and receipt timestamp; it is not yet eligible for
-normalization. One scanner run can own at most one ingestion.
+normalization. Its bounded `artifactValidation` metadata contains
+`sast-artifact-validation-v1`, outcome, artifact schema, envelope and observed-content digests,
+per-boundary boolean checks, globally ordered reason codes, aggregate parser/path/coordinate
+statistics, and a deterministic result digest. It never contains raw artifact/source bytes,
+secret values, or the object key. One scanner run can own at most one ingestion.
+
+The canonical envelope JSON is stored separately from the digest so T031 can make an
+independent disposition without trusting request reconstruction. The nullable database column
+supports rolling deployment of legacy rows; every new application reservation writes it.
+`PENDING_VALIDATION` remains a transport-complete state regardless of validation outcome until
+T031 atomically chooses `ACCEPTED`, `REJECTED`, or `QUARANTINED`.
 
 ### ArtifactIngestionDecision
 

--- a/specs/006-production-sast-runtime-design/quickstart.md
+++ b/specs/006-production-sast-runtime-design/quickstart.md
@@ -194,13 +194,37 @@ Phase 6 ingress boundary:
 - The Scan Plane has no artifact read route and its object-store port exposes only immutable
   write and cleanup delete. The default provider fails closed until the production
   Data/Security Plane adapter is installed; raw object keys never enter user-facing responses.
+- The T030 validator tees each newly reserved artifact through a strict UTF-8 and bounded
+  streaming JSON parser while the immutable object write proceeds. Parser slices are aligned to
+  global byte offsets, so valid and invalid results are invariant to transport chunking. It independently binds the
+  semantic OpenGrep SARIF 2.1.0, Trivy JSON v2, or CycloneDX 1.6 schema plus scanner-set,
+  schema-bundle, normalizer-bundle, rule, and Trivy database digests together with the exact
+  scanner and canonical artifact reference. The transport and validator independently recompute
+  content digest and byte count, and the validator recomputes schema-specific record count; it
+  rejects duplicate keys, excessive depth/tokens/key size/object-key count/string/number size, unknown boundary fields
+  or enums, missing required tool/message structures, unsafe paths, path collisions,
+  and invalid coordinates. SARIF URI paths are decoded only from canonical uppercase
+  percent-encoding before exact attested-path comparison.
+- Validation emits only a versioned, bounded, deterministically ordered result containing
+  boolean checks, reason codes, aggregate statistics, and a result digest. The canonical
+  envelope snapshot and result are durable on `SastArtifactIngestion`; neither raw bytes nor
+  object keys enter logs, audit metadata, user APIs, or the AI Plane. File coordinates require
+  exact provisioner-attested metadata for the attempt and inventory digest; the production
+  default provider returns no attestation and therefore never relaxes a location check.
+- T030 deliberately leaves both valid and invalid completed transports in
+  `PENDING_VALIDATION`. T031 owns the atomic final disposition and encrypted quarantine move,
+  so no artifact is normalization-eligible merely because streaming validation completed.
+  The online `ScannerRun_runtime_metadata_v3_check` accepts legacy digest-version rows during
+  rolling deployment while enforcing semantic schema versions and separate schema/normalizer
+  digests for new rows, and removes v1/v2 only after v3 validation succeeds.
 
 This checkpoint proves the provider-facing execution contract but does not claim that the
 provider microVM platform is live. The non-production opaque credential issuer and test
 runtime provider exist only to verify the handoff contract. Default production credential
 issuance and scanner execution both fail closed until live rollout installs provider-backed
-GitHub App/GitLab scoped minting, microVM, and artifact object-store adapters. T030 is therefore the next implementation
-task; live deployment eligibility still requires the 005 rollout and the remaining 006 gates.
+GitHub App/GitLab scoped minting, microVM, artifact object-store, and file-coordinate
+attestation adapters. T031 is therefore the next implementation task; live deployment
+eligibility still requires the 005 rollout and the remaining 006 gates.
 
 ## Deployment Position
 

--- a/specs/006-production-sast-runtime-design/tasks.md
+++ b/specs/006-production-sast-runtime-design/tasks.md
@@ -46,7 +46,7 @@
 ## Phase 6: Artifact Ingress and Normalization
 
 - [x] T029 Implement per-scan write-only artifact ingress and workload identity validation
-- [ ] T030 Verify plan binding, schema, digest, byte/count, encoding, path, and coordinate limits
+- [x] T030 Verify plan binding, schema, digest, byte/count, encoding, path, and coordinate limits
 - [ ] T031 Quarantine malformed, mismatched, oversized, and security-violating artifacts
 - [ ] T032 Implement versioned OpenGrep SARIF normalization with golden fixtures
 - [ ] T033 Implement versioned Trivy JSON normalization with golden fixtures


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/256-006-artifact-validation`
- 이슈: #256
- 선행 PR: #255

## 🔎 주요 변경 사항

- scanner artifact를 전체 메모리에 적재하지 않는 strict UTF-8·bounded streaming JSON validator를 추가했습니다.
- duplicate key, malformed JSON, BOM, depth/key/object-key/string/number/token 한도를 fail closed로 검증하며 transport chunking과 무관한 결정적 결과를 생성합니다.
- OpenGrep SARIF 2.1.0, Trivy JSON v2, CycloneDX 1.6의 pinned version·필수 구조·boundary unknown field·enum 정책과 schema/normalizer/rule/database digest를 durable plan에 다시 결합합니다.
- exact scanner/artifact reference, SHA-256, byte/record count와 profile limit를 ingress observer 및 validator가 독립적으로 교차 검증합니다.
- NFC repository-relative path, case-fold collision, SARIF URI, provisioner-attested line/column 범위를 검증하고 기본 attestation provider는 fail closed로 유지합니다.
- canonical envelope와 bounded validation metadata/result digest를 영속화하되 raw artifact/source/secret/object key는 로그·감사·사용자 API·AI Plane에 노출하지 않습니다.
- `PENDING_VALIDATION` 경계를 유지해 T031 전에는 valid/invalid artifact 모두 normalization으로 진입할 수 없도록 했습니다.
- Prisma migration/rolling v3 constraint, malicious parser corpus, schema별 fixtures, DB contract tests와 006 문서를 동기화했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `corepack pnpm lint`
- `corepack pnpm test` (shared 38, AI, web 54, API 77 suites / 357 tests, GitHub·CI·deployment contract 19)
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- focused artifact validation 34 tests 및 shared contract 38 tests
- `git diff --check`

## 006 진행 상태

- T030 완료
- 다음 작업: T031 invalid artifact final disposition 및 encrypted quarantine

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded, streaming validation for SAST and SBOM uploads, including UTF-8, JSON structure, schema, size, digest, path, and coordinate checks.
  - Added support for validating OpenGrep SARIF, Trivy JSON, and CycloneDX JSON artifacts.
  - Scanner results now retain artifact envelopes, validation outcomes, and bundle provenance for auditability.
  - Added stricter binding between scanner results, schemas, digests, and scan plans.

- **Documentation**
  - Updated runtime design and quickstart documentation to describe validation, quarantine, and final disposition workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->