### PR TITLE
feat: 006 secret value redaction 구현

### DIFF
--- a/apps/api/src/scan-plane/sast-secret-redaction.service.ts
+++ b/apps/api/src/scan-plane/sast-secret-redaction.service.ts
@@ -1,8 +1,10 @@
 import { createHash } from 'node:crypto';
+import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
 import { TextEncoder } from 'node:util';
 
 import { Injectable } from '@nestjs/common';
 import {
+  SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS,
   SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
   SAST_SECRET_REDACTION_LIMITS,
   SAST_SECRET_REDACTION_TOKEN,
@@ -27,6 +29,7 @@ import {
   type SastArtifactDispositionDecision,
   type SastNormalizedFindingCandidate,
   type SastSecretDetectorKind,
+  type SastSecretRedactionBatchInspectedField,
   type SastSecretRedactableField,
   type SastSecretRedactedFindingCandidate,
   type SastSecretRedactedFindingCandidateCore,
@@ -60,13 +63,11 @@ const KNOWN_SECRET_PATTERNS: readonly SecretPattern[] = [
   },
   {
     kind: 'AUTHORIZATION_CREDENTIAL',
-    contextual: true,
     expression:
       /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic)\s+[A-Za-z0-9+/_=.-]{4,2048}/giu
   },
   {
     kind: 'URL_CREDENTIAL',
-    contextual: true,
     expression:
       /\b[a-z][a-z0-9+.-]{1,15}:\/\/[^\s/@:]{1,256}:[^\s/@]{1,512}@/giu
   },
@@ -110,9 +111,19 @@ const KNOWN_SECRET_PATTERNS: readonly SecretPattern[] = [
   },
   {
     kind: 'SECRET_ASSIGNMENT',
+    expression:
+      /(?:\\"(?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\\"\s*:\s*\\"[^"\r\n]{1,512}\\"|\\'(?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\\'\s*:\s*\\'[^'\r\n]{1,512}\\')/giu
+  },
+  {
+    kind: 'SECRET_ASSIGNMENT',
+    expression:
+      /(?:(?<![\p{L}\p{N}])["'](?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)["']\s*:\s*(?:"[^"\r\n]{1,512}"|'[^'\r\n]{1,512}'|[^\s,;]{4,512})|(?<![\p{L}\p{N}])["']?(?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)["']?\s*(?:=>|=)\s*(?:"[^"\r\n]{1,512}"|'[^'\r\n]{1,512}'|[^\s,;]{4,512})|(?<![\p{L}\p{N}])(?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\s*:\s*(?:"[^"\r\n]{1,512}"|'[^'\r\n]{1,512}'))/giu
+  },
+  {
+    kind: 'SECRET_ASSIGNMENT',
     contextual: true,
     expression:
-      /\b(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\b\s*(?:=>|=|:)\s*(?:"[^"\r\n]{1,512}"|'[^'\r\n]{1,512}'|[^\s,;]{4,512})/giu
+      /(?<![\p{L}\p{N}])(?:[\p{L}\p{N}]{1,64}[-_.]){0,8}(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\s*:\s*[^\s"'`,;]{4,512}/giu
   }
 ];
 
@@ -166,11 +177,17 @@ export interface SastSecretRedactionInput {
 
 @Injectable()
 export class SastSecretRedactionService {
-  redact(
+  async redact(
     input: Readonly<SastSecretRedactionInput>,
     clock: () => Date = () => new Date()
-  ): SastSecretRedactionResult {
-    if (!hasCandidateCountWithinLimit(input?.batch)) {
+  ): Promise<SastSecretRedactionResult> {
+    // Apply shallow count and text-work bounds before the exact source
+    // validator traverses and canonicalizes every candidate. The exact
+    // post-classification checks remain defensive trust-boundary checks.
+    if (
+      !hasCandidateCountWithinLimit(input?.batch) ||
+      !hasInspectionWorkWithinLimit(input?.batch)
+    ) {
       return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
     }
     const source = classifySourceBatch(input?.batch);
@@ -221,10 +238,21 @@ export class SastSecretRedactionService {
         'SECRET_REDACTION_PLATFORM_VALUES_INVALID'
       ]);
     }
+    const bindingFields = batchBindingFields(source.batch);
+    let inspectedCodeUnits = bindingFields.reduce(
+      (total, field) => total + field.length,
+      0
+    );
+    if (
+      inspectedCodeUnits >
+      SAST_SECRET_REDACTION_LIMITS.maximumInspectedCodeUnits
+    ) {
+      return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
+    }
     const platformMatcher =
       new PlatformSecretMatcher(platformSecrets);
     if (
-      batchBindingFields(source.batch).some(
+      bindingFields.some(
         (field) =>
           inspectSecrets(
             field,
@@ -242,7 +270,41 @@ export class SastSecretRedactionService {
 
     const findings: SastSecretRedactedFindingCandidate[] = [];
     let inspectedFieldCount = 0;
-    for (const finding of source.batch.findings) {
+    let codeUnitsSinceYield = inspectedCodeUnits;
+    for (
+      let index = 0;
+      index < source.batch.findings.length;
+      index += 1
+    ) {
+      const finding = source.batch.findings[index] as
+        SastNormalizedFindingCandidate;
+      const candidateCodeUnits =
+        candidateInspectionCodeUnits(finding);
+      if (
+        candidateCodeUnits >
+        SAST_SECRET_REDACTION_LIMITS
+          .maximumInspectedCodeUnits -
+          inspectedCodeUnits
+      ) {
+        return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
+      }
+      const candidateIntervalReached =
+        index %
+          SAST_SECRET_REDACTION_LIMITS
+            .yieldCandidateInterval ===
+        0;
+      const codeUnitIntervalReached =
+        codeUnitsSinceYield + candidateCodeUnits >
+        SAST_SECRET_REDACTION_LIMITS.yieldCodeUnitInterval;
+      if (
+        index > 0 &&
+        (candidateIntervalReached || codeUnitIntervalReached)
+      ) {
+        await this.yieldEventLoop();
+        codeUnitsSinceYield = 0;
+      }
+      inspectedCodeUnits += candidateCodeUnits;
+      codeUnitsSinceYield += candidateCodeUnits;
       const redacted = redactCandidate(
         finding,
         platformMatcher
@@ -367,13 +429,17 @@ export class SastSecretRedactionService {
         canonicalizeSastSecretRedactionBatch(batchCore)
       )
     };
-    if (!isSastSecretRedactionBatchShapeValid(batch)) {
+    if (!isSastSecretRedactionBatchShapeValid(batch, digest)) {
       return this.reject(['SECRET_REDACTION_OUTPUT_INVALID']);
     }
     return {
       outcome: 'REDACTED',
       batch
     };
+  }
+
+  protected async yieldEventLoop(): Promise<void> {
+    await yieldToEventLoop();
   }
 
   private reject(
@@ -429,6 +495,101 @@ function hasCandidateCountWithinLimit(value: unknown): boolean {
   );
 }
 
+function hasInspectionWorkWithinLimit(value: unknown): boolean {
+  try {
+    if (!isUnknownRecord(value)) return true;
+    const findings = value.findings;
+    if (!Array.isArray(findings)) return true;
+    const scope = isUnknownRecord(value.scope)
+      ? value.scope
+      : {};
+    let total = sumStringLengths([
+      value.ingestionId,
+      scope.tenantId,
+      scope.repositoryBindingId,
+      scope.scanRequestId,
+      scope.attemptId,
+      scope.scannerRunId,
+      value.scannerVersion,
+      value.preflightAttestationRef
+    ]);
+    if (
+      total >
+      SAST_SECRET_REDACTION_LIMITS.maximumInspectedCodeUnits
+    ) {
+      return false;
+    }
+    for (const finding of findings) {
+      if (!isUnknownRecord(finding)) continue;
+      const location = isUnknownRecord(finding.location)
+        ? finding.location
+        : {};
+      const identity = isUnknownRecord(
+        finding.identityMaterial
+      )
+        ? finding.identityMaterial
+        : {};
+      const provenance = isUnknownRecord(finding.provenance)
+        ? finding.provenance
+        : {};
+      const trivy = isUnknownRecord(finding.trivy)
+        ? finding.trivy
+        : {};
+      const next = sumStringLengths([
+        finding.title,
+        finding.description,
+        location.symbol,
+        location.normalizedPath,
+        identity.ruleSemanticId,
+        identity.symbolAnchor,
+        identity.sinkKind,
+        identity.scannerMatchBasedId,
+        provenance.scannerVersion,
+        provenance.ruleId,
+        provenance.ruleRevision,
+        trivy.vulnerabilityId,
+        trivy.packageName,
+        trivy.packageType,
+        trivy.installedVersion,
+        trivy.fixedVersion,
+        trivy.category,
+        trivy.checkType,
+        trivy.avdId
+      ]);
+      if (
+        next >
+        SAST_SECRET_REDACTION_LIMITS
+          .maximumInspectedCodeUnits -
+          total
+      ) {
+        return false;
+      }
+      total += next;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isUnknownRecord(
+  value: unknown
+): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function sumStringLengths(values: readonly unknown[]): number {
+  return values.reduce<number>(
+    (total, value) =>
+      total + (typeof value === 'string' ? value.length : 0),
+    0
+  );
+}
+
 function isSourceBatchDigestValid(source: ClassifiedSource): boolean {
   if (source.kind === 'OPENGREP') {
     const { batchDigest, ...core } = source.batch;
@@ -473,16 +634,24 @@ function validateDisposition(
 function batchBindingFields(
   batch: Readonly<SastSecretRedactionSourceBatch>
 ): readonly string[] {
-  return [
-    batch.ingestionId,
-    batch.scope.tenantId,
-    batch.scope.repositoryBindingId,
-    batch.scope.scanRequestId,
-    batch.scope.attemptId,
-    batch.scope.scannerRunId,
-    batch.scannerVersion,
-    batch.preflightAttestationRef
-  ];
+  const values: Record<
+    SastSecretRedactionBatchInspectedField,
+    string
+  > = {
+    INGESTION_ID: batch.ingestionId,
+    TENANT_ID: batch.scope.tenantId,
+    REPOSITORY_BINDING_ID:
+      batch.scope.repositoryBindingId,
+    SCAN_REQUEST_ID: batch.scope.scanRequestId,
+    ATTEMPT_ID: batch.scope.attemptId,
+    SCANNER_RUN_ID: batch.scope.scannerRunId,
+    SCANNER_VERSION: batch.scannerVersion,
+    PREFLIGHT_ATTESTATION_REF:
+      batch.preflightAttestationRef
+  };
+  return SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS.map(
+    (field) => values[field]
+  );
 }
 
 function normalizePlatformSecretValues(
@@ -530,6 +699,19 @@ function normalizePlatformSecretValues(
     (left, right) =>
       right.length - left.length ||
       compareCodeUnits(left, right)
+  );
+}
+
+function candidateInspectionCodeUnits(
+  candidate: Readonly<SastNormalizedFindingCandidate>
+): number {
+  const displayCodeUnits =
+    candidate.title.length +
+    candidate.description.length +
+    (candidate.location.symbol?.length ?? 0);
+  return identityBearingFields(candidate).reduce(
+    (total, field) => total + field.value.length,
+    displayCodeUnits
   );
 }
 
@@ -658,7 +840,12 @@ function redactCandidate(
         )}`
     }
   } as SastSecretRedactedFindingCandidate;
-  if (!isSastSecretRedactedFindingCandidateShapeValid(redacted)) {
+  if (
+    !isSastSecretRedactedFindingCandidateShapeValid(
+      redacted,
+      digest
+    )
+  ) {
     return {
       inspectedFieldCount,
       rejectionReason: 'SECRET_REDACTION_OUTPUT_INVALID'

--- a/apps/api/src/scan-plane/sast-secret-redaction.service.ts
+++ b/apps/api/src/scan-plane/sast-secret-redaction.service.ts
@@ -1,0 +1,1152 @@
+import { createHash } from 'node:crypto';
+import { TextEncoder } from 'node:util';
+
+import { Injectable } from '@nestjs/common';
+import {
+  SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+  SAST_SECRET_REDACTION_LIMITS,
+  SAST_SECRET_REDACTION_TOKEN,
+  SAST_SECRET_REDACTION_VERSION,
+  canonicalizeOpenGrepSarifNormalizationBatch,
+  canonicalizeSastArtifactDispositionDecision,
+  canonicalizeSastSecretRedactionBatch,
+  canonicalizeSastSecretRedactionDecision,
+  canonicalizeSastSecretRedactionRejection,
+  canonicalizeTrivyJsonNormalizationBatch,
+  compareSastNormalizedFindingCandidates,
+  isOpenGrepSarifNormalizationBatchShapeValid,
+  isSastArtifactDispositionDecisionShapeValid,
+  isSastSecretRedactedFindingCandidateShapeValid,
+  isSastSecretRedactionBatchShapeValid,
+  isTrivyJsonNormalizationBatchShapeValid,
+  orderSastSecretDetectorKinds,
+  orderSastSecretRedactableFields,
+  orderSastSecretRedactionRejectionReasons,
+  stripSastSecretRedaction,
+  type OpenGrepSarifNormalizationBatch,
+  type SastArtifactDispositionDecision,
+  type SastNormalizedFindingCandidate,
+  type SastSecretDetectorKind,
+  type SastSecretRedactableField,
+  type SastSecretRedactedFindingCandidate,
+  type SastSecretRedactedFindingCandidateCore,
+  type SastSecretRedactionBatchCore,
+  type SastSecretRedactionRejectionCore,
+  type SastSecretRedactionRejectionReasonCode,
+  type SastSecretRedactionResult,
+  type TrivyJsonNormalizationBatch
+} from '@aegisai/shared';
+
+const UTF8_ENCODER = new TextEncoder();
+const SECRET_CONTEXT =
+  /(?:api[-_ ]?key|authorization|bearer|client[-_ ]?secret|credential|passwd|password|private[-_ ]?key|secret|session|token)/iu;
+
+interface SecretPattern {
+  kind: SastSecretDetectorKind;
+  expression: RegExp;
+  contextual?: true;
+}
+
+/**
+ * These patterns are deliberately bounded and linear over already-bounded
+ * candidate text. Provider lists are versioned with this redaction contract;
+ * any expansion requires corpus review and a version change.
+ */
+const KNOWN_SECRET_PATTERNS: readonly SecretPattern[] = [
+  {
+    kind: 'PRIVATE_KEY',
+    expression:
+      /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----[\s\S]{0,4096}?-----END (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/gu
+  },
+  {
+    kind: 'AUTHORIZATION_CREDENTIAL',
+    contextual: true,
+    expression:
+      /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic)\s+[A-Za-z0-9+/_=.-]{4,2048}/giu
+  },
+  {
+    kind: 'URL_CREDENTIAL',
+    contextual: true,
+    expression:
+      /\b[a-z][a-z0-9+.-]{1,15}:\/\/[^\s/@:]{1,256}:[^\s/@]{1,512}@/giu
+  },
+  {
+    kind: 'AWS_ACCESS_KEY_ID',
+    expression: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/gu
+  },
+  {
+    kind: 'GITHUB_TOKEN',
+    expression:
+      /\b(?:gh[pousr]_[A-Za-z0-9]{36,255}|github_pat_[A-Za-z0-9_]{22,255})\b/gu
+  },
+  {
+    kind: 'GITLAB_TOKEN',
+    expression:
+      /\b(?:glpat|gloas|gldt|glrt|glrtr|glcbt|glptt|glft|glimt|glagent|glwt|glsoat|glffct)-[A-Za-z0-9_-]{8,255}\b/gu
+  },
+  {
+    kind: 'SLACK_TOKEN',
+    expression:
+      /\b(?:xox[baprs]-[A-Za-z0-9-]{10,255}|https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]{20,512})\b/gu
+  },
+  {
+    kind: 'GOOGLE_API_KEY',
+    expression: /\bAIza[A-Za-z0-9_-]{35}\b/gu
+  },
+  {
+    kind: 'STRIPE_KEY',
+    expression:
+      /\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,255}\b/gu
+  },
+  {
+    kind: 'SENDGRID_KEY',
+    expression:
+      /\bSG\.[A-Za-z0-9_-]{16,255}\.[A-Za-z0-9_-]{16,255}\b/gu
+  },
+  {
+    kind: 'JWT',
+    expression:
+      /\beyJ[A-Za-z0-9_-]{5,511}\.[A-Za-z0-9_-]{8,2048}\.[A-Za-z0-9_-]{8,2048}\b/gu
+  },
+  {
+    kind: 'SECRET_ASSIGNMENT',
+    contextual: true,
+    expression:
+      /\b(?:access[-_ ]?key|api[-_ ]?key|client[-_ ]?secret|passwd|password|private[-_ ]?key|pwd|secret|session[-_ ]?token|token)\b\s*(?:=>|=|:)\s*(?:"[^"\r\n]{1,512}"|'[^'\r\n]{1,512}'|[^\s,;]{4,512})/giu
+  }
+];
+
+interface SecretSpan {
+  start: number;
+  end: number;
+  kinds: Set<SastSecretDetectorKind>;
+}
+
+interface SecretInspection {
+  spans: SecretSpan[];
+  kinds: SastSecretDetectorKind[];
+}
+
+interface RedactedText {
+  value: string;
+  replacementCount: number;
+  detectorKinds: SastSecretDetectorKind[];
+}
+
+interface PlatformSecretMatcherNode {
+  transitions: Map<string, number>;
+  failure: number;
+  outputLengths: number[];
+}
+
+interface CandidateRedaction {
+  candidate?: SastSecretRedactedFindingCandidate;
+  inspectedFieldCount: number;
+  rejectionReason?: Extract<
+    SastSecretRedactionRejectionReasonCode,
+    | 'SECRET_REDACTION_RESERVED_TOKEN_PRESENT'
+    | 'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+    | 'SECRET_REDACTION_OUTPUT_INVALID'
+  >;
+}
+
+export type SastSecretRedactionSourceBatch =
+  | OpenGrepSarifNormalizationBatch
+  | TrivyJsonNormalizationBatch;
+
+export interface SastSecretRedactionInput {
+  batch: Readonly<SastSecretRedactionSourceBatch>;
+  disposition: Readonly<SastArtifactDispositionDecision>;
+  /**
+   * Caller-owned transient values from the Data/Security Plane. The service
+   * never copies them into a result, digest, exception, log, or class field.
+   */
+  platformSecretValues?: readonly string[];
+}
+
+@Injectable()
+export class SastSecretRedactionService {
+  redact(
+    input: Readonly<SastSecretRedactionInput>,
+    clock: () => Date = () => new Date()
+  ): SastSecretRedactionResult {
+    if (!hasCandidateCountWithinLimit(input?.batch)) {
+      return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
+    }
+    const source = classifySourceBatch(input?.batch);
+    if (!source) {
+      return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
+    }
+    if (
+      source.batch.findings.length >
+      SAST_SECRET_REDACTION_LIMITS.maximumCandidates
+    ) {
+      return this.reject(['SECRET_REDACTION_INPUT_INVALID']);
+    }
+    if (!isSourceBatchDigestValid(source)) {
+      return this.reject([
+        'SECRET_REDACTION_SOURCE_DIGEST_MISMATCH'
+      ]);
+    }
+
+    const dispositionReasons = validateDisposition(
+      input.disposition,
+      source.batch
+    );
+    const firstReferenceTime = readReferenceTime(clock);
+    if (
+      dispositionReasons.length > 0 ||
+      !Number.isFinite(firstReferenceTime) ||
+      firstReferenceTime <
+        Date.parse(input.disposition.decidedAt)
+    ) {
+      return this.reject([
+        ...dispositionReasons,
+        'SECRET_REDACTION_DISPOSITION_INVALID'
+      ]);
+    }
+    const retentionExpiresAt =
+      input.disposition.retentionExpiresAt as string;
+    if (firstReferenceTime >= Date.parse(retentionExpiresAt)) {
+      return this.reject([
+        'SECRET_REDACTION_RETENTION_EXPIRED'
+      ]);
+    }
+
+    const platformSecrets = normalizePlatformSecretValues(
+      input.platformSecretValues
+    );
+    if (!platformSecrets) {
+      return this.reject([
+        'SECRET_REDACTION_PLATFORM_VALUES_INVALID'
+      ]);
+    }
+    const platformMatcher =
+      new PlatformSecretMatcher(platformSecrets);
+    if (
+      batchBindingFields(source.batch).some(
+        (field) =>
+          inspectSecrets(
+            field,
+            platformMatcher,
+            false,
+            false,
+            false
+          ).spans.length > 0
+      )
+    ) {
+      return this.reject([
+        'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      ]);
+    }
+
+    const findings: SastSecretRedactedFindingCandidate[] = [];
+    let inspectedFieldCount = 0;
+    for (const finding of source.batch.findings) {
+      const redacted = redactCandidate(
+        finding,
+        platformMatcher
+      );
+      inspectedFieldCount += redacted.inspectedFieldCount;
+      if (!redacted.candidate || redacted.rejectionReason) {
+        return this.reject([
+          redacted.rejectionReason ??
+            'SECRET_REDACTION_OUTPUT_INVALID'
+        ]);
+      }
+      findings.push(redacted.candidate);
+    }
+    findings.sort((left, right) =>
+      compareSastNormalizedFindingCandidates(
+        stripSastSecretRedaction(left),
+        stripSastSecretRedaction(right)
+      )
+    );
+
+    const secondReferenceTime = readReferenceTime(clock);
+    if (
+      !Number.isFinite(secondReferenceTime) ||
+      secondReferenceTime < firstReferenceTime
+    ) {
+      return this.reject([
+        'SECRET_REDACTION_DISPOSITION_INVALID'
+      ]);
+    }
+    if (secondReferenceTime >= Date.parse(retentionExpiresAt)) {
+      return this.reject([
+        'SECRET_REDACTION_RETENTION_EXPIRED'
+      ]);
+    }
+
+    const redactedCandidateCount = findings.filter(
+      (finding) => finding.redaction.replacementCount > 0
+    ).length;
+    const redactedFieldCount = findings.reduce(
+      (sum, finding) =>
+        sum + finding.redaction.redactedFields.length,
+      0
+    );
+    const replacementCount = findings.reduce(
+      (sum, finding) =>
+        sum + finding.redaction.replacementCount,
+      0
+    );
+    const detectorKinds = orderSastSecretDetectorKinds(
+      findings.flatMap(
+        (finding) => finding.redaction.detectorKinds
+      )
+    );
+    const batchCore: SastSecretRedactionBatchCore = {
+      version: SAST_SECRET_REDACTION_VERSION,
+      outcome: 'REDACTED',
+      sourceAdapterVersion: source.batch.adapterVersion,
+      artifactSchema: source.batch.artifactSchema,
+      artifactSchemaVersion: source.batch.artifactSchemaVersion,
+      ingestionId: source.batch.ingestionId,
+      scope: {
+        tenantId: source.batch.scope.tenantId,
+        repositoryBindingId:
+          source.batch.scope.repositoryBindingId,
+        scanRequestId: source.batch.scope.scanRequestId,
+        attemptId: source.batch.scope.attemptId,
+        scannerRunId: source.batch.scope.scannerRunId
+      },
+      scannerRunId: source.batch.scannerRunId,
+      scanner: source.batch.scanner,
+      scannerVersion: source.batch.scannerVersion,
+      scannerImageDigest: source.batch.scannerImageDigest,
+      ruleBundleDigest: source.batch.ruleBundleDigest,
+      ...('vulnerabilityDatabaseDigest' in source.batch
+        ? {
+            vulnerabilityDatabaseDigest:
+              source.batch.vulnerabilityDatabaseDigest
+          }
+        : {}),
+      planDigest: source.batch.planDigest,
+      canonicalScanKey: source.batch.canonicalScanKey,
+      preflightAttestationRef:
+        source.batch.preflightAttestationRef,
+      preflightInventoryDigest:
+        source.batch.preflightInventoryDigest,
+      lane: source.batch.lane,
+      commitSha: source.batch.commitSha,
+      envelopeDigest: source.batch.envelopeDigest,
+      artifactDigest: source.batch.artifactDigest,
+      schemaBundleDigest: source.batch.schemaBundleDigest,
+      normalizerBundleDigest:
+        source.batch.normalizerBundleDigest,
+      validationResultDigest:
+        source.batch.validationResultDigest,
+      dispositionDecisionDigest:
+        source.batch.dispositionDecisionDigest,
+      retentionExpiresAt,
+      findings,
+      redaction: {
+        version: SAST_SECRET_REDACTION_VERSION,
+        secretRedactionApplied: true,
+        candidateCount: findings.length,
+        batchInspectedFieldCount:
+          SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+        inspectedFieldCount:
+          inspectedFieldCount +
+          SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+        redactedCandidateCount,
+        redactedFieldCount,
+        replacementCount,
+        detectorKinds,
+        secretValuesStored: false,
+        matchedValueDigestsStored: false,
+        rawCandidatesStored: false,
+        sourceCandidateDigestStored: false
+      },
+      durablePersistenceAllowed: false
+    };
+    const batch = {
+      ...batchCore,
+      batchDigest: digest(
+        canonicalizeSastSecretRedactionBatch(batchCore)
+      )
+    };
+    if (!isSastSecretRedactionBatchShapeValid(batch)) {
+      return this.reject(['SECRET_REDACTION_OUTPUT_INVALID']);
+    }
+    return {
+      outcome: 'REDACTED',
+      batch
+    };
+  }
+
+  private reject(
+    reasons: Iterable<SastSecretRedactionRejectionReasonCode>
+  ): SastSecretRedactionResult {
+    const core: SastSecretRedactionRejectionCore = {
+      version: SAST_SECRET_REDACTION_VERSION,
+      outcome: 'REJECTED',
+      reasonCodes:
+        orderSastSecretRedactionRejectionReasons(reasons),
+      secretValuesStored: false,
+      matchedValueDigestsStored: false,
+      sourceCandidateDigestStored: false
+    };
+    return {
+      ...core,
+      rejectionDigest: digest(
+        canonicalizeSastSecretRedactionRejection(core)
+      )
+    };
+  }
+}
+
+type ClassifiedSource =
+  | {
+      kind: 'OPENGREP';
+      batch: Readonly<OpenGrepSarifNormalizationBatch>;
+    }
+  | {
+      kind: 'TRIVY';
+      batch: Readonly<TrivyJsonNormalizationBatch>;
+    };
+
+function classifySourceBatch(value: unknown): ClassifiedSource | null {
+  if (isOpenGrepSarifNormalizationBatchShapeValid(value)) {
+    return { kind: 'OPENGREP', batch: value };
+  }
+  if (isTrivyJsonNormalizationBatchShapeValid(value)) {
+    return { kind: 'TRIVY', batch: value };
+  }
+  return null;
+}
+
+function hasCandidateCountWithinLimit(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return true;
+  }
+  const findings = (value as { findings?: unknown }).findings;
+  return (
+    !Array.isArray(findings) ||
+    findings.length <=
+      SAST_SECRET_REDACTION_LIMITS.maximumCandidates
+  );
+}
+
+function isSourceBatchDigestValid(source: ClassifiedSource): boolean {
+  if (source.kind === 'OPENGREP') {
+    const { batchDigest, ...core } = source.batch;
+    return (
+      digest(
+        canonicalizeOpenGrepSarifNormalizationBatch(core)
+      ) === batchDigest
+    );
+  }
+  const { batchDigest, ...core } = source.batch;
+  return (
+    digest(canonicalizeTrivyJsonNormalizationBatch(core)) ===
+    batchDigest
+  );
+}
+
+function validateDisposition(
+  disposition: unknown,
+  batch: Readonly<SastSecretRedactionSourceBatch>
+): SastSecretRedactionRejectionReasonCode[] {
+  if (!isSastArtifactDispositionDecisionShapeValid(disposition)) {
+    return ['SECRET_REDACTION_DISPOSITION_INVALID'];
+  }
+  const { decisionDigest, ...core } = disposition;
+  if (
+    digest(canonicalizeSastArtifactDispositionDecision(core)) !==
+      decisionDigest ||
+    disposition.disposition !== 'ACCEPTED' ||
+    disposition.normalizationEligible !== true ||
+    disposition.ingestionId !== batch.ingestionId ||
+    disposition.validationResultDigest !==
+      batch.validationResultDigest ||
+    disposition.decisionDigest !==
+      batch.dispositionDecisionDigest ||
+    !disposition.retentionExpiresAt
+  ) {
+    return ['SECRET_REDACTION_DISPOSITION_INVALID'];
+  }
+  return [];
+}
+
+function batchBindingFields(
+  batch: Readonly<SastSecretRedactionSourceBatch>
+): readonly string[] {
+  return [
+    batch.ingestionId,
+    batch.scope.tenantId,
+    batch.scope.repositoryBindingId,
+    batch.scope.scanRequestId,
+    batch.scope.attemptId,
+    batch.scope.scannerRunId,
+    batch.scannerVersion,
+    batch.preflightAttestationRef
+  ];
+}
+
+function normalizePlatformSecretValues(
+  values: readonly string[] | undefined
+): string[] | null {
+  if (values === undefined) return [];
+  if (
+    !Array.isArray(values) ||
+    values.length >
+      SAST_SECRET_REDACTION_LIMITS.maximumPlatformSecretValues
+  ) {
+    return null;
+  }
+  const seen = new Set<string>();
+  let totalBytes = 0;
+  for (const value of values as readonly unknown[]) {
+    if (
+      typeof value !== 'string' ||
+      value.length === 0 ||
+      value !== value.normalize('NFC') ||
+      hasUnsafePlatformSecretCharacter(value) ||
+      value.includes(SAST_SECRET_REDACTION_TOKEN) ||
+      !/\S/u.test(value)
+    ) {
+      return null;
+    }
+    const byteSize = UTF8_ENCODER.encode(value).byteLength;
+    if (
+      byteSize < 8 ||
+      byteSize >
+        SAST_SECRET_REDACTION_LIMITS
+          .maximumPlatformSecretValueBytes ||
+      totalBytes >
+        SAST_SECRET_REDACTION_LIMITS
+          .maximumPlatformSecretValueTotalBytes -
+          byteSize ||
+      seen.has(value)
+    ) {
+      return null;
+    }
+    totalBytes += byteSize;
+    seen.add(value);
+  }
+  return [...seen].sort(
+    (left, right) =>
+      right.length - left.length ||
+      compareCodeUnits(left, right)
+  );
+}
+
+function redactCandidate(
+  candidate: Readonly<SastNormalizedFindingCandidate>,
+  platformMatcher: Readonly<PlatformSecretMatcher>
+): CandidateRedaction {
+  const displayFields: Array<{
+    field: SastSecretRedactableField;
+    value: string;
+  }> = [
+    { field: 'TITLE', value: candidate.title },
+    { field: 'DESCRIPTION', value: candidate.description },
+    ...(candidate.location.symbol === undefined
+      ? []
+      : [
+          {
+            field: 'LOCATION_SYMBOL' as const,
+            value: candidate.location.symbol
+          }
+        ])
+  ];
+  const identityFields = identityBearingFields(candidate);
+  const inspectedFieldCount =
+    displayFields.length + identityFields.length;
+  if (
+    [
+      ...displayFields.map(({ value }) => value),
+      ...identityFields.map(({ value }) => value)
+    ]
+      .some((value) =>
+        value.includes(SAST_SECRET_REDACTION_TOKEN)
+      )
+  ) {
+    return {
+      inspectedFieldCount,
+      rejectionReason:
+        'SECRET_REDACTION_RESERVED_TOKEN_PRESENT'
+    };
+  }
+
+  for (const identityField of identityFields) {
+    if (
+      inspectSecrets(
+        identityField.value,
+        platformMatcher,
+        identityField.includeEntropy,
+        identityField.includeContextual,
+        false
+      ).spans.length > 0
+    ) {
+      return {
+        inspectedFieldCount,
+        rejectionReason:
+          'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      };
+    }
+  }
+
+  const redactedByField = new Map<
+    SastSecretRedactableField,
+    RedactedText
+  >();
+  for (const { field, value } of displayFields) {
+    redactedByField.set(
+      field,
+      redactText(value, platformMatcher)
+    );
+  }
+  const title =
+    redactedByField.get('TITLE')?.value ?? candidate.title;
+  const description =
+    redactedByField.get('DESCRIPTION')?.value ??
+    candidate.description;
+  const location = cloneLocation(
+    candidate,
+    redactedByField.get('LOCATION_SYMBOL')?.value
+  );
+  const base = cloneCandidate(
+    candidate,
+    title,
+    description,
+    location
+  );
+  const redactedFields = orderSastSecretRedactableFields(
+    [...redactedByField.entries()]
+      .filter(([, result]) => result.replacementCount > 0)
+      .map(([field]) => field)
+  );
+  const replacementCount = [...redactedByField.values()].reduce(
+    (sum, result) => sum + result.replacementCount,
+    0
+  );
+  const detectorKinds = orderSastSecretDetectorKinds(
+    [...redactedByField.values()].flatMap(
+      (result) => result.detectorKinds
+    )
+  );
+  const redactionCore = {
+    version: SAST_SECRET_REDACTION_VERSION,
+    secretRedactionApplied: true as const,
+    replacementToken: SAST_SECRET_REDACTION_TOKEN,
+    inspectedFieldCount,
+    redactedFields,
+    replacementCount,
+    detectorKinds,
+    secretValueStored: false as const,
+    matchedValueDigestStored: false as const,
+    rawCandidateStored: false as const
+  };
+  const decisionCore = {
+    ...base,
+    redaction: redactionCore
+  } as SastSecretRedactedFindingCandidateCore;
+  const decisionDigest = digest(
+    canonicalizeSastSecretRedactionDecision(decisionCore)
+  );
+  const redacted = {
+    ...base,
+    redaction: {
+      ...redactionCore,
+      decisionDigest,
+      decisionRef:
+        `redaction://${SAST_SECRET_REDACTION_VERSION}/${decisionDigest.slice(
+          'sha256:'.length
+        )}`
+    }
+  } as SastSecretRedactedFindingCandidate;
+  if (!isSastSecretRedactedFindingCandidateShapeValid(redacted)) {
+    return {
+      inspectedFieldCount,
+      rejectionReason: 'SECRET_REDACTION_OUTPUT_INVALID'
+    };
+  }
+  return { candidate: redacted, inspectedFieldCount };
+}
+
+function identityBearingFields(
+  candidate: Readonly<SastNormalizedFindingCandidate>
+): Array<{
+  value: string;
+  includeEntropy: boolean;
+  includeContextual: boolean;
+}> {
+  const fields: Array<{
+    value: string;
+    includeEntropy: boolean;
+    includeContextual: boolean;
+  }> = [
+    {
+      value: candidate.identityMaterial.ruleSemanticId,
+      includeEntropy: true,
+      includeContextual: false
+    },
+    {
+      value: candidate.identityMaterial.symbolAnchor,
+      includeEntropy: true,
+      includeContextual: true
+    },
+    {
+      value: candidate.identityMaterial.sinkKind,
+      includeEntropy: true,
+      includeContextual: true
+    },
+    {
+      value: candidate.identityMaterial.scannerMatchBasedId,
+      includeEntropy: true,
+      includeContextual: false
+    },
+    {
+      value: candidate.provenance.scannerVersion,
+      includeEntropy: true,
+      includeContextual: false
+    },
+    {
+      value: candidate.provenance.ruleId,
+      includeEntropy: true,
+      includeContextual: false
+    },
+    {
+      value: candidate.provenance.ruleRevision,
+      includeEntropy: true,
+      includeContextual: false
+    }
+  ];
+  if (candidate.location.kind === 'FILE') {
+    fields.push({
+      value: candidate.location.normalizedPath,
+      includeEntropy: true,
+      includeContextual: true
+    });
+  }
+  if (!('trivy' in candidate)) return fields;
+  if (candidate.trivy.kind === 'DEPENDENCY_VULNERABILITY') {
+    fields.push(
+      {
+        value: candidate.trivy.vulnerabilityId,
+        includeEntropy: true,
+        includeContextual: false
+      },
+      {
+        value: candidate.trivy.packageName,
+        includeEntropy: true,
+        includeContextual: true
+      },
+      {
+        value: candidate.trivy.packageType,
+        includeEntropy: true,
+        includeContextual: true
+      },
+      {
+        value: candidate.trivy.installedVersion,
+        includeEntropy: true,
+        includeContextual: true
+      },
+      {
+        value: candidate.trivy.fixedVersion,
+        includeEntropy: true,
+        includeContextual: true
+      }
+    );
+  } else if (candidate.trivy.kind === 'SECRET_DETECTION') {
+    fields.push({
+      value: candidate.trivy.category,
+      includeEntropy: true,
+      includeContextual: true
+    });
+  } else {
+    fields.push(
+      {
+        value: candidate.trivy.checkType,
+        includeEntropy: true,
+        includeContextual: true
+      },
+      {
+        value: candidate.trivy.avdId,
+        includeEntropy: true,
+        includeContextual: true
+      }
+    );
+  }
+  return fields;
+}
+
+function cloneCandidate(
+  candidate: Readonly<SastNormalizedFindingCandidate>,
+  title: string,
+  description: string,
+  location: SastNormalizedFindingCandidate['location']
+): SastNormalizedFindingCandidate {
+  const common = {
+    ...candidate,
+    title,
+    description,
+    cweIds: [...candidate.cweIds],
+    cveIds: [...candidate.cveIds],
+    location,
+    identityMaterial: { ...candidate.identityMaterial },
+    provenance: { ...candidate.provenance },
+    notes: [...candidate.notes],
+    durablePersistenceAllowed: false as const
+  };
+  if (!('trivy' in candidate)) {
+    return common as SastNormalizedFindingCandidate;
+  }
+  return {
+    ...common,
+    scannerDisposition: { ...candidate.scannerDisposition },
+    trivy: { ...candidate.trivy }
+  } as SastNormalizedFindingCandidate;
+}
+
+function cloneLocation(
+  candidate: Readonly<SastNormalizedFindingCandidate>,
+  redactedSymbol: string | undefined
+): SastNormalizedFindingCandidate['location'] {
+  const location = candidate.location;
+  if (location.kind === 'UNKNOWN') {
+    return {
+      kind: location.kind,
+      reasonCode: location.reasonCode,
+      ...(redactedSymbol === undefined
+        ? {}
+        : { symbol: redactedSymbol })
+    };
+  }
+  return {
+    kind: location.kind,
+    normalizedPath: location.normalizedPath,
+    lineStart: location.lineStart,
+    ...(location.lineEnd === undefined
+      ? {}
+      : { lineEnd: location.lineEnd }),
+    ...(location.columnStart === undefined
+      ? {}
+      : { columnStart: location.columnStart }),
+    ...(location.columnEnd === undefined
+      ? {}
+      : { columnEnd: location.columnEnd }),
+    ...(redactedSymbol === undefined
+      ? {}
+      : { symbol: redactedSymbol })
+  };
+}
+
+function redactText(
+  value: string,
+  platformMatcher: Readonly<PlatformSecretMatcher>
+): RedactedText {
+  const inspection = inspectSecrets(
+    value,
+    platformMatcher,
+    true
+  );
+  if (inspection.spans.length === 0) {
+    return {
+      value,
+      replacementCount: 0,
+      detectorKinds: []
+    };
+  }
+  let output = '';
+  let offset = 0;
+  for (const span of inspection.spans) {
+    output += value.slice(offset, span.start);
+    output += SAST_SECRET_REDACTION_TOKEN;
+    offset = span.end;
+  }
+  output += value.slice(offset);
+  return {
+    value: output,
+    replacementCount: inspection.spans.length,
+    detectorKinds: inspection.kinds
+  };
+}
+
+function inspectSecrets(
+  value: string,
+  platformMatcher: Readonly<PlatformSecretMatcher>,
+  includeEntropy: boolean,
+  includeContextual = true,
+  aggressiveEntropy = true
+): SecretInspection {
+  const spans = platformMatcher.find(value);
+  for (const pattern of KNOWN_SECRET_PATTERNS) {
+    if (pattern.contextual && !includeContextual) continue;
+    pattern.expression.lastIndex = 0;
+    for (const match of value.matchAll(pattern.expression)) {
+      const start = match.index;
+      if (
+        start !== undefined &&
+        match[0].length > 0
+      ) {
+        addSpan(
+          spans,
+          start,
+          start + match[0].length,
+          pattern.kind
+        );
+      }
+    }
+  }
+  if (includeEntropy) {
+    const expression =
+      /[A-Za-z0-9][A-Za-z0-9+/_=-]{19,511}/gu;
+    for (const match of value.matchAll(expression)) {
+      const start = match.index;
+      const token = match[0];
+      if (
+        start !== undefined &&
+        isHighEntropySecret(
+          value,
+          token,
+          start,
+          aggressiveEntropy
+        )
+      ) {
+        addSpan(
+          spans,
+          start,
+          start + token.length,
+          'HIGH_ENTROPY'
+        );
+      }
+    }
+  }
+  const merged = mergeSpans(spans);
+  return {
+    spans: merged,
+    kinds: orderSastSecretDetectorKinds(
+      merged.flatMap((span) => [...span.kinds])
+    )
+  };
+}
+
+/**
+ * A per-call Aho-Corasick matcher keeps registered-value inspection linear in
+ * total candidate text plus matches instead of rescanning each field up to 64
+ * times. Nodes are local to one redaction call and never escape in results.
+ */
+class PlatformSecretMatcher {
+  private readonly nodes: PlatformSecretMatcherNode[] = [
+    {
+      transitions: new Map(),
+      failure: 0,
+      outputLengths: []
+    }
+  ];
+
+  constructor(values: readonly string[]) {
+    for (const value of values) this.insert(value);
+    this.buildFailures();
+  }
+
+  find(value: string): SecretSpan[] {
+    const spans: SecretSpan[] = [];
+    let state = 0;
+    for (let index = 0; index < value.length; index += 1) {
+      const character = value[index] as string;
+      while (
+        state !== 0 &&
+        !this.nodes[state]?.transitions.has(character)
+      ) {
+        state = this.nodes[state]?.failure ?? 0;
+      }
+      state =
+        this.nodes[state]?.transitions.get(character) ??
+        this.nodes[0]?.transitions.get(character) ??
+        0;
+      const lengths =
+        this.nodes[state]?.outputLengths ?? [];
+      if (lengths.length === 0) continue;
+      const end = index + 1;
+      const start = Math.min(
+        ...lengths.map((length) => end - length)
+      );
+      const previous = spans.at(-1);
+      if (previous && start <= previous.end) {
+        previous.start = Math.min(previous.start, start);
+        previous.end = Math.max(previous.end, end);
+        previous.kinds.add('PLATFORM_VALUE');
+      } else {
+        spans.push({
+          start,
+          end,
+          kinds: new Set(['PLATFORM_VALUE'])
+        });
+      }
+    }
+    return spans;
+  }
+
+  private insert(value: string): void {
+    let state = 0;
+    for (let index = 0; index < value.length; index += 1) {
+      const character = value[index] as string;
+      const existing =
+        this.nodes[state]?.transitions.get(character);
+      if (existing !== undefined) {
+        state = existing;
+        continue;
+      }
+      const next = this.nodes.length;
+      this.nodes.push({
+        transitions: new Map(),
+        failure: 0,
+        outputLengths: []
+      });
+      this.nodes[state]?.transitions.set(character, next);
+      state = next;
+    }
+    this.nodes[state]?.outputLengths.push(value.length);
+  }
+
+  private buildFailures(): void {
+    const queue: number[] = [];
+    for (const state of this.nodes[0]?.transitions.values() ?? []) {
+      queue.push(state);
+    }
+    for (let offset = 0; offset < queue.length; offset += 1) {
+      const state = queue[offset] as number;
+      const node = this.nodes[state] as PlatformSecretMatcherNode;
+      for (const [character, next] of node.transitions) {
+        queue.push(next);
+        let failure = node.failure;
+        while (
+          failure !== 0 &&
+          !this.nodes[failure]?.transitions.has(character)
+        ) {
+          failure = this.nodes[failure]?.failure ?? 0;
+        }
+        const fallback =
+          this.nodes[failure]?.transitions.get(character);
+        this.nodes[next]!.failure =
+          fallback === undefined || fallback === next
+            ? 0
+            : fallback;
+        const inherited =
+          this.nodes[this.nodes[next]!.failure]?.outputLengths ?? [];
+        this.nodes[next]!.outputLengths = [
+          ...new Set([
+            ...this.nodes[next]!.outputLengths,
+            ...inherited
+          ])
+        ];
+      }
+    }
+  }
+}
+
+function isHighEntropySecret(
+  source: string,
+  token: string,
+  start: number,
+  aggressive: boolean
+): boolean {
+  const classes = [
+    /[a-z]/u,
+    /[A-Z]/u,
+    /[0-9]/u,
+    /[+/_=-]/u
+  ].filter((expression) => expression.test(token)).length;
+  const entropy = shannonEntropy(token);
+  const context = source.slice(
+    Math.max(0, start - 64),
+    Math.min(source.length, start + token.length + 24)
+  );
+  const hexadecimal =
+    token.length >= 32 && /^[A-Fa-f0-9]+$/u.test(token);
+  return (
+    (token.length >= 32 && classes >= 3 && entropy >= 4.2) ||
+    (aggressive &&
+      classes >= 2 &&
+      entropy >= 4.5) ||
+    (aggressive && hexadecimal && entropy >= 3.5) ||
+    (classes >= 2 && entropy >= 3.2 && SECRET_CONTEXT.test(context))
+  );
+}
+
+function shannonEntropy(value: string): number {
+  const counts = new Map<string, number>();
+  for (const character of value) {
+    counts.set(character, (counts.get(character) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const probability = count / value.length;
+    entropy -= probability * Math.log2(probability);
+  }
+  return entropy;
+}
+
+function addSpan(
+  spans: SecretSpan[],
+  start: number,
+  end: number,
+  kind: SastSecretDetectorKind
+): void {
+  if (start < 0 || end <= start) return;
+  spans.push({ start, end, kinds: new Set([kind]) });
+}
+
+function mergeSpans(spans: readonly SecretSpan[]): SecretSpan[] {
+  const ordered = [...spans].sort(
+    (left, right) =>
+      left.start - right.start || left.end - right.end
+  );
+  const merged: SecretSpan[] = [];
+  for (const span of ordered) {
+    const previous = merged.at(-1);
+    if (!previous || span.start > previous.end) {
+      merged.push({
+        start: span.start,
+        end: span.end,
+        kinds: new Set(span.kinds)
+      });
+      continue;
+    }
+    previous.end = Math.max(previous.end, span.end);
+    for (const kind of span.kinds) previous.kinds.add(kind);
+  }
+  return merged;
+}
+
+function readReferenceTime(clock: () => Date): number {
+  try {
+    return Date.prototype.getTime.call(clock());
+  } catch {
+    return Number.NaN;
+  }
+}
+
+function hasUnsafePlatformSecretCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return (
+      (codePoint <= 0x1f &&
+        codePoint !== 0x09 &&
+        codePoint !== 0x0a) ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    );
+  });
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference =
+      left.charCodeAt(index) - right.charCodeAt(index);
+    if (difference !== 0) return difference;
+  }
+  return left.length - right.length;
+}
+
+function digest(value: string): `sha256:${string}` {
+  return `sha256:${createHash('sha256')
+    .update(value)
+    .digest('hex')}`;
+}

--- a/apps/api/src/scan-plane/scan-plane.module.ts
+++ b/apps/api/src/scan-plane/scan-plane.module.ts
@@ -72,6 +72,7 @@ import {
 import { OpenGrepSarifNormalizer } from './opengrep-sarif-normalizer';
 import { TrivyJsonNormalizer } from './trivy-json-normalizer';
 import { SyftCycloneDxInventoryIngestor } from './syft-cyclonedx-inventory-ingestor';
+import { SastSecretRedactionService } from './sast-secret-redaction.service';
 
 @Module({
   imports: [ConfigModule, ControlPlaneModule, TokenBrokerModule],
@@ -89,6 +90,7 @@ import { SyftCycloneDxInventoryIngestor } from './syft-cyclonedx-inventory-inges
     OpenGrepSarifNormalizer,
     TrivyJsonNormalizer,
     SyftCycloneDxInventoryIngestor,
+    SastSecretRedactionService,
     SastArtifactDispositionService,
     SastArtifactDispositionTask,
     PrismaSastArtifactDispositionStore,
@@ -163,9 +165,8 @@ import { SyftCycloneDxInventoryIngestor } from './syft-cyclonedx-inventory-inges
     RepositoryPreflightService,
     SandboxRuntimeAttestationService,
     SastScannerRuntimeService,
-    OpenGrepSarifNormalizer,
-    TrivyJsonNormalizer,
-    SyftCycloneDxInventoryIngestor
+    SyftCycloneDxInventoryIngestor,
+    SastSecretRedactionService
   ]
 })
 export class ScanPlaneModule {}

--- a/apps/api/test/scan-plane/sast-secret-redaction.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-secret-redaction.e2e-spec.ts
@@ -1,0 +1,802 @@
+import { createHash } from 'node:crypto';
+
+import {
+  OPENGREP_SARIF_NORMALIZER_VERSION,
+  SAST_ARTIFACT_DISPOSITION_VERSION,
+  SAST_SECRET_REDACTION_LIMITS,
+  SAST_SECRET_REDACTION_TOKEN,
+  SAST_SECRET_REDACTION_VERSION,
+  TRIVY_JSON_NORMALIZER_VERSION,
+  canonicalizeOpenGrepSarifNormalizationBatch,
+  canonicalizeSastArtifactDispositionDecision,
+  canonicalizeSastSecretRedactionBatch,
+  canonicalizeSastSecretRedactionDecision,
+  canonicalizeTrivyJsonNormalizationBatch,
+  isSastSecretRedactionBatchShapeValid,
+  toSastSecretRedactionAuditMetadata,
+  type OpenGrepNormalizedFindingCandidate,
+  type OpenGrepSarifNormalizationBatch,
+  type OpenGrepSarifNormalizationBatchCore,
+  type SastArtifactDispositionDecision,
+  type SastArtifactDispositionDecisionCore,
+  type TrivyJsonNormalizationBatch,
+  type TrivyJsonNormalizationBatchCore,
+  type TrivyNormalizedFindingCandidate
+} from '@aegisai/shared';
+
+import {
+  SastSecretRedactionService
+} from '../../src/scan-plane/sast-secret-redaction.service';
+
+const DECIDED_AT = '2026-07-26T10:00:00.000Z';
+const REDACTED_AT = '2026-07-26T10:01:00.000Z';
+const RETENTION_EXPIRES_AT = '2026-08-01T10:00:00.000Z';
+const VALIDATION_DIGEST = digest('validation');
+const ARTIFACT_DIGEST = digest('artifact');
+const REGISTERED_SECRET = 'platform-runtime-secret-0123456789';
+
+describe('SastSecretRedactionService', () => {
+  const service = new SastSecretRedactionService();
+
+  it('redacts the known-format, entropy, and registered-value corpus deterministically', () => {
+    const secrets = {
+      aws: 'AKIAIOSFODNN7EXAMPLE',
+      github: `github_pat_${'A'.repeat(30)}`,
+      gitlab: 'glpat-SYNTHETIC0123456789',
+      slack: 'xoxb-1234567890-SYNTHETIC-TOKEN',
+      google: `AIza${'B'.repeat(35)}`,
+      stripe: `sk_test_${'C'.repeat(24)}`,
+      sendgrid: `SG.${'D'.repeat(20)}.${'E'.repeat(24)}`,
+      jwt: `eyJ${'F'.repeat(12)}.${'G'.repeat(16)}.${'H'.repeat(16)}`,
+      authorization: `Authorization: Bearer ${'I'.repeat(32)}`,
+      url: 'https://synthetic-user:synthetic-password@example.invalid/path',
+      assignment: 'password=synthetic-password-value',
+      entropy: 'aB3dE5fG7hJ9kL2mN4pQ6rS8tU0vW1xY',
+      hexadecimalEntropy: '0123456789abcdef'.repeat(2),
+      privateKey:
+        '-----BEGIN PRIVATE KEY-----\nSYNTHETICNOTAREALKEY1234567890\n-----END PRIVATE KEY-----'
+    };
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition, {
+      title: `Credential ${secrets.github}`,
+      description: Object.values(secrets).join('\n'),
+      location: {
+        kind: 'FILE',
+        normalizedPath: 'src/config.ts',
+        lineStart: 7,
+        lineEnd: 7,
+        symbol: `configure-${REGISTERED_SECRET}`
+      }
+    });
+    const input = {
+      batch,
+      disposition,
+      platformSecretValues: [REGISTERED_SECRET]
+    };
+
+    const first = service.redact(input, fixedClock);
+    const second = service.redact(input, fixedClock);
+    expect(first).toEqual(second);
+    expect(first.outcome).toBe('REDACTED');
+    if (first.outcome !== 'REDACTED') return;
+
+    expect(
+      isSastSecretRedactionBatchShapeValid(first.batch)
+    ).toBe(true);
+    expect(first.batch.version).toBe(
+      SAST_SECRET_REDACTION_VERSION
+    );
+    expect(first.batch.durablePersistenceAllowed).toBe(false);
+    expect(first.batch.redaction.secretRedactionApplied).toBe(true);
+    expect(first.batch.redaction.redactedCandidateCount).toBe(1);
+    expect(first.batch.redaction.redactedFieldCount).toBe(3);
+    expect(first.batch.redaction.detectorKinds).toEqual(
+      expect.arrayContaining([
+        'PLATFORM_VALUE',
+        'PRIVATE_KEY',
+        'AUTHORIZATION_CREDENTIAL',
+        'URL_CREDENTIAL',
+        'AWS_ACCESS_KEY_ID',
+        'GITHUB_TOKEN',
+        'GITLAB_TOKEN',
+        'SLACK_TOKEN',
+        'GOOGLE_API_KEY',
+        'STRIPE_KEY',
+        'SENDGRID_KEY',
+        'JWT',
+        'SECRET_ASSIGNMENT',
+        'HIGH_ENTROPY'
+      ])
+    );
+    const { batchDigest, ...batchCore } = first.batch;
+    void batchDigest;
+    const canonical =
+      canonicalizeSastSecretRedactionBatch(batchCore);
+    expect(digest(canonical)).toBe(first.batch.batchDigest);
+
+    const serialized = JSON.stringify(first);
+    const leakSentinels = [
+      ...Object.values(secrets),
+      REGISTERED_SECRET,
+      'synthetic-user',
+      'synthetic-password',
+      'SYNTHETICNOTAREALKEY1234567890',
+      'I'.repeat(32)
+    ];
+    for (const secret of leakSentinels) {
+      expect(serialized).not.toContain(secret);
+      expect(serialized).not.toContain(digest(secret));
+    }
+    expect(serialized).not.toContain(batch.batchDigest);
+    expect(serialized).not.toContain('sourceBatchDigest');
+    expect(serialized).not.toContain('"matchedValueDigest":');
+    expect(serialized).toContain(SAST_SECRET_REDACTION_TOKEN);
+    const redactedFinding = first.batch.findings[0];
+    const {
+      decisionDigest,
+      decisionRef,
+      ...redactionCore
+    } = redactedFinding.redaction;
+    void decisionRef;
+    expect(
+      digest(
+        canonicalizeSastSecretRedactionDecision({
+          ...redactedFinding,
+          redaction: redactionCore
+        })
+      )
+    ).toBe(decisionDigest);
+    expect(
+      toSastSecretRedactionAuditMetadata(first)
+    ).not.toHaveProperty('findings');
+  });
+
+  it('redacts supported Trivy candidates without granting durable or policy authority', () => {
+    const disposition = acceptedDisposition();
+    const secret = `github_pat_${'J'.repeat(30)}`;
+    const batch = trivyBatch(disposition, {
+      description: `Potential credential ${secret} was reported.`
+    });
+
+    const result = service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    expect(result.batch.scanner).toBe('TRIVY');
+    expect(result.batch.sourceAdapterVersion).toBe(
+      TRIVY_JSON_NORMALIZER_VERSION
+    );
+    expect(result.batch.vulnerabilityDatabaseDigest).toBe(
+      digest('vulnerability-database')
+    );
+    expect(result.batch.findings[0]).toMatchObject({
+      capability: 'SECRET_DETECTION',
+      scannerDisposition: {
+        platformPolicyAuthority: false
+      },
+      trivy: {
+        secretValueStored: false,
+        secretPayloadDiscarded: true
+      },
+      durablePersistenceAllowed: false
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it('merges overlapping detector matches into one fixed replacement', () => {
+    const disposition = acceptedDisposition();
+    const secret = 'registered-password-1234567890';
+    const batch = openGrepBatch(disposition, {
+      description: `password=${secret}`
+    });
+    const result = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [secret]
+      },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    const finding = result.batch.findings[0];
+    expect(finding.description).toBe(SAST_SECRET_REDACTION_TOKEN);
+    expect(finding.redaction.replacementCount).toBe(1);
+    expect(finding.redaction.detectorKinds).toEqual([
+      'PLATFORM_VALUE',
+      'SECRET_ASSIGNMENT',
+      'HIGH_ENTROPY'
+    ]);
+  });
+
+  it('is invariant to registered-value ordering and redacts NFC Unicode values', () => {
+    const disposition = acceptedDisposition();
+    const firstSecret = '플랫폼-비밀값-0123456789';
+    const secondSecret = 'second-platform-secret-9876543210';
+    const batch = openGrepBatch(disposition, {
+      description: `${firstSecret} and ${secondSecret}`
+    });
+    const first = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [firstSecret, secondSecret]
+      },
+      fixedClock
+    );
+    const second = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [secondSecret, firstSecret]
+      },
+      fixedClock
+    );
+
+    expect(first).toEqual(second);
+    expect(first.outcome).toBe('REDACTED');
+    expect(JSON.stringify(first)).not.toContain(firstSecret);
+    expect(JSON.stringify(first)).not.toContain(secondSecret);
+  });
+
+  it('redacts an entire registered value when its shorter suffix matches first', () => {
+    const disposition = acceptedDisposition();
+    const shorterSecret = '12345678';
+    const longerSecret = 'xx12345678yy';
+    const batch = openGrepBatch(disposition, {
+      description: longerSecret
+    });
+    const result = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [shorterSecret, longerSecret]
+      },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    expect(result.batch.findings[0]?.description).toBe(
+      SAST_SECRET_REDACTION_TOKEN
+    );
+    expect(JSON.stringify(result)).not.toContain(longerSecret);
+  });
+
+  it('fails closed when an identity-bearing field contains a secret', () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition, {
+      identityMaterial: {
+        ...openGrepFinding().identityMaterial,
+        symbolAnchor: REGISTERED_SECRET
+      }
+    });
+    const result = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [REGISTERED_SECRET]
+      },
+      fixedClock
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      ],
+      secretValuesStored: false,
+      matchedValueDigestsStored: false,
+      sourceCandidateDigestStored: false
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(REGISTERED_SECRET);
+    expect(serialized).not.toContain(batch.batchDigest);
+    expect(serialized).not.toContain(batch.artifactDigest);
+  });
+
+  it('rejects an unregistered high-entropy scanner identity instead of hashing it', () => {
+    const disposition = acceptedDisposition();
+    const highEntropyIdentity =
+      'aB3dE5fG7hJ9kL2mN4pQ6rS8tU0vW1xY';
+    const batch = openGrepBatch(disposition, {
+      identityMaterial: {
+        ...openGrepFinding().identityMaterial,
+        scannerMatchBasedId: highEntropyIdentity,
+        structuralHash: digest(highEntropyIdentity)
+      }
+    });
+    const result = service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      ]
+    });
+    expect(JSON.stringify(result)).not.toContain(
+      highEntropyIdentity
+    );
+  });
+
+  it('rejects a forged reserved marker before it can claim redaction', () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition, {
+      description: `forged ${SAST_SECRET_REDACTION_TOKEN}`
+    });
+    expect(
+      service.redact({ batch, disposition }, fixedClock)
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_RESERVED_TOKEN_PRESENT'
+      ]
+    });
+  });
+
+  it('rejects source digest tamper and invalid registered-secret sets with bounded metadata', () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition);
+    const tampered = {
+      ...batch,
+      batchDigest: digest('tampered')
+    };
+    expect(
+      service.redact(
+        {
+          batch: tampered,
+          disposition
+        },
+        fixedClock
+      )
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_SOURCE_DIGEST_MISMATCH'
+      ]
+    });
+    expect(
+      service.redact(
+        {
+          batch: {
+            ...batch,
+            findings: Array.from(
+              {
+                length:
+                  SAST_SECRET_REDACTION_LIMITS
+                    .maximumCandidates + 1
+              },
+              () => batch.findings[0]
+            )
+          },
+          disposition
+        },
+        fixedClock
+      )
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: ['SECRET_REDACTION_INPUT_INVALID']
+    });
+
+    for (const platformSecretValues of [
+      [REGISTERED_SECRET, REGISTERED_SECRET],
+      ['short'],
+      [SAST_SECRET_REDACTION_TOKEN],
+      ['synthetic\u0001secret'],
+      [`synthetic-${String.fromCharCode(0xd800)}-secret`],
+      ['de\u0301composed-secret-value'],
+      Array.from(
+        { length: 65 },
+        (_, index) => `synthetic-secret-${index.toString().padStart(3, '0')}`
+      )
+    ]) {
+      expect(
+        service.redact(
+          {
+            batch,
+            disposition,
+            platformSecretValues
+          },
+          fixedClock
+        )
+      ).toMatchObject({
+        outcome: 'REJECTED',
+        reasonCodes: [
+          'SECRET_REDACTION_PLATFORM_VALUES_INVALID'
+        ]
+      });
+    }
+  });
+
+  it('revalidates the accepted disposition and retention on both sides of redaction', () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition);
+    const tamperedDisposition = {
+      ...disposition,
+      storageReceiptDigest: digest('tampered-receipt')
+    };
+    expect(
+      service.redact(
+        {
+          batch,
+          disposition: tamperedDisposition
+        },
+        fixedClock
+      )
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_DISPOSITION_INVALID'
+      ]
+    });
+
+    const times = [
+      new Date(REDACTED_AT),
+      new Date(RETENTION_EXPIRES_AT)
+    ];
+    expect(
+      service.redact(
+        { batch, disposition },
+        () => times.shift() as Date
+      )
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_RETENTION_EXPIRED'
+      ]
+    });
+  });
+
+  it('emits a deterministic fully bound zero-finding redaction batch', () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition, undefined, []);
+    const result = service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    expect(result.batch.findings).toEqual([]);
+    expect(result.batch.redaction).toMatchObject({
+      candidateCount: 0,
+      batchInspectedFieldCount: 8,
+      inspectedFieldCount: 8,
+      redactedCandidateCount: 0,
+      redactedFieldCount: 0,
+      replacementCount: 0,
+      detectorKinds: []
+    });
+    expect(isSastSecretRedactionBatchShapeValid(result.batch)).toBe(
+      true
+    );
+  });
+
+  it('does not classify the pinned OpenGrep matchBasedId hex form as a secret', () => {
+    const disposition = acceptedDisposition();
+    const scannerMatchBasedId = `${'0123456789abcdef'.repeat(
+      8
+    )}_0`;
+    const batch = openGrepBatch(disposition, {
+      identityMaterial: {
+        ...openGrepFinding().identityMaterial,
+        scannerMatchBasedId,
+        structuralHash: digest(scannerMatchBasedId)
+      }
+    });
+    const result = service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    expect(
+      result.batch.findings[0].identityMaterial
+        .scannerMatchBasedId
+    ).toBe(scannerMatchBasedId);
+  });
+
+  it('rejects secret-bearing batch bindings even when there are no findings', () => {
+    const disposition = acceptedDisposition();
+    const original = openGrepBatch(
+      disposition,
+      undefined,
+      []
+    );
+    const { batchDigest, ...originalCore } = original;
+    void batchDigest;
+    const core: OpenGrepSarifNormalizationBatchCore = {
+      ...originalCore,
+      scope: {
+        ...originalCore.scope,
+        tenantId: REGISTERED_SECRET
+      }
+    };
+    const batch = {
+      ...core,
+      batchDigest: digest(
+        canonicalizeOpenGrepSarifNormalizationBatch(core)
+      )
+    };
+
+    const result = service.redact(
+      {
+        batch,
+        disposition,
+        platformSecretValues: [REGISTERED_SECRET]
+      },
+      fixedClock
+    );
+    expect(result).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      ]
+    });
+    expect(JSON.stringify(result)).not.toContain(
+      REGISTERED_SECRET
+    );
+  });
+});
+
+function openGrepBatch(
+  disposition: Readonly<SastArtifactDispositionDecision>,
+  findingOverrides?: Partial<OpenGrepNormalizedFindingCandidate>,
+  findings?: OpenGrepNormalizedFindingCandidate[]
+): OpenGrepSarifNormalizationBatch {
+  const core: OpenGrepSarifNormalizationBatchCore = {
+    version: OPENGREP_SARIF_NORMALIZER_VERSION,
+    adapterVersion: OPENGREP_SARIF_NORMALIZER_VERSION,
+    artifactSchema: 'OPENGREP_SARIF',
+    artifactSchemaVersion: '2.1.0',
+    ingestionId: disposition.ingestionId,
+    scope: scope(),
+    scannerRunId: 'scanner-run-1',
+    scanner: 'OPENGREP',
+    scannerVersion: '1.22.0',
+    scannerImageDigest: digest('opengrep-image'),
+    ruleBundleDigest: digest('opengrep-rules'),
+    planDigest: digest('plan'),
+    canonicalScanKey: digest('canonical-scan'),
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: digest('inventory'),
+    lane: 'FAST',
+    commitSha: 'a'.repeat(40),
+    envelopeDigest: digest('envelope'),
+    artifactDigest: ARTIFACT_DIGEST,
+    schemaBundleDigest: digest('schema'),
+    normalizerBundleDigest: digest('normalizer'),
+    validationResultDigest: VALIDATION_DIGEST,
+    dispositionDecisionDigest: disposition.decisionDigest,
+    findings:
+      findings ??
+      [
+        {
+          ...openGrepFinding(),
+          ...findingOverrides
+        }
+      ],
+    durablePersistenceAllowed: false
+  };
+  return {
+    ...core,
+    batchDigest: digest(
+      canonicalizeOpenGrepSarifNormalizationBatch(core)
+    )
+  };
+}
+
+function openGrepFinding(): OpenGrepNormalizedFindingCandidate {
+  return {
+    tenantId: 'tenant-1',
+    repositoryBindingId: 'repository-1',
+    scanRequestId: 'scan-1',
+    attemptId: 'attempt-1',
+    scannerRunId: 'scanner-run-1',
+    planDigest: digest('plan'),
+    canonicalScanKey: digest('canonical-scan'),
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: digest('inventory'),
+    commitSha: 'a'.repeat(40),
+    lane: 'FAST',
+    capability: 'SAST',
+    title: 'Hardcoded credential',
+    description: 'A credential-like value was detected.',
+    severity: 'HIGH',
+    confidence: 'HIGH',
+    cweIds: ['CWE-798'],
+    cveIds: [],
+    location: {
+      kind: 'FILE',
+      normalizedPath: 'src/config.ts',
+      lineStart: 7,
+      lineEnd: 7
+    },
+    identityMaterial: {
+      ruleSemanticId: 'javascript.hardcoded-secret',
+      symbolAnchor: '',
+      sinkKind: '',
+      structuralHash: digest('structure'),
+      scannerMatchBasedId: 'rules.secret:match-1'
+    },
+    provenance: {
+      scanner: 'OPENGREP',
+      scannerVersion: '1.22.0',
+      scannerImageDigest: digest('opengrep-image'),
+      ruleId: 'rules.secret',
+      ruleRevision: '2026.07.1',
+      ruleBundleDigest: digest('opengrep-rules'),
+      artifactDigest: ARTIFACT_DIGEST
+    },
+    notes: [],
+    durablePersistenceAllowed: false
+  };
+}
+
+function trivyBatch(
+  disposition: Readonly<SastArtifactDispositionDecision>,
+  findingOverrides?: Partial<TrivyNormalizedFindingCandidate>
+): TrivyJsonNormalizationBatch {
+  const core: TrivyJsonNormalizationBatchCore = {
+    version: TRIVY_JSON_NORMALIZER_VERSION,
+    adapterVersion: TRIVY_JSON_NORMALIZER_VERSION,
+    artifactSchema: 'TRIVY_JSON',
+    artifactSchemaVersion: '2',
+    ingestionId: disposition.ingestionId,
+    scope: scope(),
+    scannerRunId: 'scanner-run-1',
+    scanner: 'TRIVY',
+    scannerVersion: '0.66.0',
+    scannerImageDigest: digest('trivy-image'),
+    ruleBundleDigest: digest('trivy-rules'),
+    vulnerabilityDatabaseDigest: digest(
+      'vulnerability-database'
+    ),
+    planDigest: digest('plan'),
+    canonicalScanKey: digest('canonical-scan'),
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: digest('inventory'),
+    lane: 'FAST',
+    commitSha: 'a'.repeat(40),
+    envelopeDigest: digest('envelope'),
+    artifactDigest: ARTIFACT_DIGEST,
+    schemaBundleDigest: digest('schema'),
+    normalizerBundleDigest: digest('normalizer'),
+    validationResultDigest: VALIDATION_DIGEST,
+    dispositionDecisionDigest: disposition.decisionDigest,
+    findings: [
+      {
+        ...trivyFinding(),
+        ...findingOverrides
+      } as TrivyNormalizedFindingCandidate
+    ],
+    durablePersistenceAllowed: false
+  };
+  return {
+    ...core,
+    batchDigest: digest(
+      canonicalizeTrivyJsonNormalizationBatch(core)
+    )
+  };
+}
+
+function trivyFinding(): TrivyNormalizedFindingCandidate {
+  const matchId = digest('trivy-match');
+  return {
+    tenantId: 'tenant-1',
+    repositoryBindingId: 'repository-1',
+    scanRequestId: 'scan-1',
+    attemptId: 'attempt-1',
+    scannerRunId: 'scanner-run-1',
+    planDigest: digest('plan'),
+    canonicalScanKey: digest('canonical-scan'),
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: digest('inventory'),
+    commitSha: 'a'.repeat(40),
+    lane: 'FAST',
+    capability: 'SECRET_DETECTION',
+    title: 'Secret detected: generic-api-key',
+    description:
+      'Potential API secret detected. The secret value and scanner context were discarded.',
+    severity: 'HIGH',
+    confidence: 'UNKNOWN',
+    cweIds: [],
+    cveIds: [],
+    location: {
+      kind: 'FILE',
+      normalizedPath: 'src/config.ts',
+      lineStart: 7,
+      lineEnd: 7
+    },
+    identityMaterial: {
+      ruleSemanticId: 'secret.generic-api-key',
+      symbolAnchor: '',
+      sinkKind: 'API',
+      structuralHash: digest(`trivy-structure:${matchId}`),
+      scannerMatchBasedId: matchId
+    },
+    provenance: {
+      scanner: 'TRIVY',
+      scannerVersion: '0.66.0',
+      scannerImageDigest: digest('trivy-image'),
+      ruleId: 'generic-api-key',
+      ruleRevision: '2026.07.1',
+      ruleBundleDigest: digest('trivy-rules'),
+      artifactDigest: ARTIFACT_DIGEST,
+      ruleSource: 'CHECK_BUNDLE',
+      vulnerabilityDatabaseDigest: digest(
+        'vulnerability-database'
+      )
+    },
+    scannerDisposition: {
+      source: 'DIRECT',
+      status: 'active',
+      platformPolicyAuthority: false
+    },
+    trivy: {
+      kind: 'SECRET_DETECTION',
+      category: 'API',
+      secretValueStored: false,
+      secretPayloadDiscarded: true
+    },
+    notes: ['UNKNOWN_CONFIDENCE'],
+    durablePersistenceAllowed: false
+  };
+}
+
+function acceptedDisposition(): SastArtifactDispositionDecision {
+  const intentDigest = digest('intent');
+  const core: SastArtifactDispositionDecisionCore = {
+    version: SAST_ARTIFACT_DISPOSITION_VERSION,
+    ingestionId: 'ingestion-1',
+    disposition: 'ACCEPTED',
+    storageAction: 'RETAIN_ACCEPTED',
+    reasonCodes: ['ARTIFACT_VALIDATION_ACCEPTED'],
+    validationReasonCodes: [],
+    validationResultDigest: VALIDATION_DIGEST,
+    normalizationEligible: true,
+    retentionExpiresAt: RETENTION_EXPIRES_AT,
+    acceptanceControlRef: 'acceptance://policy/allow',
+    intentDigest,
+    storageOperationId:
+      `${SAST_ARTIFACT_DISPOSITION_VERSION}:${intentDigest.slice(
+        'sha256:'.length
+      )}`,
+    storageReceiptRef: 'storage-receipt://accepted/ingestion-1',
+    storageReceiptDigest: digest('receipt'),
+    decidedAt: DECIDED_AT
+  };
+  return {
+    ...core,
+    decisionDigest: digest(
+      canonicalizeSastArtifactDispositionDecision(core)
+    )
+  };
+}
+
+function scope() {
+  return {
+    tenantId: 'tenant-1',
+    repositoryBindingId: 'repository-1',
+    scanRequestId: 'scan-1',
+    attemptId: 'attempt-1',
+    scannerRunId: 'scanner-run-1'
+  };
+}
+
+function fixedClock(): Date {
+  return new Date(REDACTED_AT);
+}
+
+function digest(value: string): `sha256:${string}` {
+  return `sha256:${createHash('sha256')
+    .update(value)
+    .digest('hex')}`;
+}

--- a/apps/api/test/scan-plane/sast-secret-redaction.e2e-spec.ts
+++ b/apps/api/test/scan-plane/sast-secret-redaction.e2e-spec.ts
@@ -38,7 +38,7 @@ const REGISTERED_SECRET = 'platform-runtime-secret-0123456789';
 describe('SastSecretRedactionService', () => {
   const service = new SastSecretRedactionService();
 
-  it('redacts the known-format, entropy, and registered-value corpus deterministically', () => {
+  it('redacts the known-format, entropy, and registered-value corpus deterministically', async () => {
     const secrets = {
       aws: 'AKIAIOSFODNN7EXAMPLE',
       github: `github_pat_${'A'.repeat(30)}`,
@@ -53,6 +53,8 @@ describe('SastSecretRedactionService', () => {
       assignment: 'password=synthetic-password-value',
       entropy: 'aB3dE5fG7hJ9kL2mN4pQ6rS8tU0vW1xY',
       hexadecimalEntropy: '0123456789abcdef'.repeat(2),
+      digestShapedSecret:
+        `sha256:${'fedcba9876543210'.repeat(4)}`,
       privateKey:
         '-----BEGIN PRIVATE KEY-----\nSYNTHETICNOTAREALKEY1234567890\n-----END PRIVATE KEY-----'
     };
@@ -74,14 +76,17 @@ describe('SastSecretRedactionService', () => {
       platformSecretValues: [REGISTERED_SECRET]
     };
 
-    const first = service.redact(input, fixedClock);
-    const second = service.redact(input, fixedClock);
+    const first = await service.redact(input, fixedClock);
+    const second = await service.redact(input, fixedClock);
     expect(first).toEqual(second);
     expect(first.outcome).toBe('REDACTED');
     if (first.outcome !== 'REDACTED') return;
 
     expect(
-      isSastSecretRedactionBatchShapeValid(first.batch)
+      isSastSecretRedactionBatchShapeValid(
+        first.batch,
+        digest
+      )
     ).toBe(true);
     expect(first.batch.version).toBe(
       SAST_SECRET_REDACTION_VERSION
@@ -147,18 +152,18 @@ describe('SastSecretRedactionService', () => {
       )
     ).toBe(decisionDigest);
     expect(
-      toSastSecretRedactionAuditMetadata(first)
+      toSastSecretRedactionAuditMetadata(first, digest)
     ).not.toHaveProperty('findings');
   });
 
-  it('redacts supported Trivy candidates without granting durable or policy authority', () => {
+  it('redacts supported Trivy candidates without granting durable or policy authority', async () => {
     const disposition = acceptedDisposition();
     const secret = `github_pat_${'J'.repeat(30)}`;
     const batch = trivyBatch(disposition, {
       description: `Potential credential ${secret} was reported.`
     });
 
-    const result = service.redact(
+    const result = await service.redact(
       { batch, disposition },
       fixedClock
     );
@@ -185,13 +190,13 @@ describe('SastSecretRedactionService', () => {
     expect(JSON.stringify(result)).not.toContain(secret);
   });
 
-  it('merges overlapping detector matches into one fixed replacement', () => {
+  it('merges overlapping detector matches into one fixed replacement', async () => {
     const disposition = acceptedDisposition();
     const secret = 'registered-password-1234567890';
     const batch = openGrepBatch(disposition, {
       description: `password=${secret}`
     });
-    const result = service.redact(
+    const result = await service.redact(
       {
         batch,
         disposition,
@@ -212,14 +217,39 @@ describe('SastSecretRedactionService', () => {
     ]);
   });
 
-  it('is invariant to registered-value ordering and redacts NFC Unicode values', () => {
+  it('redacts prefixed and quoted low-entropy secret assignments', async () => {
+    const disposition = acceptedDisposition();
+    const batch = openGrepBatch(disposition, {
+      description:
+        `DB_PASSWORD="hunter2"; "password": "swordfish"; config.client_secret: "abc"; serialized {${String.raw`\"password\": \"lowpass\"`}}`
+    });
+    const result = await service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    if (result.outcome !== 'REDACTED') return;
+    expect(result.batch.findings[0]?.description).toBe(
+      `${SAST_SECRET_REDACTION_TOKEN}; ${SAST_SECRET_REDACTION_TOKEN}; ${SAST_SECRET_REDACTION_TOKEN}; serialized {${SAST_SECRET_REDACTION_TOKEN}}`
+    );
+    expect(
+      result.batch.findings[0]?.redaction.detectorKinds
+    ).toEqual(['SECRET_ASSIGNMENT']);
+    expect(JSON.stringify(result)).not.toContain('hunter2');
+    expect(JSON.stringify(result)).not.toContain('swordfish');
+    expect(JSON.stringify(result)).not.toContain('"abc"');
+    expect(JSON.stringify(result)).not.toContain('lowpass');
+  });
+
+  it('is invariant to registered-value ordering and redacts NFC Unicode values', async () => {
     const disposition = acceptedDisposition();
     const firstSecret = '플랫폼-비밀값-0123456789';
     const secondSecret = 'second-platform-secret-9876543210';
     const batch = openGrepBatch(disposition, {
       description: `${firstSecret} and ${secondSecret}`
     });
-    const first = service.redact(
+    const first = await service.redact(
       {
         batch,
         disposition,
@@ -227,7 +257,7 @@ describe('SastSecretRedactionService', () => {
       },
       fixedClock
     );
-    const second = service.redact(
+    const second = await service.redact(
       {
         batch,
         disposition,
@@ -242,14 +272,14 @@ describe('SastSecretRedactionService', () => {
     expect(JSON.stringify(first)).not.toContain(secondSecret);
   });
 
-  it('redacts an entire registered value when its shorter suffix matches first', () => {
+  it('redacts an entire registered value when its shorter suffix matches first', async () => {
     const disposition = acceptedDisposition();
     const shorterSecret = '12345678';
     const longerSecret = 'xx12345678yy';
     const batch = openGrepBatch(disposition, {
       description: longerSecret
     });
-    const result = service.redact(
+    const result = await service.redact(
       {
         batch,
         disposition,
@@ -266,7 +296,7 @@ describe('SastSecretRedactionService', () => {
     expect(JSON.stringify(result)).not.toContain(longerSecret);
   });
 
-  it('fails closed when an identity-bearing field contains a secret', () => {
+  it('fails closed when an identity-bearing field contains a secret', async () => {
     const disposition = acceptedDisposition();
     const batch = openGrepBatch(disposition, {
       identityMaterial: {
@@ -274,7 +304,7 @@ describe('SastSecretRedactionService', () => {
         symbolAnchor: REGISTERED_SECRET
       }
     });
-    const result = service.redact(
+    const result = await service.redact(
       {
         batch,
         disposition,
@@ -298,7 +328,7 @@ describe('SastSecretRedactionService', () => {
     expect(serialized).not.toContain(batch.artifactDigest);
   });
 
-  it('rejects an unregistered high-entropy scanner identity instead of hashing it', () => {
+  it('rejects an unregistered high-entropy scanner identity instead of hashing it', async () => {
     const disposition = acceptedDisposition();
     const highEntropyIdentity =
       'aB3dE5fG7hJ9kL2mN4pQ6rS8tU0vW1xY';
@@ -309,7 +339,7 @@ describe('SastSecretRedactionService', () => {
         structuralHash: digest(highEntropyIdentity)
       }
     });
-    const result = service.redact(
+    const result = await service.redact(
       { batch, disposition },
       fixedClock
     );
@@ -325,13 +355,39 @@ describe('SastSecretRedactionService', () => {
     );
   });
 
-  it('rejects a forged reserved marker before it can claim redaction', () => {
+  it('rejects low-entropy credential syntax in opaque identity fields', async () => {
+    const disposition = acceptedDisposition();
+    const credentialIdentity = 'DB_PASSWORD="hunter2"';
+    const batch = openGrepBatch(disposition, {
+      identityMaterial: {
+        ...openGrepFinding().identityMaterial,
+        scannerMatchBasedId: credentialIdentity
+      }
+    });
+    const result = await service.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: [
+        'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'
+      ]
+    });
+    expect(JSON.stringify(result)).not.toContain(
+      credentialIdentity
+    );
+    expect(JSON.stringify(result)).not.toContain('hunter2');
+  });
+
+  it('rejects a forged reserved marker before it can claim redaction', async () => {
     const disposition = acceptedDisposition();
     const batch = openGrepBatch(disposition, {
       description: `forged ${SAST_SECRET_REDACTION_TOKEN}`
     });
     expect(
-      service.redact({ batch, disposition }, fixedClock)
+      await service.redact({ batch, disposition }, fixedClock)
     ).toMatchObject({
       outcome: 'REJECTED',
       reasonCodes: [
@@ -340,7 +396,7 @@ describe('SastSecretRedactionService', () => {
     });
   });
 
-  it('rejects source digest tamper and invalid registered-secret sets with bounded metadata', () => {
+  it('rejects source digest tamper and invalid registered-secret sets with bounded metadata', async () => {
     const disposition = acceptedDisposition();
     const batch = openGrepBatch(disposition);
     const tampered = {
@@ -348,7 +404,7 @@ describe('SastSecretRedactionService', () => {
       batchDigest: digest('tampered')
     };
     expect(
-      service.redact(
+      await service.redact(
         {
           batch: tampered,
           disposition
@@ -362,7 +418,7 @@ describe('SastSecretRedactionService', () => {
       ]
     });
     expect(
-      service.redact(
+      await service.redact(
         {
           batch: {
             ...batch,
@@ -374,6 +430,29 @@ describe('SastSecretRedactionService', () => {
               },
               () => batch.findings[0]
             )
+          },
+          disposition
+        },
+        fixedClock
+      )
+    ).toMatchObject({
+      outcome: 'REJECTED',
+      reasonCodes: ['SECRET_REDACTION_INPUT_INVALID']
+    });
+    expect(
+      await service.redact(
+        {
+          batch: {
+            ...batch,
+            findings: [
+              {
+                ...batch.findings[0],
+                description: 'x'.repeat(
+                  SAST_SECRET_REDACTION_LIMITS
+                    .maximumInspectedCodeUnits + 1
+                )
+              }
+            ]
           },
           disposition
         },
@@ -397,7 +476,7 @@ describe('SastSecretRedactionService', () => {
       )
     ]) {
       expect(
-        service.redact(
+        await service.redact(
           {
             batch,
             disposition,
@@ -414,7 +493,7 @@ describe('SastSecretRedactionService', () => {
     }
   });
 
-  it('revalidates the accepted disposition and retention on both sides of redaction', () => {
+  it('revalidates the accepted disposition and retention on both sides of redaction', async () => {
     const disposition = acceptedDisposition();
     const batch = openGrepBatch(disposition);
     const tamperedDisposition = {
@@ -422,7 +501,7 @@ describe('SastSecretRedactionService', () => {
       storageReceiptDigest: digest('tampered-receipt')
     };
     expect(
-      service.redact(
+      await service.redact(
         {
           batch,
           disposition: tamperedDisposition
@@ -441,7 +520,7 @@ describe('SastSecretRedactionService', () => {
       new Date(RETENTION_EXPIRES_AT)
     ];
     expect(
-      service.redact(
+      await service.redact(
         { batch, disposition },
         () => times.shift() as Date
       )
@@ -453,10 +532,10 @@ describe('SastSecretRedactionService', () => {
     });
   });
 
-  it('emits a deterministic fully bound zero-finding redaction batch', () => {
+  it('emits a deterministic fully bound zero-finding redaction batch', async () => {
     const disposition = acceptedDisposition();
     const batch = openGrepBatch(disposition, undefined, []);
-    const result = service.redact(
+    const result = await service.redact(
       { batch, disposition },
       fixedClock
     );
@@ -473,12 +552,71 @@ describe('SastSecretRedactionService', () => {
       replacementCount: 0,
       detectorKinds: []
     });
-    expect(isSastSecretRedactionBatchShapeValid(result.batch)).toBe(
-      true
-    );
+    expect(
+      isSastSecretRedactionBatchShapeValid(
+        result.batch,
+        digest
+      )
+    ).toBe(true);
   });
 
-  it('does not classify the pinned OpenGrep matchBasedId hex form as a secret', () => {
+  it('yields to the event loop at candidate and code-unit chunk bounds', async () => {
+    const disposition = acceptedDisposition();
+    const findings = Array.from({ length: 65 }, (_, index) => {
+      const finding = openGrepFinding();
+      const line = index + 1;
+      return {
+        ...finding,
+        location: {
+          ...finding.location,
+          lineStart: line,
+          lineEnd: line
+        },
+        identityMaterial: {
+          ...finding.identityMaterial,
+          scannerMatchBasedId:
+            `rules.secret:match-${index
+              .toString()
+              .padStart(3, '0')}`
+        }
+      } as OpenGrepNormalizedFindingCandidate;
+    });
+    const batch = openGrepBatch(
+      disposition,
+      undefined,
+      findings
+    );
+    const yieldingService =
+      new YieldObservingSastSecretRedactionService();
+    const result = await yieldingService.redact(
+      { batch, disposition },
+      fixedClock
+    );
+
+    expect(result.outcome).toBe('REDACTED');
+    expect(yieldingService.yieldCount).toBe(1);
+    if (result.outcome !== 'REDACTED') return;
+    expect(result.batch.findings).toHaveLength(65);
+
+    const wideBatch = openGrepBatch(
+      disposition,
+      undefined,
+      findings.slice(0, 10).map((finding) => ({
+        ...finding,
+        description: 'x'.repeat(3_500)
+      }))
+    );
+    yieldingService.yieldCount = 0;
+    const wideResult = await yieldingService.redact(
+      { batch: wideBatch, disposition },
+      fixedClock
+    );
+
+    expect(wideResult.outcome).toBe('REDACTED');
+    expect(yieldingService.yieldCount).toBe(1);
+  });
+
+  it('does not classify the pinned OpenGrep matchBasedId hex form as a secret', async () => {
     const disposition = acceptedDisposition();
     const scannerMatchBasedId = `${'0123456789abcdef'.repeat(
       8
@@ -490,7 +628,7 @@ describe('SastSecretRedactionService', () => {
         structuralHash: digest(scannerMatchBasedId)
       }
     });
-    const result = service.redact(
+    const result = await service.redact(
       { batch, disposition },
       fixedClock
     );
@@ -503,7 +641,7 @@ describe('SastSecretRedactionService', () => {
     ).toBe(scannerMatchBasedId);
   });
 
-  it('rejects secret-bearing batch bindings even when there are no findings', () => {
+  it('rejects secret-bearing batch bindings even when there are no findings', async () => {
     const disposition = acceptedDisposition();
     const original = openGrepBatch(
       disposition,
@@ -526,7 +664,7 @@ describe('SastSecretRedactionService', () => {
       )
     };
 
-    const result = service.redact(
+    const result = await service.redact(
       {
         batch,
         disposition,
@@ -545,6 +683,14 @@ describe('SastSecretRedactionService', () => {
     );
   });
 });
+
+class YieldObservingSastSecretRedactionService extends SastSecretRedactionService {
+  yieldCount = 0;
+
+  protected override async yieldEventLoop(): Promise<void> {
+    this.yieldCount += 1;
+  }
+}
 
 function openGrepBatch(
   disposition: Readonly<SastArtifactDispositionDecision>,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,7 @@ export * from './types/sast-artifact-disposition';
 export * from './types/sast-normalization';
 export * from './types/sast-trivy-normalization';
 export * from './types/sast-sbom-inventory';
+export * from './types/sast-secret-redaction';
 export * from './types/sast-planning';
 export * from './types/sast-fetch';
 export * from './types/sast-wrapper';

--- a/packages/shared/src/types/sast-normalization.ts
+++ b/packages/shared/src/types/sast-normalization.ts
@@ -170,8 +170,9 @@ export interface TrivyFindingProvenance
 }
 
 /**
- * T032/T033 adapters return transient candidates. T035 must redact them and
- * T036 must compute the platform fingerprint before durable finding storage.
+ * T032/T033 adapters return transient candidates. T035 accepts them only
+ * through the redaction gate, and T036 must compute the platform fingerprint
+ * before durable finding storage.
  */
 interface SastNormalizedFindingCandidateBase {
   tenantId: string;

--- a/packages/shared/src/types/sast-secret-redaction.ts
+++ b/packages/shared/src/types/sast-secret-redaction.ts
@@ -1,0 +1,819 @@
+import type {
+  SastArtifactDispositionScope
+} from './sast-artifact-disposition';
+import {
+  canonicalizeSastNormalizedFindingCandidate,
+  compareSastNormalizedFindingCandidates,
+  isSastNormalizedFindingCandidateShapeValid,
+  OPENGREP_SARIF_NORMALIZER_VERSION,
+  type SastNormalizedFindingCandidate
+} from './sast-normalization';
+import {
+  hasExactKeys,
+  isAllowedString,
+  isBoundedIdentifier,
+  isBoundedReference,
+  isCommitSha,
+  isNormalizationScopeValid,
+  isRecord,
+  isSha256Digest
+} from './sast-normalization-validation';
+import {
+  TRIVY_JSON_NORMALIZER_VERSION
+} from './sast-trivy-normalization';
+
+export const SAST_SECRET_REDACTION_VERSION =
+  'sast-secret-redaction-v1' as const;
+
+/**
+ * A fixed, non-secret-bearing marker prevents the replacement from exposing
+ * secret length, a matched-value digest, or provider-specific secret detail.
+ */
+export const SAST_SECRET_REDACTION_TOKEN = '[REDACTED]' as const;
+
+export const SAST_SECRET_REDACTION_LIMITS = Object.freeze({
+  maximumCandidates: 25_000,
+  maximumPlatformSecretValues: 64,
+  maximumPlatformSecretValueBytes: 4_096,
+  maximumPlatformSecretValueTotalBytes: 65_536
+});
+
+export const SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT = 8;
+
+/**
+ * Order is part of every redaction decision digest.
+ */
+export const SAST_SECRET_DETECTOR_KINDS = [
+  'PLATFORM_VALUE',
+  'PRIVATE_KEY',
+  'AUTHORIZATION_CREDENTIAL',
+  'URL_CREDENTIAL',
+  'AWS_ACCESS_KEY_ID',
+  'GITHUB_TOKEN',
+  'GITLAB_TOKEN',
+  'SLACK_TOKEN',
+  'GOOGLE_API_KEY',
+  'STRIPE_KEY',
+  'SENDGRID_KEY',
+  'JWT',
+  'SECRET_ASSIGNMENT',
+  'HIGH_ENTROPY'
+] as const;
+export type SastSecretDetectorKind =
+  (typeof SAST_SECRET_DETECTOR_KINDS)[number];
+
+export const SAST_SECRET_REDACTABLE_FIELDS = [
+  'TITLE',
+  'DESCRIPTION',
+  'LOCATION_SYMBOL'
+] as const;
+export type SastSecretRedactableField =
+  (typeof SAST_SECRET_REDACTABLE_FIELDS)[number];
+
+/**
+ * Rejections are intentionally coarse. A field name, matched value, match
+ * length, or matched-value digest would become a secret side channel.
+ */
+export const SAST_SECRET_REDACTION_REJECTION_REASON_CODES = [
+  'SECRET_REDACTION_INPUT_INVALID',
+  'SECRET_REDACTION_SOURCE_DIGEST_MISMATCH',
+  'SECRET_REDACTION_DISPOSITION_INVALID',
+  'SECRET_REDACTION_RETENTION_EXPIRED',
+  'SECRET_REDACTION_PLATFORM_VALUES_INVALID',
+  'SECRET_REDACTION_RESERVED_TOKEN_PRESENT',
+  'SECRET_REDACTION_IDENTITY_FIELD_BLOCKED',
+  'SECRET_REDACTION_OUTPUT_INVALID'
+] as const;
+export type SastSecretRedactionRejectionReasonCode =
+  (typeof SAST_SECRET_REDACTION_REJECTION_REASON_CODES)[number];
+
+export type SastSecretRedactionSourceAdapterVersion =
+  | typeof OPENGREP_SARIF_NORMALIZER_VERSION
+  | typeof TRIVY_JSON_NORMALIZER_VERSION;
+
+export interface SastFindingSecretRedaction {
+  version: typeof SAST_SECRET_REDACTION_VERSION;
+  secretRedactionApplied: true;
+  replacementToken: typeof SAST_SECRET_REDACTION_TOKEN;
+  inspectedFieldCount: number;
+  redactedFields: SastSecretRedactableField[];
+  replacementCount: number;
+  detectorKinds: SastSecretDetectorKind[];
+  secretValueStored: false;
+  matchedValueDigestStored: false;
+  rawCandidateStored: false;
+  decisionDigest: `sha256:${string}`;
+  decisionRef: string;
+}
+
+type WithSecretRedaction<T> =
+  T extends SastNormalizedFindingCandidate
+    ? Omit<T, 'durablePersistenceAllowed'> & {
+        redaction: SastFindingSecretRedaction;
+        durablePersistenceAllowed: false;
+      }
+    : never;
+
+export type SastSecretRedactedFindingCandidate =
+  WithSecretRedaction<SastNormalizedFindingCandidate>;
+
+export type SastSecretRedactedFindingCandidateCore =
+  Omit<SastSecretRedactedFindingCandidate, 'redaction'> & {
+    redaction: Omit<
+      SastFindingSecretRedaction,
+      'decisionDigest' | 'decisionRef'
+    >;
+  };
+
+export interface SastSecretRedactionSummary {
+  version: typeof SAST_SECRET_REDACTION_VERSION;
+  secretRedactionApplied: true;
+  candidateCount: number;
+  batchInspectedFieldCount: number;
+  inspectedFieldCount: number;
+  redactedCandidateCount: number;
+  redactedFieldCount: number;
+  replacementCount: number;
+  detectorKinds: SastSecretDetectorKind[];
+  secretValuesStored: false;
+  matchedValueDigestsStored: false;
+  rawCandidatesStored: false;
+  sourceCandidateDigestStored: false;
+}
+
+export interface SastSecretRedactionBatch {
+  version: typeof SAST_SECRET_REDACTION_VERSION;
+  outcome: 'REDACTED';
+  sourceAdapterVersion: SastSecretRedactionSourceAdapterVersion;
+  artifactSchema: 'OPENGREP_SARIF' | 'TRIVY_JSON';
+  artifactSchemaVersion: '2.1.0' | '2';
+  ingestionId: string;
+  scope: Readonly<SastArtifactDispositionScope>;
+  scannerRunId: string;
+  scanner: 'OPENGREP' | 'TRIVY';
+  scannerVersion: string;
+  scannerImageDigest: `sha256:${string}`;
+  ruleBundleDigest: `sha256:${string}`;
+  vulnerabilityDatabaseDigest?: `sha256:${string}`;
+  planDigest: `sha256:${string}`;
+  canonicalScanKey: `sha256:${string}`;
+  preflightAttestationRef: string;
+  preflightInventoryDigest: `sha256:${string}`;
+  lane: 'FAST' | 'DEEP';
+  commitSha: string;
+  envelopeDigest: `sha256:${string}`;
+  artifactDigest: `sha256:${string}`;
+  schemaBundleDigest: `sha256:${string}`;
+  normalizerBundleDigest: `sha256:${string}`;
+  validationResultDigest: `sha256:${string}`;
+  dispositionDecisionDigest: `sha256:${string}`;
+  retentionExpiresAt: string;
+  findings: SastSecretRedactedFindingCandidate[];
+  redaction: SastSecretRedactionSummary;
+  durablePersistenceAllowed: false;
+  batchDigest: `sha256:${string}`;
+}
+
+export type SastSecretRedactionBatchCore = Omit<
+  SastSecretRedactionBatch,
+  'batchDigest'
+>;
+
+export interface SastSecretRedactionSuccess {
+  outcome: 'REDACTED';
+  batch: SastSecretRedactionBatch;
+}
+
+export interface SastSecretRedactionRejection {
+  version: typeof SAST_SECRET_REDACTION_VERSION;
+  outcome: 'REJECTED';
+  reasonCodes: SastSecretRedactionRejectionReasonCode[];
+  secretValuesStored: false;
+  matchedValueDigestsStored: false;
+  sourceCandidateDigestStored: false;
+  rejectionDigest: `sha256:${string}`;
+}
+
+export type SastSecretRedactionRejectionCore = Omit<
+  SastSecretRedactionRejection,
+  'rejectionDigest'
+>;
+
+export type SastSecretRedactionResult =
+  | SastSecretRedactionSuccess
+  | SastSecretRedactionRejection;
+
+export type SastSecretRedactionAuditMetadata =
+  | {
+      version: typeof SAST_SECRET_REDACTION_VERSION;
+      outcome: 'REDACTED';
+      batchDigest: `sha256:${string}`;
+      artifactDigest: `sha256:${string}`;
+      dispositionDecisionDigest: `sha256:${string}`;
+      candidateCount: number;
+      redactedCandidateCount: number;
+      replacementCount: number;
+      detectorKinds: SastSecretDetectorKind[];
+    }
+  | {
+      version: typeof SAST_SECRET_REDACTION_VERSION;
+      outcome: 'REJECTED';
+      reasonCodes: SastSecretRedactionRejectionReasonCode[];
+      rejectionDigest: `sha256:${string}`;
+    };
+
+export function orderSastSecretDetectorKinds(
+  kinds: Iterable<SastSecretDetectorKind>
+): SastSecretDetectorKind[] {
+  const present = new Set(kinds);
+  return SAST_SECRET_DETECTOR_KINDS.filter((kind) =>
+    present.has(kind)
+  );
+}
+
+export function orderSastSecretRedactableFields(
+  fields: Iterable<SastSecretRedactableField>
+): SastSecretRedactableField[] {
+  const present = new Set(fields);
+  return SAST_SECRET_REDACTABLE_FIELDS.filter((field) =>
+    present.has(field)
+  );
+}
+
+export function orderSastSecretRedactionRejectionReasons(
+  reasons: Iterable<SastSecretRedactionRejectionReasonCode>
+): SastSecretRedactionRejectionReasonCode[] {
+  const present = new Set(reasons);
+  return SAST_SECRET_REDACTION_REJECTION_REASON_CODES.filter(
+    (reason) => present.has(reason)
+  );
+}
+
+export function canonicalizeSastSecretRedactedFindingCandidate(
+  finding: Readonly<SastSecretRedactedFindingCandidate>
+): string {
+  const base = stripSastSecretRedaction(finding);
+  return JSON.stringify({
+    candidate: canonicalizeSastNormalizedFindingCandidate(base),
+    redaction: {
+      version: finding.redaction.version,
+      secretRedactionApplied: true,
+      replacementToken: finding.redaction.replacementToken,
+      inspectedFieldCount: finding.redaction.inspectedFieldCount,
+      redactedFields: [...finding.redaction.redactedFields],
+      replacementCount: finding.redaction.replacementCount,
+      detectorKinds: [...finding.redaction.detectorKinds],
+      secretValueStored: false,
+      matchedValueDigestStored: false,
+      rawCandidateStored: false,
+      decisionDigest: finding.redaction.decisionDigest,
+      decisionRef: finding.redaction.decisionRef
+    }
+  });
+}
+
+export function canonicalizeSastSecretRedactionDecision(
+  finding: Readonly<SastSecretRedactedFindingCandidateCore>
+): string {
+  const base = stripSastSecretRedaction(finding);
+  return JSON.stringify({
+    candidate: canonicalizeSastNormalizedFindingCandidate(base),
+    redaction: {
+      version: finding.redaction.version,
+      secretRedactionApplied: true,
+      replacementToken: finding.redaction.replacementToken,
+      inspectedFieldCount: finding.redaction.inspectedFieldCount,
+      redactedFields: [...finding.redaction.redactedFields],
+      replacementCount: finding.redaction.replacementCount,
+      detectorKinds: [...finding.redaction.detectorKinds],
+      secretValueStored: false,
+      matchedValueDigestStored: false,
+      rawCandidateStored: false
+    }
+  });
+}
+
+export function canonicalizeSastSecretRedactionBatch(
+  batch: Readonly<SastSecretRedactionBatchCore>
+): string {
+  return JSON.stringify({
+    version: batch.version,
+    outcome: batch.outcome,
+    sourceAdapterVersion: batch.sourceAdapterVersion,
+    artifactSchema: batch.artifactSchema,
+    artifactSchemaVersion: batch.artifactSchemaVersion,
+    ingestionId: batch.ingestionId,
+    scope: {
+      tenantId: batch.scope.tenantId,
+      repositoryBindingId: batch.scope.repositoryBindingId,
+      scanRequestId: batch.scope.scanRequestId,
+      attemptId: batch.scope.attemptId,
+      scannerRunId: batch.scope.scannerRunId
+    },
+    scannerRunId: batch.scannerRunId,
+    scanner: batch.scanner,
+    scannerVersion: batch.scannerVersion,
+    scannerImageDigest: batch.scannerImageDigest,
+    ruleBundleDigest: batch.ruleBundleDigest,
+    ...(batch.vulnerabilityDatabaseDigest
+      ? {
+          vulnerabilityDatabaseDigest:
+            batch.vulnerabilityDatabaseDigest
+        }
+      : {}),
+    planDigest: batch.planDigest,
+    canonicalScanKey: batch.canonicalScanKey,
+    preflightAttestationRef: batch.preflightAttestationRef,
+    preflightInventoryDigest: batch.preflightInventoryDigest,
+    lane: batch.lane,
+    commitSha: batch.commitSha,
+    envelopeDigest: batch.envelopeDigest,
+    artifactDigest: batch.artifactDigest,
+    schemaBundleDigest: batch.schemaBundleDigest,
+    normalizerBundleDigest: batch.normalizerBundleDigest,
+    validationResultDigest: batch.validationResultDigest,
+    dispositionDecisionDigest: batch.dispositionDecisionDigest,
+    retentionExpiresAt: batch.retentionExpiresAt,
+    findings: batch.findings.map(
+      canonicalizeSastSecretRedactedFindingCandidate
+    ),
+    redaction: {
+      version: batch.redaction.version,
+      secretRedactionApplied: true,
+      candidateCount: batch.redaction.candidateCount,
+      batchInspectedFieldCount:
+        batch.redaction.batchInspectedFieldCount,
+      inspectedFieldCount: batch.redaction.inspectedFieldCount,
+      redactedCandidateCount:
+        batch.redaction.redactedCandidateCount,
+      redactedFieldCount: batch.redaction.redactedFieldCount,
+      replacementCount: batch.redaction.replacementCount,
+      detectorKinds: [...batch.redaction.detectorKinds],
+      secretValuesStored: false,
+      matchedValueDigestsStored: false,
+      rawCandidatesStored: false,
+      sourceCandidateDigestStored: false
+    },
+    durablePersistenceAllowed: false
+  });
+}
+
+export function canonicalizeSastSecretRedactionRejection(
+  rejection: Readonly<SastSecretRedactionRejectionCore>
+): string {
+  return JSON.stringify({
+    version: rejection.version,
+    outcome: rejection.outcome,
+    reasonCodes: [...rejection.reasonCodes],
+    secretValuesStored: false,
+    matchedValueDigestsStored: false,
+    sourceCandidateDigestStored: false
+  });
+}
+
+export function isSastSecretRedactionBatchShapeValid(
+  value: unknown
+): value is SastSecretRedactionBatch {
+  if (!isRecord(value)) return false;
+  const isTrivy = value.scanner === 'TRIVY';
+  const commonKeys = [
+    'version',
+    'outcome',
+    'sourceAdapterVersion',
+    'artifactSchema',
+    'artifactSchemaVersion',
+    'ingestionId',
+    'scope',
+    'scannerRunId',
+    'scanner',
+    'scannerVersion',
+    'scannerImageDigest',
+    'ruleBundleDigest',
+    'planDigest',
+    'canonicalScanKey',
+    'preflightAttestationRef',
+    'preflightInventoryDigest',
+    'lane',
+    'commitSha',
+    'envelopeDigest',
+    'artifactDigest',
+    'schemaBundleDigest',
+    'normalizerBundleDigest',
+    'validationResultDigest',
+    'dispositionDecisionDigest',
+    'retentionExpiresAt',
+    'findings',
+    'redaction',
+    'durablePersistenceAllowed',
+    'batchDigest'
+  ] as const;
+  if (
+    !hasExactKeys(
+      value,
+      isTrivy
+        ? [...commonKeys, 'vulnerabilityDatabaseDigest']
+        : commonKeys
+    ) ||
+    value.version !== SAST_SECRET_REDACTION_VERSION ||
+    value.outcome !== 'REDACTED' ||
+    !isBoundedReference(value.ingestionId) ||
+    !isNormalizationScopeValid(value.scope) ||
+    !isBoundedReference(value.scannerRunId) ||
+    !isBoundedIdentifier(value.scannerVersion, 255, false) ||
+    !isAllowedString(value.lane, ['FAST', 'DEEP']) ||
+    !isBoundedReference(value.preflightAttestationRef) ||
+    !isCommitSha(value.commitSha) ||
+    !isIsoTimestamp(value.retentionExpiresAt) ||
+    ![
+      value.scannerImageDigest,
+      value.ruleBundleDigest,
+      value.planDigest,
+      value.canonicalScanKey,
+      value.preflightInventoryDigest,
+      value.envelopeDigest,
+      value.artifactDigest,
+      value.schemaBundleDigest,
+      value.normalizerBundleDigest,
+      value.validationResultDigest,
+      value.dispositionDecisionDigest,
+      value.batchDigest
+    ].every(isSha256Digest) ||
+    !Array.isArray(value.findings) ||
+    value.findings.length >
+      SAST_SECRET_REDACTION_LIMITS.maximumCandidates ||
+    !isSastSecretRedactionSummaryValid(value.redaction) ||
+    value.durablePersistenceAllowed !== false
+  ) {
+    return false;
+  }
+  if (
+    isTrivy
+      ? value.sourceAdapterVersion !==
+          TRIVY_JSON_NORMALIZER_VERSION ||
+        value.artifactSchema !== 'TRIVY_JSON' ||
+        value.artifactSchemaVersion !== '2' ||
+        !isSha256Digest(value.vulnerabilityDatabaseDigest)
+      : value.scanner !== 'OPENGREP' ||
+        value.sourceAdapterVersion !==
+          OPENGREP_SARIF_NORMALIZER_VERSION ||
+        value.artifactSchema !== 'OPENGREP_SARIF' ||
+        value.artifactSchemaVersion !== '2.1.0' ||
+        'vulnerabilityDatabaseDigest' in value
+  ) {
+    return false;
+  }
+
+  const scope = value.scope as SastArtifactDispositionScope;
+  if (value.scannerRunId !== scope.scannerRunId) return false;
+  const findings =
+    value.findings as readonly SastSecretRedactedFindingCandidate[];
+  if (
+    !findings.every(
+      (finding) =>
+        isSastSecretRedactedFindingCandidateShapeValid(finding) &&
+        finding.tenantId === scope.tenantId &&
+        finding.repositoryBindingId === scope.repositoryBindingId &&
+        finding.scanRequestId === scope.scanRequestId &&
+        finding.attemptId === scope.attemptId &&
+        finding.scannerRunId === value.scannerRunId &&
+        finding.planDigest === value.planDigest &&
+        finding.canonicalScanKey === value.canonicalScanKey &&
+        finding.preflightAttestationRef ===
+          value.preflightAttestationRef &&
+        finding.preflightInventoryDigest ===
+          value.preflightInventoryDigest &&
+        finding.commitSha === value.commitSha &&
+        finding.lane === value.lane &&
+        finding.provenance.scanner === value.scanner &&
+        finding.provenance.scannerVersion ===
+          value.scannerVersion &&
+        finding.provenance.scannerImageDigest ===
+          value.scannerImageDigest &&
+        finding.provenance.ruleBundleDigest ===
+          value.ruleBundleDigest &&
+        finding.provenance.artifactDigest ===
+          value.artifactDigest &&
+        (isTrivy
+          ? finding.provenance.scanner === 'TRIVY' &&
+            finding.provenance.vulnerabilityDatabaseDigest ===
+              value.vulnerabilityDatabaseDigest
+          : finding.provenance.scanner === 'OPENGREP')
+    )
+  ) {
+    return false;
+  }
+  if (
+    !findings.every(
+      (finding, index) =>
+        index === 0 ||
+        compareSastNormalizedFindingCandidates(
+          stripSastSecretRedaction(
+            findings[index - 1] as SastSecretRedactedFindingCandidate
+          ),
+          stripSastSecretRedaction(finding)
+        ) < 0
+    )
+  ) {
+    return false;
+  }
+
+  const summary = value.redaction as SastSecretRedactionSummary;
+  const inspectedFieldCount = findings.reduce(
+    (sum, finding) =>
+      sum + finding.redaction.inspectedFieldCount,
+    0
+  );
+  const redactedCandidateCount = findings.filter(
+    (finding) => finding.redaction.replacementCount > 0
+  ).length;
+  const redactedFieldCount = findings.reduce(
+    (sum, finding) =>
+      sum + finding.redaction.redactedFields.length,
+    0
+  );
+  const replacementCount = findings.reduce(
+    (sum, finding) => sum + finding.redaction.replacementCount,
+    0
+  );
+  const detectorKinds = orderSastSecretDetectorKinds(
+    findings.flatMap((finding) => finding.redaction.detectorKinds)
+  );
+  return (
+    summary.candidateCount === findings.length &&
+    summary.batchInspectedFieldCount ===
+      SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT &&
+    summary.inspectedFieldCount ===
+      inspectedFieldCount +
+        SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT &&
+    summary.redactedCandidateCount === redactedCandidateCount &&
+    summary.redactedFieldCount === redactedFieldCount &&
+    summary.replacementCount === replacementCount &&
+    arraysEqual(summary.detectorKinds, detectorKinds)
+  );
+}
+
+export function isSastSecretRedactedFindingCandidateShapeValid(
+  value: unknown
+): value is SastSecretRedactedFindingCandidate {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.redaction) ||
+    !isSastFindingSecretRedactionValid(value.redaction)
+  ) {
+    return false;
+  }
+  const base = stripSastSecretRedaction(
+    value as SastSecretRedactedFindingCandidate
+  );
+  if (!isSastNormalizedFindingCandidateShapeValid(base)) {
+    return false;
+  }
+  const displayValues: Record<SastSecretRedactableField, string> = {
+    TITLE: base.title,
+    DESCRIPTION: base.description,
+    LOCATION_SYMBOL:
+      base.location.symbol === undefined
+        ? ''
+        : base.location.symbol
+  };
+  const actualFields = orderSastSecretRedactableFields(
+    SAST_SECRET_REDACTABLE_FIELDS.filter((field) =>
+      displayValues[field].includes(SAST_SECRET_REDACTION_TOKEN)
+    )
+  );
+  const replacementCount = Object.values(displayValues).reduce(
+    (sum, text) =>
+      sum + countOccurrences(text, SAST_SECRET_REDACTION_TOKEN),
+    0
+  );
+  const redaction =
+    value.redaction as unknown as SastFindingSecretRedaction;
+  return (
+    arraysEqual(redaction.redactedFields, actualFields) &&
+    redaction.replacementCount === replacementCount &&
+    (replacementCount === 0
+      ? redaction.detectorKinds.length === 0 &&
+        redaction.redactedFields.length === 0
+      : redaction.detectorKinds.length > 0 &&
+        redaction.redactedFields.length > 0)
+  );
+}
+
+export function isSastSecretRedactionRejectionShapeValid(
+  value: unknown
+): value is SastSecretRedactionRejection {
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, [
+      'version',
+      'outcome',
+      'reasonCodes',
+      'secretValuesStored',
+      'matchedValueDigestsStored',
+      'sourceCandidateDigestStored',
+      'rejectionDigest'
+    ]) &&
+    value.version === SAST_SECRET_REDACTION_VERSION &&
+    value.outcome === 'REJECTED' &&
+    isStrictOrderedMembers(
+      value.reasonCodes,
+      SAST_SECRET_REDACTION_REJECTION_REASON_CODES
+    ) &&
+    (value.reasonCodes as readonly unknown[]).length > 0 &&
+    value.secretValuesStored === false &&
+    value.matchedValueDigestsStored === false &&
+    value.sourceCandidateDigestStored === false &&
+    isSha256Digest(value.rejectionDigest)
+  );
+}
+
+export function toSastSecretRedactionAuditMetadata(
+  result: unknown
+): SastSecretRedactionAuditMetadata {
+  if (isSastSecretRedactionRejectionShapeValid(result)) {
+    return {
+      version: result.version,
+      outcome: result.outcome,
+      reasonCodes: [...result.reasonCodes],
+      rejectionDigest: result.rejectionDigest
+    };
+  }
+  if (
+    !isRecord(result) ||
+    !hasExactKeys(result, ['outcome', 'batch']) ||
+    result.outcome !== 'REDACTED' ||
+    !isSastSecretRedactionBatchShapeValid(result.batch)
+  ) {
+    throw new TypeError(
+      'SAST secret-redaction result is invalid.'
+    );
+  }
+  const batch = result.batch;
+  return {
+    version: batch.version,
+    outcome: result.outcome,
+    batchDigest: batch.batchDigest,
+    artifactDigest: batch.artifactDigest,
+    dispositionDecisionDigest:
+      batch.dispositionDecisionDigest,
+    candidateCount: batch.redaction.candidateCount,
+    redactedCandidateCount:
+      batch.redaction.redactedCandidateCount,
+    replacementCount: batch.redaction.replacementCount,
+    detectorKinds: [...batch.redaction.detectorKinds]
+  };
+}
+
+export function stripSastSecretRedaction(
+  finding:
+    | Readonly<SastSecretRedactedFindingCandidate>
+    | Readonly<SastSecretRedactedFindingCandidateCore>
+): SastNormalizedFindingCandidate {
+  const { redaction, ...base } = finding;
+  void redaction;
+  return base as SastNormalizedFindingCandidate;
+}
+
+function isSastFindingSecretRedactionValid(
+  value: Record<string, unknown>
+): boolean {
+  return (
+    hasExactKeys(value, [
+      'version',
+      'secretRedactionApplied',
+      'replacementToken',
+      'inspectedFieldCount',
+      'redactedFields',
+      'replacementCount',
+      'detectorKinds',
+      'secretValueStored',
+      'matchedValueDigestStored',
+      'rawCandidateStored',
+      'decisionDigest',
+      'decisionRef'
+    ]) &&
+    value.version === SAST_SECRET_REDACTION_VERSION &&
+    value.secretRedactionApplied === true &&
+    value.replacementToken === SAST_SECRET_REDACTION_TOKEN &&
+    isPositiveSafeInteger(value.inspectedFieldCount) &&
+    isStrictOrderedMembers(
+      value.redactedFields,
+      SAST_SECRET_REDACTABLE_FIELDS
+    ) &&
+    isNonNegativeSafeInteger(value.replacementCount) &&
+    isStrictOrderedMembers(
+      value.detectorKinds,
+      SAST_SECRET_DETECTOR_KINDS
+    ) &&
+    value.secretValueStored === false &&
+    value.matchedValueDigestStored === false &&
+    value.rawCandidateStored === false &&
+    isSha256Digest(value.decisionDigest) &&
+    value.decisionRef ===
+      `redaction://${SAST_SECRET_REDACTION_VERSION}/${
+        (value.decisionDigest as string).slice('sha256:'.length)
+      }`
+  );
+}
+
+function isSastSecretRedactionSummaryValid(
+  value: unknown
+): value is SastSecretRedactionSummary {
+  return (
+    isRecord(value) &&
+    hasExactKeys(value, [
+      'version',
+      'secretRedactionApplied',
+      'candidateCount',
+      'batchInspectedFieldCount',
+      'inspectedFieldCount',
+      'redactedCandidateCount',
+      'redactedFieldCount',
+      'replacementCount',
+      'detectorKinds',
+      'secretValuesStored',
+      'matchedValueDigestsStored',
+      'rawCandidatesStored',
+      'sourceCandidateDigestStored'
+    ]) &&
+    value.version === SAST_SECRET_REDACTION_VERSION &&
+    value.secretRedactionApplied === true &&
+    isNonNegativeSafeInteger(value.candidateCount) &&
+    value.batchInspectedFieldCount ===
+      SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT &&
+    isNonNegativeSafeInteger(value.inspectedFieldCount) &&
+    value.inspectedFieldCount >= value.batchInspectedFieldCount &&
+    isNonNegativeSafeInteger(value.redactedCandidateCount) &&
+    isNonNegativeSafeInteger(value.redactedFieldCount) &&
+    isNonNegativeSafeInteger(value.replacementCount) &&
+    value.redactedCandidateCount <= value.candidateCount &&
+    value.redactedFieldCount <=
+      value.candidateCount *
+        SAST_SECRET_REDACTABLE_FIELDS.length &&
+    isStrictOrderedMembers(
+      value.detectorKinds,
+      SAST_SECRET_DETECTOR_KINDS
+    ) &&
+    value.secretValuesStored === false &&
+    value.matchedValueDigestsStored === false &&
+    value.rawCandidatesStored === false &&
+    value.sourceCandidateDigestStored === false
+  );
+}
+
+function isStrictOrderedMembers(
+  value: unknown,
+  allowed: readonly string[]
+): boolean {
+  if (!Array.isArray(value)) return false;
+  let previous = -1;
+  for (const member of value) {
+    if (typeof member !== 'string') return false;
+    const index = allowed.indexOf(member);
+    if (index <= previous) return false;
+    previous = index;
+  }
+  return true;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0
+  );
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return isNonNegativeSafeInteger(value) && value > 0;
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    Number.isFinite(Date.parse(value)) &&
+    new Date(value).toISOString() === value
+  );
+}
+
+function countOccurrences(text: string, token: string): number {
+  let count = 0;
+  let offset = 0;
+  while (offset <= text.length - token.length) {
+    const index = text.indexOf(token, offset);
+    if (index < 0) break;
+    count += 1;
+    offset = index + token.length;
+  }
+  return count;
+}
+
+function arraysEqual(
+  left: readonly unknown[],
+  right: readonly unknown[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}

--- a/packages/shared/src/types/sast-secret-redaction.ts
+++ b/packages/shared/src/types/sast-secret-redaction.ts
@@ -33,12 +33,34 @@ export const SAST_SECRET_REDACTION_TOKEN = '[REDACTED]' as const;
 
 export const SAST_SECRET_REDACTION_LIMITS = Object.freeze({
   maximumCandidates: 25_000,
+  maximumInspectedCodeUnits: 8_000_000,
+  yieldCandidateInterval: 64,
+  yieldCodeUnitInterval: 32_768,
   maximumPlatformSecretValues: 64,
   maximumPlatformSecretValueBytes: 4_096,
   maximumPlatformSecretValueTotalBytes: 65_536
 });
 
-export const SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT = 8;
+export const SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS =
+  Object.freeze([
+    'INGESTION_ID',
+    'TENANT_ID',
+    'REPOSITORY_BINDING_ID',
+    'SCAN_REQUEST_ID',
+    'ATTEMPT_ID',
+    'SCANNER_RUN_ID',
+    'SCANNER_VERSION',
+    'PREFLIGHT_ATTESTATION_REF'
+  ] as const);
+export type SastSecretRedactionBatchInspectedField =
+  (typeof SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS)[number];
+
+export const SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT =
+  SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS.length;
+
+export type SastSecretRedactionCanonicalDigester = (
+  canonicalValue: string
+) => `sha256:${string}`;
 
 /**
  * Order is part of every redaction decision digest.
@@ -315,7 +337,7 @@ export function canonicalizeSastSecretRedactionBatch(
     scannerVersion: batch.scannerVersion,
     scannerImageDigest: batch.scannerImageDigest,
     ruleBundleDigest: batch.ruleBundleDigest,
-    ...(batch.vulnerabilityDatabaseDigest
+    ...('vulnerabilityDatabaseDigest' in batch
       ? {
           vulnerabilityDatabaseDigest:
             batch.vulnerabilityDatabaseDigest
@@ -372,7 +394,8 @@ export function canonicalizeSastSecretRedactionRejection(
 }
 
 export function isSastSecretRedactionBatchShapeValid(
-  value: unknown
+  value: unknown,
+  digestCanonical: SastSecretRedactionCanonicalDigester
 ): value is SastSecretRedactionBatch {
   if (!isRecord(value)) return false;
   const isTrivy = value.scanner === 'TRIVY';
@@ -470,7 +493,10 @@ export function isSastSecretRedactionBatchShapeValid(
   if (
     !findings.every(
       (finding) =>
-        isSastSecretRedactedFindingCandidateShapeValid(finding) &&
+        isSastSecretRedactedFindingCandidateShapeValid(
+          finding,
+          digestCanonical
+        ) &&
         finding.tenantId === scope.tenantId &&
         finding.repositoryBindingId === scope.repositoryBindingId &&
         finding.scanRequestId === scope.scanRequestId &&
@@ -538,6 +564,9 @@ export function isSastSecretRedactionBatchShapeValid(
   const detectorKinds = orderSastSecretDetectorKinds(
     findings.flatMap((finding) => finding.redaction.detectorKinds)
   );
+  const typedBatch =
+    value as unknown as SastSecretRedactionBatch;
+  const { batchDigest, ...batchCore } = typedBatch;
   return (
     summary.candidateCount === findings.length &&
     summary.batchInspectedFieldCount ===
@@ -548,12 +577,18 @@ export function isSastSecretRedactionBatchShapeValid(
     summary.redactedCandidateCount === redactedCandidateCount &&
     summary.redactedFieldCount === redactedFieldCount &&
     summary.replacementCount === replacementCount &&
-    arraysEqual(summary.detectorKinds, detectorKinds)
+    arraysEqual(summary.detectorKinds, detectorKinds) &&
+    canonicalDigestMatches(
+      digestCanonical,
+      canonicalizeSastSecretRedactionBatch(batchCore),
+      batchDigest
+    )
   );
 }
 
 export function isSastSecretRedactedFindingCandidateShapeValid(
-  value: unknown
+  value: unknown,
+  digestCanonical: SastSecretRedactionCanonicalDigester
 ): value is SastSecretRedactedFindingCandidate {
   if (
     !isRecord(value) ||
@@ -588,6 +623,16 @@ export function isSastSecretRedactedFindingCandidateShapeValid(
   );
   const redaction =
     value.redaction as unknown as SastFindingSecretRedaction;
+  const {
+    decisionDigest,
+    decisionRef: _decisionRef,
+    ...redactionCore
+  } = redaction;
+  void _decisionRef;
+  const decisionCore = {
+    ...base,
+    redaction: redactionCore
+  } as SastSecretRedactedFindingCandidateCore;
   return (
     arraysEqual(redaction.redactedFields, actualFields) &&
     redaction.replacementCount === replacementCount &&
@@ -595,15 +640,22 @@ export function isSastSecretRedactedFindingCandidateShapeValid(
       ? redaction.detectorKinds.length === 0 &&
         redaction.redactedFields.length === 0
       : redaction.detectorKinds.length > 0 &&
-        redaction.redactedFields.length > 0)
+        redaction.redactedFields.length > 0) &&
+    canonicalDigestMatches(
+      digestCanonical,
+      canonicalizeSastSecretRedactionDecision(decisionCore),
+      decisionDigest
+    )
   );
 }
 
 export function isSastSecretRedactionRejectionShapeValid(
-  value: unknown
+  value: unknown,
+  digestCanonical: SastSecretRedactionCanonicalDigester
 ): value is SastSecretRedactionRejection {
-  return (
-    isRecord(value) &&
+  if (
+    !(
+      isRecord(value) &&
     hasExactKeys(value, [
       'version',
       'outcome',
@@ -624,13 +676,30 @@ export function isSastSecretRedactionRejectionShapeValid(
     value.matchedValueDigestsStored === false &&
     value.sourceCandidateDigestStored === false &&
     isSha256Digest(value.rejectionDigest)
+    )
+  ) {
+    return false;
+  }
+  const typedRejection =
+    value as unknown as SastSecretRedactionRejection;
+  const { rejectionDigest, ...rejectionCore } = typedRejection;
+  return canonicalDigestMatches(
+    digestCanonical,
+    canonicalizeSastSecretRedactionRejection(rejectionCore),
+    rejectionDigest
   );
 }
 
 export function toSastSecretRedactionAuditMetadata(
-  result: unknown
+  result: unknown,
+  digestCanonical: SastSecretRedactionCanonicalDigester
 ): SastSecretRedactionAuditMetadata {
-  if (isSastSecretRedactionRejectionShapeValid(result)) {
+  if (
+    isSastSecretRedactionRejectionShapeValid(
+      result,
+      digestCanonical
+    )
+  ) {
     return {
       version: result.version,
       outcome: result.outcome,
@@ -642,7 +711,10 @@ export function toSastSecretRedactionAuditMetadata(
     !isRecord(result) ||
     !hasExactKeys(result, ['outcome', 'batch']) ||
     result.outcome !== 'REDACTED' ||
-    !isSastSecretRedactionBatchShapeValid(result.batch)
+    !isSastSecretRedactionBatchShapeValid(
+      result.batch,
+      digestCanonical
+    )
   ) {
     throw new TypeError(
       'SAST secret-redaction result is invalid.'
@@ -816,4 +888,16 @@ function arraysEqual(
     left.length === right.length &&
     left.every((value, index) => value === right[index])
   );
+}
+
+function canonicalDigestMatches(
+  digestCanonical: SastSecretRedactionCanonicalDigester,
+  canonicalValue: string,
+  expectedDigest: string
+): boolean {
+  try {
+    return digestCanonical(canonicalValue) === expectedDigest;
+  } catch {
+    return false;
+  }
 }

--- a/packages/shared/test/sast-secret-redaction.test.mjs
+++ b/packages/shared/test/sast-secret-redaction.test.mjs
@@ -1,0 +1,328 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  OPENGREP_SARIF_NORMALIZER_VERSION,
+  SAST_SECRET_REDACTION_TOKEN,
+  SAST_SECRET_REDACTION_VERSION,
+  canonicalizeSastSecretRedactionBatch,
+  canonicalizeSastSecretRedactionDecision,
+  canonicalizeSastSecretRedactionRejection,
+  isSastSecretRedactedFindingCandidateShapeValid,
+  isSastSecretRedactionBatchShapeValid,
+  isSastSecretRedactionRejectionShapeValid,
+  orderSastSecretDetectorKinds,
+  orderSastSecretRedactableFields,
+  orderSastSecretRedactionRejectionReasons,
+  stripSastSecretRedaction,
+  toSastSecretRedactionAuditMetadata
+} from '../dist/index.js';
+
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+const DECISION_REF =
+  `redaction://${SAST_SECRET_REDACTION_VERSION}/${'a'.repeat(64)}`;
+
+test('validates a canonical transient redacted-candidate batch', () => {
+  const finding = redactedFinding();
+  const batch = redactedBatch(finding);
+
+  assert.equal(
+    isSastSecretRedactedFindingCandidateShapeValid(finding),
+    true
+  );
+  assert.equal(isSastSecretRedactionBatchShapeValid(batch), true);
+  assert.equal(batch.durablePersistenceAllowed, false);
+  assert.equal(batch.redaction.secretValuesStored, false);
+  assert.equal(batch.redaction.matchedValueDigestsStored, false);
+  assert.equal(batch.redaction.sourceCandidateDigestStored, false);
+  assert.equal(
+    stripSastSecretRedaction(finding).durablePersistenceAllowed,
+    false
+  );
+
+  const { batchDigest, ...batchCore } = batch;
+  void batchDigest;
+  const canonical =
+    canonicalizeSastSecretRedactionBatch(batchCore);
+  assert.match(canonical, /"sourceCandidateDigestStored":false/u);
+  assert.match(canonical, /"durablePersistenceAllowed":false/u);
+  assert.doesNotMatch(canonical, /\bstableFingerprint\b/u);
+  assert.doesNotMatch(canonical, /\bevidencePackIds\b/u);
+  assert.doesNotMatch(canonical, /\bstatus\b/u);
+});
+
+test('binds only sanitized candidate content into a redaction decision', () => {
+  const finding = redactedFinding();
+  const { decisionDigest, decisionRef, ...redactionCore } =
+    finding.redaction;
+  void decisionDigest;
+  void decisionRef;
+  const canonical = canonicalizeSastSecretRedactionDecision({
+    ...finding,
+    redaction: redactionCore
+  });
+
+  assert.match(canonical, /\[REDACTED\]/u);
+  assert.doesNotMatch(canonical, /"matchedValueDigest":/u);
+  assert.doesNotMatch(canonical, /sourceBatchDigest/u);
+  assert.doesNotMatch(canonical, /rawCandidateStored":true/u);
+});
+
+test('rejects forged redaction metadata and summary totals', () => {
+  const finding = redactedFinding();
+  const batch = redactedBatch(finding);
+  for (const forged of [
+    {
+      ...finding,
+      redaction: {
+        ...finding.redaction,
+        replacementCount: 0
+      }
+    },
+    {
+      ...finding,
+      redaction: {
+        ...finding.redaction,
+        redactedFields: []
+      }
+    },
+    {
+      ...finding,
+      redaction: {
+        ...finding.redaction,
+        decisionRef:
+          `redaction://${SAST_SECRET_REDACTION_VERSION}/${'b'.repeat(64)}`
+      }
+    },
+    {
+      ...finding,
+      durablePersistenceAllowed: true
+    }
+  ]) {
+    assert.equal(
+      isSastSecretRedactedFindingCandidateShapeValid(forged),
+      false
+    );
+  }
+  assert.equal(
+    isSastSecretRedactionBatchShapeValid({
+      ...batch,
+      redaction: {
+        ...batch.redaction,
+        replacementCount: 2
+      }
+    }),
+    false
+  );
+  assert.equal(
+    isSastSecretRedactionBatchShapeValid({
+      ...batch,
+      vulnerabilityDatabaseDigest: DIGEST
+    }),
+    false
+  );
+});
+
+test('orders detector, field, and rejection enums canonically', () => {
+  assert.deepEqual(
+    orderSastSecretDetectorKinds([
+      'JWT',
+      'PLATFORM_VALUE',
+      'JWT',
+      'GITHUB_TOKEN'
+    ]),
+    ['PLATFORM_VALUE', 'GITHUB_TOKEN', 'JWT']
+  );
+  assert.deepEqual(
+    orderSastSecretRedactableFields([
+      'LOCATION_SYMBOL',
+      'TITLE',
+      'TITLE'
+    ]),
+    ['TITLE', 'LOCATION_SYMBOL']
+  );
+  assert.deepEqual(
+    orderSastSecretRedactionRejectionReasons([
+      'SECRET_REDACTION_OUTPUT_INVALID',
+      'SECRET_REDACTION_INPUT_INVALID',
+      'SECRET_REDACTION_OUTPUT_INVALID'
+    ]),
+    [
+      'SECRET_REDACTION_INPUT_INVALID',
+      'SECRET_REDACTION_OUTPUT_INVALID'
+    ]
+  );
+});
+
+test('exposes bounded safe audit metadata only', () => {
+  const batch = redactedBatch(redactedFinding());
+  const acceptedAudit = toSastSecretRedactionAuditMetadata({
+    outcome: 'REDACTED',
+    batch
+  });
+  assert.deepEqual(Object.keys(acceptedAudit), [
+    'version',
+    'outcome',
+    'batchDigest',
+    'artifactDigest',
+    'dispositionDecisionDigest',
+    'candidateCount',
+    'redactedCandidateCount',
+    'replacementCount',
+    'detectorKinds'
+  ]);
+
+  const rejectionCore = {
+    version: SAST_SECRET_REDACTION_VERSION,
+    outcome: 'REJECTED',
+    reasonCodes: ['SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'],
+    secretValuesStored: false,
+    matchedValueDigestsStored: false,
+    sourceCandidateDigestStored: false
+  };
+  const rejection = {
+    ...rejectionCore,
+    rejectionDigest: DIGEST
+  };
+  assert.equal(
+    isSastSecretRedactionRejectionShapeValid(rejection),
+    true
+  );
+  assert.deepEqual(
+    toSastSecretRedactionAuditMetadata(rejection),
+    {
+      version: SAST_SECRET_REDACTION_VERSION,
+      outcome: 'REJECTED',
+      reasonCodes: ['SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'],
+      rejectionDigest: DIGEST
+    }
+  );
+  assert.throws(
+    () =>
+      toSastSecretRedactionAuditMetadata({
+        outcome: 'REDACTED',
+        batch,
+        secretValue: 'must-not-project'
+      }),
+    /result is invalid/u
+  );
+  assert.doesNotMatch(
+    canonicalizeSastSecretRedactionRejection(rejectionCore),
+    /candidate|matchedValueDigest":|secretValue":/u
+  );
+});
+
+function redactedFinding() {
+  return {
+    tenantId: 'tenant-1',
+    repositoryBindingId: 'repository-1',
+    scanRequestId: 'scan-1',
+    attemptId: 'attempt-1',
+    scannerRunId: 'scanner-run-1',
+    planDigest: DIGEST,
+    canonicalScanKey: DIGEST,
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: DIGEST,
+    commitSha: 'a'.repeat(40),
+    lane: 'FAST',
+    capability: 'SAST',
+    title: `${SAST_SECRET_REDACTION_TOKEN} exposure`,
+    description: 'A credential-like value was removed.',
+    severity: 'HIGH',
+    confidence: 'HIGH',
+    cweIds: ['CWE-798'],
+    cveIds: [],
+    location: {
+      kind: 'FILE',
+      normalizedPath: 'src/config.ts',
+      lineStart: 4,
+      lineEnd: 4
+    },
+    identityMaterial: {
+      ruleSemanticId: 'javascript.hardcoded-secret',
+      symbolAnchor: '',
+      sinkKind: '',
+      structuralHash: DIGEST,
+      scannerMatchBasedId: 'rules.secret:match-1'
+    },
+    provenance: {
+      scanner: 'OPENGREP',
+      scannerVersion: '1.22.0',
+      scannerImageDigest: DIGEST,
+      ruleId: 'rules.secret',
+      ruleRevision: '2026.07.1',
+      ruleBundleDigest: DIGEST,
+      artifactDigest: DIGEST
+    },
+    notes: [],
+    redaction: {
+      version: SAST_SECRET_REDACTION_VERSION,
+      secretRedactionApplied: true,
+      replacementToken: SAST_SECRET_REDACTION_TOKEN,
+      inspectedFieldCount: 10,
+      redactedFields: ['TITLE'],
+      replacementCount: 1,
+      detectorKinds: ['GITHUB_TOKEN'],
+      secretValueStored: false,
+      matchedValueDigestStored: false,
+      rawCandidateStored: false,
+      decisionDigest: DIGEST,
+      decisionRef: DECISION_REF
+    },
+    durablePersistenceAllowed: false
+  };
+}
+
+function redactedBatch(finding) {
+  return {
+    version: SAST_SECRET_REDACTION_VERSION,
+    outcome: 'REDACTED',
+    sourceAdapterVersion: OPENGREP_SARIF_NORMALIZER_VERSION,
+    artifactSchema: 'OPENGREP_SARIF',
+    artifactSchemaVersion: '2.1.0',
+    ingestionId: 'ingestion-1',
+    scope: {
+      tenantId: 'tenant-1',
+      repositoryBindingId: 'repository-1',
+      scanRequestId: 'scan-1',
+      attemptId: 'attempt-1',
+      scannerRunId: 'scanner-run-1'
+    },
+    scannerRunId: 'scanner-run-1',
+    scanner: 'OPENGREP',
+    scannerVersion: '1.22.0',
+    scannerImageDigest: DIGEST,
+    ruleBundleDigest: DIGEST,
+    planDigest: DIGEST,
+    canonicalScanKey: DIGEST,
+    preflightAttestationRef: 'preflight://attempt-1',
+    preflightInventoryDigest: DIGEST,
+    lane: 'FAST',
+    commitSha: 'a'.repeat(40),
+    envelopeDigest: DIGEST,
+    artifactDigest: DIGEST,
+    schemaBundleDigest: DIGEST,
+    normalizerBundleDigest: DIGEST,
+    validationResultDigest: DIGEST,
+    dispositionDecisionDigest: DIGEST,
+    retentionExpiresAt: '2026-08-01T00:00:00.000Z',
+    findings: [finding],
+    redaction: {
+      version: SAST_SECRET_REDACTION_VERSION,
+      secretRedactionApplied: true,
+      candidateCount: 1,
+      batchInspectedFieldCount: 8,
+      inspectedFieldCount: 18,
+      redactedCandidateCount: 1,
+      redactedFieldCount: 1,
+      replacementCount: 1,
+      detectorKinds: ['GITHUB_TOKEN'],
+      secretValuesStored: false,
+      matchedValueDigestsStored: false,
+      rawCandidatesStored: false,
+      sourceCandidateDigestStored: false
+    },
+    durablePersistenceAllowed: false,
+    batchDigest: DIGEST
+  };
+}

--- a/packages/shared/test/sast-secret-redaction.test.mjs
+++ b/packages/shared/test/sast-secret-redaction.test.mjs
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import test from 'node:test';
 
 import {
   OPENGREP_SARIF_NORMALIZER_VERSION,
+  SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS,
+  SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+  SAST_SECRET_REDACTION_LIMITS,
   SAST_SECRET_REDACTION_TOKEN,
   SAST_SECRET_REDACTION_VERSION,
   canonicalizeSastSecretRedactionBatch,
@@ -19,18 +23,51 @@ import {
 } from '../dist/index.js';
 
 const DIGEST = `sha256:${'a'.repeat(64)}`;
-const DECISION_REF =
-  `redaction://${SAST_SECRET_REDACTION_VERSION}/${'a'.repeat(64)}`;
 
 test('validates a canonical transient redacted-candidate batch', () => {
   const finding = redactedFinding();
   const batch = redactedBatch(finding);
 
   assert.equal(
-    isSastSecretRedactedFindingCandidateShapeValid(finding),
+    isSastSecretRedactedFindingCandidateShapeValid(
+      finding,
+      digest
+    ),
     true
   );
-  assert.equal(isSastSecretRedactionBatchShapeValid(batch), true);
+  assert.equal(
+    isSastSecretRedactionBatchShapeValid(batch, digest),
+    true
+  );
+  assert.equal(
+    SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+    SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS.length
+  );
+  assert.deepEqual(
+    SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELDS,
+    [
+      'INGESTION_ID',
+      'TENANT_ID',
+      'REPOSITORY_BINDING_ID',
+      'SCAN_REQUEST_ID',
+      'ATTEMPT_ID',
+      'SCANNER_RUN_ID',
+      'SCANNER_VERSION',
+      'PREFLIGHT_ATTESTATION_REF'
+    ]
+  );
+  assert.equal(
+    SAST_SECRET_REDACTION_LIMITS.maximumInspectedCodeUnits,
+    8_000_000
+  );
+  assert.equal(
+    SAST_SECRET_REDACTION_LIMITS.yieldCandidateInterval,
+    64
+  );
+  assert.equal(
+    SAST_SECRET_REDACTION_LIMITS.yieldCodeUnitInterval,
+    32_768
+  );
   assert.equal(batch.durablePersistenceAllowed, false);
   assert.equal(batch.redaction.secretValuesStored, false);
   assert.equal(batch.redaction.matchedValueDigestsStored, false);
@@ -96,29 +133,57 @@ test('rejects forged redaction metadata and summary totals', () => {
     },
     {
       ...finding,
+      redaction: {
+        ...finding.redaction,
+        decisionDigest: `sha256:${'b'.repeat(64)}`,
+        decisionRef:
+          `redaction://${SAST_SECRET_REDACTION_VERSION}/${'b'.repeat(64)}`
+      }
+    },
+    {
+      ...finding,
       durablePersistenceAllowed: true
     }
   ]) {
     assert.equal(
-      isSastSecretRedactedFindingCandidateShapeValid(forged),
+      isSastSecretRedactedFindingCandidateShapeValid(
+        forged,
+        digest
+      ),
       false
     );
   }
   assert.equal(
-    isSastSecretRedactionBatchShapeValid({
-      ...batch,
-      redaction: {
-        ...batch.redaction,
-        replacementCount: 2
-      }
-    }),
+    isSastSecretRedactionBatchShapeValid(
+      {
+        ...batch,
+        redaction: {
+          ...batch.redaction,
+          replacementCount: 2
+        }
+      },
+      digest
+    ),
     false
   );
   assert.equal(
-    isSastSecretRedactionBatchShapeValid({
-      ...batch,
-      vulnerabilityDatabaseDigest: DIGEST
-    }),
+    isSastSecretRedactionBatchShapeValid(
+      {
+        ...batch,
+        vulnerabilityDatabaseDigest: DIGEST
+      },
+      digest
+    ),
+    false
+  );
+  assert.equal(
+    isSastSecretRedactionBatchShapeValid(
+      {
+        ...batch,
+        retentionExpiresAt: '2026-08-02T00:00:00.000Z'
+      },
+      digest
+    ),
     false
   );
 });
@@ -156,10 +221,13 @@ test('orders detector, field, and rejection enums canonically', () => {
 
 test('exposes bounded safe audit metadata only', () => {
   const batch = redactedBatch(redactedFinding());
-  const acceptedAudit = toSastSecretRedactionAuditMetadata({
-    outcome: 'REDACTED',
-    batch
-  });
+  const acceptedAudit = toSastSecretRedactionAuditMetadata(
+    {
+      outcome: 'REDACTED',
+      batch
+    },
+    digest
+  );
   assert.deepEqual(Object.keys(acceptedAudit), [
     'version',
     'outcome',
@@ -182,19 +250,24 @@ test('exposes bounded safe audit metadata only', () => {
   };
   const rejection = {
     ...rejectionCore,
-    rejectionDigest: DIGEST
+    rejectionDigest: digest(
+      canonicalizeSastSecretRedactionRejection(rejectionCore)
+    )
   };
   assert.equal(
-    isSastSecretRedactionRejectionShapeValid(rejection),
+    isSastSecretRedactionRejectionShapeValid(
+      rejection,
+      digest
+    ),
     true
   );
   assert.deepEqual(
-    toSastSecretRedactionAuditMetadata(rejection),
+    toSastSecretRedactionAuditMetadata(rejection, digest),
     {
       version: SAST_SECRET_REDACTION_VERSION,
       outcome: 'REJECTED',
       reasonCodes: ['SECRET_REDACTION_IDENTITY_FIELD_BLOCKED'],
-      rejectionDigest: DIGEST
+      rejectionDigest: rejection.rejectionDigest
     }
   );
   assert.throws(
@@ -203,7 +276,7 @@ test('exposes bounded safe audit metadata only', () => {
         outcome: 'REDACTED',
         batch,
         secretValue: 'must-not-project'
-      }),
+      }, digest),
     /result is invalid/u
   );
   assert.doesNotMatch(
@@ -213,7 +286,7 @@ test('exposes bounded safe audit metadata only', () => {
 });
 
 function redactedFinding() {
-  return {
+  const finding = {
     tenantId: 'tenant-1',
     repositoryBindingId: 'repository-1',
     scanRequestId: 'scan-1',
@@ -267,14 +340,34 @@ function redactedFinding() {
       matchedValueDigestStored: false,
       rawCandidateStored: false,
       decisionDigest: DIGEST,
-      decisionRef: DECISION_REF
+      decisionRef:
+        `redaction://${SAST_SECRET_REDACTION_VERSION}/${'a'.repeat(64)}`
     },
     durablePersistenceAllowed: false
   };
+  const {
+    decisionDigest: _decisionDigest,
+    decisionRef: _decisionRef,
+    ...redactionCore
+  } = finding.redaction;
+  void _decisionDigest;
+  void _decisionRef;
+  const decisionDigest = digest(
+    canonicalizeSastSecretRedactionDecision({
+      ...finding,
+      redaction: redactionCore
+    })
+  );
+  finding.redaction.decisionDigest = decisionDigest;
+  finding.redaction.decisionRef =
+    `redaction://${SAST_SECRET_REDACTION_VERSION}/${decisionDigest.slice(
+      'sha256:'.length
+    )}`;
+  return finding;
 }
 
 function redactedBatch(finding) {
-  return {
+  const batch = {
     version: SAST_SECRET_REDACTION_VERSION,
     outcome: 'REDACTED',
     sourceAdapterVersion: OPENGREP_SARIF_NORMALIZER_VERSION,
@@ -311,8 +404,11 @@ function redactedBatch(finding) {
       version: SAST_SECRET_REDACTION_VERSION,
       secretRedactionApplied: true,
       candidateCount: 1,
-      batchInspectedFieldCount: 8,
-      inspectedFieldCount: 18,
+      batchInspectedFieldCount:
+        SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
+      inspectedFieldCount:
+        finding.redaction.inspectedFieldCount +
+        SAST_SECRET_REDACTION_BATCH_INSPECTED_FIELD_COUNT,
       redactedCandidateCount: 1,
       redactedFieldCount: 1,
       replacementCount: 1,
@@ -325,4 +421,16 @@ function redactedBatch(finding) {
     durablePersistenceAllowed: false,
     batchDigest: DIGEST
   };
+  const { batchDigest: _batchDigest, ...batchCore } = batch;
+  void _batchDigest;
+  batch.batchDigest = digest(
+    canonicalizeSastSecretRedactionBatch(batchCore)
+  );
+  return batch;
+}
+
+function digest(value) {
+  return `sha256:${createHash('sha256')
+    .update(value)
+    .digest('hex')}`;
 }

--- a/packages/shared/test/shared-contract-exports.test.mjs
+++ b/packages/shared/test/shared-contract-exports.test.mjs
@@ -25,6 +25,10 @@ const files = {
     '../src/types/sast-normalization.ts',
     import.meta.url
   ),
+  sastSecretRedaction: new URL(
+    '../src/types/sast-secret-redaction.ts',
+    import.meta.url
+  ),
   sastPlanning: new URL('../src/types/sast-planning.ts', import.meta.url),
   sastFetch: new URL('../src/types/sast-fetch.ts', import.meta.url),
   sastWrapper: new URL('../src/types/sast-wrapper.ts', import.meta.url),
@@ -52,6 +56,7 @@ test('shared contract modules exist and are re-exported from the package root', 
     'sast-artifact-validation',
     'sast-artifact-disposition',
     'sast-normalization',
+    'sast-secret-redaction',
     'sast-planning',
     'sast-fetch',
     'sast-wrapper'

--- a/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
+++ b/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
@@ -759,15 +759,17 @@ digest and independently verifies the exact T031 decision shape/digest, `ACCEPTE
 disposition, `normalizationEligible=true`, ingestion and validation-result binding, and
 candidate-carried disposition digest. Its private default wall clock must be at or after
 `decidedAt` and before `retentionExpiresAt`; the same monotonic check runs after the complete
-pass. A caller-provided clock is a trusted test/task seam only.
+pass. A caller-provided clock is a trusted test/task seam only; production uses the private
+wall clock and the service's internal `setImmediate`-backed yield.
 
 The detector policy is versioned with this gate:
 
 - at most 64 unique NFC platform values, each 8-4,096 UTF-8 bytes and at most 65,536 bytes
   total, may be supplied as caller-owned transient values;
 - private-key blocks, authorization credentials, URL user information, documented AWS,
-  GitHub, GitLab, Slack, Google, Stripe, and SendGrid formats, JWTs, contextual secret
-  assignments, and bounded high-entropy tokens are detected;
+  GitHub, GitLab, Slack, Google, Stripe, and SendGrid formats, JWTs, prefixed/quoted
+  low-entropy and contextual secret assignments, and bounded high-entropy tokens are
+  detected;
 - pattern evaluation is linear over already-bounded candidate scalars. Detector order is
   canonical, and overlapping or directly adjacent spans merge before replacement;
 - the sole replacement is the fixed ASCII `[REDACTED]` marker. It reveals no original
@@ -777,12 +779,19 @@ The detector policy is versioned with this gate:
 
 Only `title`, `description`, and optional `location.symbol` are display-redactable.
 Ingestion/scope/preflight bindings are inspected even for a zero-finding batch. A match in
-one of those bindings or in normalized path, rule semantic identity, symbol anchor, sink
-kind, scanner identity hint, rule provenance, dependency package/version, secret category,
-or IaC check identity rejects the complete batch with
+one of those bindings or in normalized path, semantic rule identity, symbol anchor, sink
+kind, scanner version/match identity, rule provenance identifier/revision, dependency
+vulnerability/package/type/installed/fixed-version identity, secret category, or IaC check
+type/AVD identity rejects the complete batch with
 `SECRET_REDACTION_IDENTITY_FIELD_BLOCKED`. The gate does not replace an identity field,
 silently drop the candidate, hash the match, or use line coordinates to invent a
 replacement identity.
+
+The async gate rejects a batch above 8,000,000 inspected UTF-16 code units. It yields before
+the next candidate when either 64 candidates or 32,768 code units have been processed in the
+current chunk. Candidate, batch, rejection, and audit validation requires the trusted
+canonical SHA-256 digester and recomputes the sanitized preimage; digest syntax alone is not
+integrity.
 
 Success returns only a fresh, ordered `SastSecretRedactionBatch`. Each finding carries an
 ordered `SastFindingSecretRedaction` decision and a
@@ -804,7 +813,7 @@ durablePersistenceAllowed=false
 
 The output and bounded audit projection never carry a matched value, match length,
 matched-value digest, input object, input candidate-batch digest, or rejected binding.
-Rejections contain only the exact version, globally ordered coarse reason codes, the four
+Rejections contain only the exact version, globally ordered coarse reason codes, the three
 negative storage assertions, and a digest over those safe fields. The source artifact digest
 may remain normal accepted-artifact provenance only on success; it is absent from rejection.
 

--- a/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
+++ b/specs/006-production-sast-runtime-design/contracts/sast-runtime.md
@@ -491,7 +491,7 @@ The sandbox never has direct Prisma, findings, policy, comment, or AI access.
 Each supported artifact schema has one explicit adapter version. T032 and T033 adapters emit
 transient `SastNormalizedFindingCandidate` values and cannot change policy state. A candidate
 is not a `NormalizedSastFinding`: it has no platform stable fingerprint, evidence reference,
-or finding lifecycle status and carries `durablePersistenceAllowed=false`. T035 must redact
+or finding lifecycle status and carries `durablePersistenceAllowed=false`. T035 redacts
 the transient candidate before any durable storage, log, audit, dashboard, or evidence path;
 T036 then computes the platform fingerprint and constructs the final normalized finding.
 T034 emits a separate transient `SyftCycloneDxInventoryBatch`, not a finding candidate. It
@@ -508,8 +508,9 @@ Retention is evaluated before and after streaming against the adapter's own defa
 an alternate clock exists only as an explicit trusted test/task seam and is never read from
 artifact or envelope payload.
 The adapter does not expose a route and does not gain a general object-store read capability.
-Its bounded stream is supplied only by the later Data/Security-owned redaction/persistence
-worker; the default runtime remains unwired and fail closed until that worker exists.
+Its bounded stream is supplied only by the later Data/Security-owned
+normalization/redaction/fingerprinting worker. The T035 redaction component exists, but the
+default runtime remains unwired and fail closed until that worker and T036 exist.
 
 The v1 schema mapping is deliberately narrower than generic SARIF:
 
@@ -749,6 +750,70 @@ Raw artifact bytes, raw properties, source paths, raw license text, prose, exter
 payloads, findings, severity, stable fingerprints, evidence references, and object keys are
 not batch fields. The accepted raw SBOM remains only in the Data/Security Plane under the
 T031 retention deadline, which is derived from receipt time and capped at seven days.
+
+### Secret redaction gate v1
+
+`sast-secret-redaction-v1` accepts only an exact shape-valid OpenGrep or Trivy candidate
+batch. Before reading candidate text it recomputes the adapter-specific canonical batch
+digest and independently verifies the exact T031 decision shape/digest, `ACCEPTED`
+disposition, `normalizationEligible=true`, ingestion and validation-result binding, and
+candidate-carried disposition digest. Its private default wall clock must be at or after
+`decidedAt` and before `retentionExpiresAt`; the same monotonic check runs after the complete
+pass. A caller-provided clock is a trusted test/task seam only.
+
+The detector policy is versioned with this gate:
+
+- at most 64 unique NFC platform values, each 8-4,096 UTF-8 bytes and at most 65,536 bytes
+  total, may be supplied as caller-owned transient values;
+- private-key blocks, authorization credentials, URL user information, documented AWS,
+  GitHub, GitLab, Slack, Google, Stripe, and SendGrid formats, JWTs, contextual secret
+  assignments, and bounded high-entropy tokens are detected;
+- pattern evaluation is linear over already-bounded candidate scalars. Detector order is
+  canonical, and overlapping or directly adjacent spans merge before replacement;
+- the sole replacement is the fixed ASCII `[REDACTED]` marker. It reveals no original
+  length, digest, provider account, or validity signal;
+- a source candidate containing the reserved marker is rejected so scanner content cannot
+  forge `secretRedactionApplied=true`.
+
+Only `title`, `description`, and optional `location.symbol` are display-redactable.
+Ingestion/scope/preflight bindings are inspected even for a zero-finding batch. A match in
+one of those bindings or in normalized path, rule semantic identity, symbol anchor, sink
+kind, scanner identity hint, rule provenance, dependency package/version, secret category,
+or IaC check identity rejects the complete batch with
+`SECRET_REDACTION_IDENTITY_FIELD_BLOCKED`. The gate does not replace an identity field,
+silently drop the candidate, hash the match, or use line coordinates to invent a
+replacement identity.
+
+Success returns only a fresh, ordered `SastSecretRedactionBatch`. Each finding carries an
+ordered `SastFindingSecretRedaction` decision and a
+`redaction://sast-secret-redaction-v1/<safe-decision-digest>` reference. The decision digest
+preimage contains the sanitized candidate plus version, fixed token, safe counts, ordered
+redacted-field names, and ordered detector categories. Batch counts include the eight
+binding fields plus all finding fields, so a zero-finding batch still proves binding
+inspection. Its canonical batch digest contains only fresh sanitized output. These
+invariants are literal:
+
+```text
+secretRedactionApplied=true
+secretValueStored=false
+matchedValueDigestStored=false
+rawCandidateStored=false
+sourceCandidateDigestStored=false
+durablePersistenceAllowed=false
+```
+
+The output and bounded audit projection never carry a matched value, match length,
+matched-value digest, input object, input candidate-batch digest, or rejected binding.
+Rejections contain only the exact version, globally ordered coarse reason codes, the four
+negative storage assertions, and a digest over those safe fields. The source artifact digest
+may remain normal accepted-artifact provenance only on success; it is absent from rejection.
+
+`ScanPlaneModule` does not export the raw OpenGrep or Trivy normalizer providers after T035.
+It exports the redaction gate for the next internal stage. This limits normal Nest module
+consumers to the sanitized handoff but does not authorize a user route, log sink, audit of
+candidate text, evidence construction, policy evaluation, AI call, or persistence. T036
+must verify this batch, compute the platform fingerprint from secret-free identity material,
+and construct the first durable normalized finding.
 
 ## Stable Fingerprint Contract
 

--- a/specs/006-production-sast-runtime-design/data-model.md
+++ b/specs/006-production-sast-runtime-design/data-model.md
@@ -428,8 +428,48 @@ title/description/message, secret match/code/context, modified-finding statement
 misconfiguration traces/rendered causes, and scanner payload substructures are never fields.
 Dependency locations remain explicitly unknown when the fixed Trivy wrapper omits package
 coordinates; no fallback line is invented. Exact-coordinate secret/IaC duplicates that cannot
-be distinguished without coordinate-derived identity are rejected as ambiguous. T035 must
-redact candidates before durable storage and T036 must construct the final entity below.
+be distinguished without coordinate-derived identity are rejected as ambiguous. This is the
+pre-redaction T035 input and cannot be logged, audited, persisted, exposed, or used as evidence.
+
+### SastSecretRedactionBatch
+
+A fresh, in-memory, non-durable T035 handoff produced only from one canonical T032/T033 batch:
+
+- exact `sast-secret-redaction-v1`, source adapter/schema, ingestion and immutable
+  tenant/repository/scan/attempt/scanner scope, scanner/rule/artifact, plan/canonical scan,
+  preflight, validation, disposition, envelope, schema/normalizer, lane, and fixed-commit
+  provenance
+- the active T031 `retentionExpiresAt`, revalidated at or after disposition time before and
+  after the pass
+- a fresh ordered copy of each candidate with sanitized title, description, and optional
+  location symbol; no object from the input candidate graph is returned as the durable handoff
+- per-candidate `SastFindingSecretRedaction`: exact version, fixed `[REDACTED]` marker,
+  inspected-field count, ordered redacted fields, merged replacement count, ordered detector
+  categories, and a decision reference/digest computed only from sanitized content and safe
+  metadata
+- batch summary counts covering the eight scope/binding fields even when there are zero
+  findings, plus all inspected candidate fields, redacted candidates/fields, replacements,
+  and ordered detector categories
+- invariants `secretRedactionApplied=true`, `secretValueStored=false`,
+  `matchedValueDigestStored=false`, `rawCandidateStored=false`,
+  `sourceCandidateDigestStored=false`, and `durablePersistenceAllowed=false`
+- a canonical SHA-256 batch digest whose preimage contains only the fresh sanitized batch
+
+Registered platform values are transient caller-owned inputs and never output fields. Known
+provider/private-key/authentication/URL/JWT/assignment/high-entropy matches may be replaced
+only in display fields. A match in ingestion/scope/preflight bindings, normalized path,
+semantic rule, symbol anchor, sink kind, scanner identity hint, rule revision, package name or
+version, category, or check identity rejects the complete batch. The rejection contains only
+ordered coarse reason codes, negative storage assertions, and a digest over those safe
+values. It omits the ingestion/scope values, matched field/type/value/length, matched-value
+hash, artifact digest, and pre-redaction batch digest.
+
+The pre-redaction source batch may be used only inside this gate. OpenGrep and Trivy
+normalizers are no longer exported from `ScanPlaneModule`; downstream code receives the
+redaction service boundary. The successful output still has no platform fingerprint,
+evidence, finding lifecycle, policy, dashboard, or AI authority. T036 must validate this
+batch, compute `sast-fingerprint-v1`, and construct the final entity below before durable
+normalized finding persistence.
 
 ### NormalizedSastFinding
 

--- a/specs/006-production-sast-runtime-design/data-model.md
+++ b/specs/006-production-sast-runtime-design/data-model.md
@@ -442,7 +442,8 @@ A fresh, in-memory, non-durable T035 handoff produced only from one canonical T0
 - the active T031 `retentionExpiresAt`, revalidated at or after disposition time before and
   after the pass
 - a fresh ordered copy of each candidate with sanitized title, description, and optional
-  location symbol; no object from the input candidate graph is returned as the durable handoff
+  location symbol; no object from the input candidate graph is returned as the non-durable
+  handoff
 - per-candidate `SastFindingSecretRedaction`: exact version, fixed `[REDACTED]` marker,
   inspected-field count, ordered redacted fields, merged replacement count, ordered detector
   categories, and a decision reference/digest computed only from sanitized content and safe
@@ -454,15 +455,23 @@ A fresh, in-memory, non-durable T035 handoff produced only from one canonical T0
   `matchedValueDigestStored=false`, `rawCandidateStored=false`,
   `sourceCandidateDigestStored=false`, and `durablePersistenceAllowed=false`
 - a canonical SHA-256 batch digest whose preimage contains only the fresh sanitized batch
+- an 8,000,000 inspected UTF-16 code-unit work ceiling and cooperative async chunk boundaries
+  of 64 candidates or 32,768 code units; overflow rejects the complete batch without payload
 
 Registered platform values are transient caller-owned inputs and never output fields. Known
 provider/private-key/authentication/URL/JWT/assignment/high-entropy matches may be replaced
-only in display fields. A match in ingestion/scope/preflight bindings, normalized path,
-semantic rule, symbol anchor, sink kind, scanner identity hint, rule revision, package name or
-version, category, or check identity rejects the complete batch. The rejection contains only
+only in display fields. A match in ingestion/scope/preflight bindings or in normalized path,
+semantic rule identity, symbol anchor, sink kind, scanner version/match identity, rule
+provenance identifier/revision, dependency vulnerability/package/type/installed/fixed-version
+identity, secret category, or IaC check type/AVD identity rejects the complete batch. The
+rejection contains only
 ordered coarse reason codes, negative storage assertions, and a digest over those safe
 values. It omits the ingestion/scope values, matched field/type/value/length, matched-value
 hash, artifact digest, and pre-redaction batch digest.
+
+Candidate, batch, and rejection validators require a trusted canonical SHA-256 digester and
+recompute every T035 decision preimage. A digest that is merely well-formed but does not bind
+the sanitized object is invalid and cannot enter T036.
 
 The pre-redaction source batch may be used only inside this gate. OpenGrep and Trivy
 normalizers are no longer exported from `ScanPlaneModule`; downstream code receives the

--- a/specs/006-production-sast-runtime-design/plan.md
+++ b/specs/006-production-sast-runtime-design/plan.md
@@ -67,7 +67,8 @@ schema, size/count, encoding, coordinates, paths, enums, and status outside the 
 Quarantine invalid artifacts. Normalize only through versioned adapters with golden fixtures;
 emit only transient `durablePersistenceAllowed=false` candidates, and redact detected secret
 values before durable normalized storage. T032's OpenGrep adapter is scalar-streaming and is
-not wired to a production artifact reader or persistence worker ahead of T035. Its candidate
+not wired to a production artifact reader or persistence worker; the T035 component remains
+an internal handoff until Data/Security orchestration and T036 exist. Its candidate
 batch retains immutable plan/attestation digests and resolves semantic rule identity only from
 the signed rule-bundle manifest. T033's Trivy adapter applies the same transient boundary to
 dependency, secret, and IaC records, including supported `ExperimentalModifiedFindings`.
@@ -77,7 +78,13 @@ discarded before candidate construction. T034's Syft adapter pins the v1.44.0 di
 producer and CycloneDX JSON 1.6 schema, shares the same bounded scalar-streaming core, and
 emits only a transient SBOM inventory with hashed producer references. Raw properties,
 source locations, license text, prose, external references, and the raw artifact are excluded;
-the inventory has no finding, vulnerability, policy, persistence, or AI authority.
+the inventory has no finding, vulnerability, policy, persistence, or AI authority. T035's
+`sast-secret-redaction-v1` gate verifies canonical OpenGrep/Trivy batch and accepted
+disposition digests, rechecks retention on both sides, and scans both non-empty candidates
+and zero-finding batch bindings. It replaces only display text with a fixed marker; a match
+in any future identity field rejects the entire batch. Its fresh output exposes safe counts
+and sanitized-only decision digests, never matched values, matched-value hashes, or the
+source-candidate digest, and remains non-durable until T036.
 
 ### Slice 5 - Identity, Correlation, and Lifecycle
 
@@ -111,6 +118,7 @@ gates. Produce a machine-readable go/no-go record. Hand live cluster/microVM rol
 - `ScannerArtifactEnvelope` and result-ingress decision
 - `SastNormalizedFindingCandidate`, `opengrep-sarif-normalizer-v1`, and
   `trivy-json-normalizer-v1`
+- `SastSecretRedactionBatch`, `sast-secret-redaction-v1`, and bounded audit projection
 - `NormalizedSastFinding`, provenance, occurrence, and correlation
 - `ScannerCoverageRecord` and `SastCoverageDecision`
 - `SastEvidencePolicy` and evidence pack reference

--- a/specs/006-production-sast-runtime-design/plan.md
+++ b/specs/006-production-sast-runtime-design/plan.md
@@ -82,8 +82,13 @@ the inventory has no finding, vulnerability, policy, persistence, or AI authorit
 `sast-secret-redaction-v1` gate verifies canonical OpenGrep/Trivy batch and accepted
 disposition digests, rechecks retention on both sides, and scans both non-empty candidates
 and zero-finding batch bindings. It replaces only display text with a fixed marker; a match
-in any future identity field rejects the entire batch. Its fresh output exposes safe counts
-and sanitized-only decision digests, never matched values, matched-value hashes, or the
+in normalized path, semantic rule identity, symbol anchor, sink kind, scanner version/match
+identity, rule provenance identifier/revision, dependency
+vulnerability/package/type/installed/fixed-version identity, secret category, or IaC check
+type/AVD identity rejects the entire batch. The async gate has an 8,000,000 inspected
+UTF-16 code-unit ceiling, yields at bounded 64-candidate/32,768-code-unit chunks, and requires
+trusted canonical SHA-256 recomputation at receiving boundaries. Its fresh output exposes
+safe counts and sanitized-only decision digests, never matched values, matched-value hashes, or the
 source-candidate digest, and remains non-durable until T036.
 
 ### Slice 5 - Identity, Correlation, and Lifecycle

--- a/specs/006-production-sast-runtime-design/quality-gates.md
+++ b/specs/006-production-sast-runtime-design/quality-gates.md
@@ -168,7 +168,23 @@ Raw artifact/evidence expiry is tested at seven days maximum and AI request payl
   semantic-rule/revision resolution from immutable bundle metadata rather than scanner IDs.
 - 100% artifact tenant, scan, scanner, commit, schema, digest, size, and count binding.
 - 100% unknown/unsafe enum, coordinate, path, encoding, and over-limit rejection.
-- 100% secret-value redaction before persistence outside the scanner artifact quarantine.
+- 100% `sast-secret-redaction-v1` determinism for repeated inputs, platform-value ordering,
+  detector overlap/adjacency, empty batches, and OpenGrep/Trivy source adapters.
+- 100% known-format, registered platform-value, private-key, authorization/URL credential,
+  JWT, assignment, and admitted high-entropy corpus removal from display fields using the
+  one fixed marker, with zero matched value or length disclosure.
+- 100% complete-batch rejection when any detected value occurs in ingestion/scope/preflight
+  bindings, path, semantic rule, scanner hint, rule/package/version, anchor, sink, category,
+  or check identity; no secret-derived replacement identity or digest may be constructed.
+- Exactly zero matched values, matched-value digests, raw candidates, pre-redaction
+  candidate-batch digests, or rejected bindings in redaction result, log, audit, dashboard,
+  evidence, policy, or AI surfaces. A rejection also contains no accepted-artifact digest;
+  success may retain only the pre-existing accepted-artifact provenance digest.
+- 100% canonical source-batch and accepted-disposition digest verification plus pre/post-pass
+  active-retention checks; malformed, forged-marker, invalid platform-set, clock rollback,
+  and expiry-crossing cases fail closed.
+- 100% secret-value redaction before persistence outside the scanner artifact quarantine;
+  T035 success remains `durablePersistenceAllowed=false` until T036 fingerprinting.
 - 100% fingerprint stability for line/branch/commit-only changes.
 - 100% provenance preservation during correlation; no lower-severity result may hide a
   higher-severity authoritative result.

--- a/specs/006-production-sast-runtime-design/quality-gates.md
+++ b/specs/006-production-sast-runtime-design/quality-gates.md
@@ -171,11 +171,16 @@ Raw artifact/evidence expiry is tested at seven days maximum and AI request payl
 - 100% `sast-secret-redaction-v1` determinism for repeated inputs, platform-value ordering,
   detector overlap/adjacency, empty batches, and OpenGrep/Trivy source adapters.
 - 100% known-format, registered platform-value, private-key, authorization/URL credential,
-  JWT, assignment, and admitted high-entropy corpus removal from display fields using the
-  one fixed marker, with zero matched value or length disclosure.
+  JWT, prefixed/quoted low-entropy assignment, and admitted high-entropy corpus removal from
+  display fields using the one fixed marker, with zero matched value or length disclosure.
 - 100% complete-batch rejection when any detected value occurs in ingestion/scope/preflight
-  bindings, path, semantic rule, scanner hint, rule/package/version, anchor, sink, category,
-  or check identity; no secret-derived replacement identity or digest may be constructed.
+  bindings or in normalized path, semantic rule identity, symbol anchor, sink kind, scanner
+  version/match identity, rule provenance identifier/revision, dependency
+  vulnerability/package/type/installed/fixed-version identity, secret category, or IaC check
+  type/AVD identity; no secret-derived replacement identity or digest may be constructed.
+- 100% rejection above 8,000,000 inspected UTF-16 code units, event-loop yielding before the
+  next candidate at the 64-candidate or 32,768-code-unit chunk boundary, and canonical digest
+  recomputation for every candidate, batch, rejection, and audit projection.
 - Exactly zero matched values, matched-value digests, raw candidates, pre-redaction
   candidate-batch digests, or rejected bindings in redaction result, log, audit, dashboard,
   evidence, policy, or AI surfaces. A rejection also contains no accepted-artifact digest;

--- a/specs/006-production-sast-runtime-design/quickstart.md
+++ b/specs/006-production-sast-runtime-design/quickstart.md
@@ -272,8 +272,9 @@ portion of Phase 6:
   immutable plan, coordinated attestation, validation/envelope/content/disposition digests,
   exact Trivy 0.66.0 scanner/image/wrapper/schema/normalizer/checks-bundle metadata, and pinned
   vulnerability-database digest/version before reading a bounded stream. The adapter has no
-  route or general object-store capability and remains unwired until the later
-  Data/Security-owned redaction/persistence worker exists.
+  route or general object-store capability. T035 is the implemented in-memory redaction
+  boundary, but artifact reading and durable flow remain unwired until the later
+  Data/Security-owned orchestration and T036 persistence worker exist.
 - The Trivy adapter accepts only JSON v2 dependency, secret, and failed IaC result classes.
   It streams bounded scalars through globally aligned parser slices, independently rehashes
   bytes and recounts direct plus `ExperimentalModifiedFindings`, and never materializes the
@@ -319,14 +320,33 @@ portion of Phase 6:
   external references, and raw artifact bytes are absent. Authority is explicitly SBOM-only:
   no finding creation, vulnerability decision, policy authority, durable persistence, or AI
   payload eligibility.
+- `sast-secret-redaction-v1` now verifies the exact OpenGrep/Trivy canonical batch digest,
+  T031 accepted disposition/validation binding, and active retention window before and after
+  processing. It inspects the eight ingestion/scope/preflight binding fields even for an
+  empty batch and rejects binding drift without copying the rejected values.
+- The T035 detector combines transient registered platform values with bounded private-key,
+  authorization/URL credential, documented provider-token, JWT, contextual assignment, and
+  high-entropy detection. Overlapping spans become the one fixed `[REDACTED]` marker only in
+  title, description, and optional symbol display fields. A forged marker or any match in
+  path/rule/package/version/anchor/sink/scanner identity rejects the whole batch rather than
+  creating a secret-derived fingerprint input.
+- Successful T035 output is a fresh canonical `SastSecretRedactionBatch` with per-finding
+  sanitized-only decisions, safe aggregate counts, no raw or matched value, no matched-value
+  hash, and no pre-redaction candidate digest. Its audit helper exposes metadata only.
+  `secretRedactionApplied=true` does not grant persistence:
+  `durablePersistenceAllowed=false` remains fixed until T036.
+- `ScanPlaneModule` no longer exports the raw OpenGrep or Trivy normalizer providers; internal
+  consumers receive the T035 redaction boundary. There is still no user route, evidence,
+  policy, AI, or durable-finding path.
 
 This checkpoint proves the provider-facing execution contract but does not claim that the
 provider microVM platform is live. The non-production opaque credential issuer and test
 runtime provider exist only to verify the handoff contract. Default production credential
 issuance and scanner execution both fail closed until live rollout installs provider-backed
 GitHub App/GitLab scoped minting, microVM, artifact object-store/disposition,
-file-coordinate-attestation, and acceptance-gate adapters. T035 secret redaction is therefore
-the next implementation task; live deployment eligibility
+file-coordinate-attestation, and acceptance-gate adapters. T035 secret redaction is complete;
+T036 `sast-fingerprint-v1` identity construction is therefore the next implementation task.
+Live deployment eligibility
 still requires the 005 rollout and the remaining 006 gates.
 
 ## Deployment Position

--- a/specs/006-production-sast-runtime-design/quickstart.md
+++ b/specs/006-production-sast-runtime-design/quickstart.md
@@ -327,9 +327,16 @@ portion of Phase 6:
 - The T035 detector combines transient registered platform values with bounded private-key,
   authorization/URL credential, documented provider-token, JWT, contextual assignment, and
   high-entropy detection. Overlapping spans become the one fixed `[REDACTED]` marker only in
-  title, description, and optional symbol display fields. A forged marker or any match in
-  path/rule/package/version/anchor/sink/scanner identity rejects the whole batch rather than
-  creating a secret-derived fingerprint input.
+  title, description, and optional symbol display fields. A forged marker or any match in a
+  normalized path, semantic rule identity, symbol anchor, sink kind, scanner version/match
+  identity, rule provenance identifier/revision, dependency
+  vulnerability/package/type/installed/fixed-version identity, secret category, or IaC check
+  type/AVD identity rejects the whole batch rather than creating a secret-derived fingerprint
+  input.
+- The async gate rejects more than 8,000,000 inspected UTF-16 code units and yields before the
+  next candidate whenever the 64-candidate or 32,768-code-unit chunk boundary is reached.
+  Receiving code must supply the trusted SHA-256 canonical digester so candidate, batch, and
+  rejection validators recompute their preimages instead of format-checking digests only.
 - Successful T035 output is a fresh canonical `SastSecretRedactionBatch` with per-finding
   sanitized-only decisions, safe aggregate counts, no raw or matched value, no matched-value
   hash, and no pre-redaction candidate digest. Its audit helper exposes metadata only.

--- a/specs/006-production-sast-runtime-design/research.md
+++ b/specs/006-production-sast-runtime-design/research.md
@@ -271,3 +271,47 @@ output while preventing generic extension smuggling and long-lived path/prose le
 retaining raw BOM references or Syft properties, treating an SBOM as vulnerability evidence,
 accepting separator-count-only CPEs or regex-shaped invented SPDX IDs/exceptions, granting it
 policy/AI authority, or persisting the pre-gate inventory.
+
+## Decision 17: Redact Display Text and Reject Secret-Bearing Identity
+
+**Decision**: `sast-secret-redaction-v1` is the only exported Scan Plane handoff for
+T032/T033 candidate batches. It first verifies the exact canonical source-batch digest and
+the still-active T031 accepted disposition. It performs deterministic, bounded span
+detection over registered platform values, private-key blocks, authorization and URL
+credentials, provider token formats, JWTs, secret assignments, and high-entropy tokens.
+Overlapping and adjacent matches become one fixed `[REDACTED]` marker, so output reveals
+neither matched value nor its length.
+
+Only title, description, and optional location symbol are redactable display fields. A
+detected value in scope/preflight bindings, normalized path, semantic rule identity,
+symbol anchor, sink kind, scanner identity hint, rule provenance, or Trivy package/check
+identity rejects the whole batch. This avoids resolving collisions by hashing or otherwise
+retaining a secret-derived identity preimage. The output is a fresh
+`SastSecretRedactionBatch` with per-finding decisions, ordered safe detector categories,
+sanitized-only digests, no source-candidate digest, and
+`durablePersistenceAllowed=false`. T036 remains the sole next step allowed to construct a
+stable fingerprint.
+
+The detector families follow the provider/generic distinction documented by
+[GitHub supported secret-scanning patterns](https://docs.github.com/en/code-security/reference/secret-security/supported-secret-scanning-patterns),
+the current [GitLab token-prefix registry](https://docs.gitlab.com/security/tokens/), and
+the documented AWS `AKIA`/`ASIA` access-key identifiers in
+[AWS IAM identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html).
+The decision to exclude the values themselves, rather than log a correlation hash, follows
+the [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)
+guidance for access tokens, passwords, connection strings, encryption keys, and primary
+secrets. These sources were reviewed on 2026-07-26. Runtime patterns are the code-reviewed
+v1 snapshot and never update themselves from the network; source changes require corpus
+review and a new redaction contract version.
+
+**Rationale**: Scanner rule messages may interpolate repository values even after snippets
+and Trivy secret context are structurally discarded. Redacting only evidence is therefore
+too late. Conversely, replacing identity-bearing values with one marker can collapse
+distinct findings, while hashing the value would retain a secret-derived correlation
+oracle. Display redaction plus identity rejection preserves both confidentiality and future
+fingerprint integrity.
+
+**Rejected**: Logging or persisting the pre-redaction batch digest, hashing matched values,
+revealing provider/match detail in a rejection, masking only Trivy secret findings, silently
+dropping a secret-bearing candidate, replacing identity fields and guessing a new identity,
+trusting a forged `[REDACTED]` marker, or checking retention only before the pass.

--- a/specs/006-production-sast-runtime-design/research.md
+++ b/specs/006-production-sast-runtime-design/research.md
@@ -283,14 +283,23 @@ Overlapping and adjacent matches become one fixed `[REDACTED]` marker, so output
 neither matched value nor its length.
 
 Only title, description, and optional location symbol are redactable display fields. A
-detected value in scope/preflight bindings, normalized path, semantic rule identity,
-symbol anchor, sink kind, scanner identity hint, rule provenance, or Trivy package/check
-identity rejects the whole batch. This avoids resolving collisions by hashing or otherwise
-retaining a secret-derived identity preimage. The output is a fresh
+detected value in scope/preflight bindings or in normalized path, semantic rule identity,
+symbol anchor, sink kind, scanner version/match identity, rule provenance
+identifier/revision, dependency vulnerability/package/type/installed/fixed-version identity,
+secret category, or IaC check type/AVD identity rejects the whole batch. This avoids
+resolving collisions by hashing or otherwise retaining a secret-derived identity preimage.
+The output is a fresh
 `SastSecretRedactionBatch` with per-finding decisions, ordered safe detector categories,
 sanitized-only digests, no source-candidate digest, and
 `durablePersistenceAllowed=false`. T036 remains the sole next step allowed to construct a
 stable fingerprint.
+
+The implementation is asynchronous and cooperatively yields between bounded chunks rather
+than scanning 25,000 candidates in one event-loop turn. An 8,000,000 inspected UTF-16
+code-unit ceiling bounds total text work; 64-candidate and 32,768-code-unit chunk thresholds
+bound each uninterrupted pass. Shared validators accept a trusted canonical SHA-256
+digester and recompute decision, batch, and rejection preimages so T036 cannot trust a
+format-only digest.
 
 The detector families follow the provider/generic distinction documented by
 [GitHub supported secret-scanning patterns](https://docs.github.com/en/code-security/reference/secret-security/supported-secret-scanning-patterns),
@@ -303,6 +312,11 @@ guidance for access tokens, passwords, connection strings, encryption keys, and 
 secrets. These sources were reviewed on 2026-07-26. Runtime patterns are the code-reviewed
 v1 snapshot and never update themselves from the network; source changes require corpus
 review and a new redaction contract version.
+
+Typed provenance digest fields remain outside display text and are shape-bound separately.
+Untrusted scanner title/description/symbol text receives no `sha1:`/`sha256:` or bare-hex
+exemption: otherwise a scanner message could relabel a 32- or 64-hex credential as a digest
+and bypass T035. Digest-shaped high-entropy display values are therefore redacted by design.
 
 **Rationale**: Scanner rule messages may interpolate repository values even after snippets
 and Trivy secret context are structurally discarded. Redacting only evidence is therefore

--- a/specs/006-production-sast-runtime-design/spec.md
+++ b/specs/006-production-sast-runtime-design/spec.md
@@ -173,6 +173,18 @@ incomplete, stale, quarantined, or security-blocked scan.
   artifact bytes MUST NOT enter the inventory. SBOM inventory MUST NOT create findings,
   evaluate vulnerabilities, influence policy, enter AI payloads, or become durably
   persisted before a later explicit data-handling gate.
+- **FR-031c**: `sast-secret-redaction-v1` MUST revalidate the exact canonical T032/T033
+  batch digest, accepted T031 disposition digest, validation binding, and active retention
+  window before and after redaction. Display-only title, description, and optional symbol
+  values MUST replace detected platform values, private keys, credentials, supported
+  provider tokens, secret assignments, JWTs, and high-entropy tokens with one fixed marker.
+  A detected value in a batch binding, path, semantic identity, scanner identity hint,
+  rule/package/version, symbol anchor, or sink kind MUST reject the complete batch rather
+  than create a secret-derived fingerprint input. Successful output MUST be a fresh,
+  deterministic, still non-durable candidate batch with explicit redaction decisions.
+  Matched values, value lengths, matched-value digests, raw candidates, and the
+  pre-redaction candidate-batch digest MUST NOT enter output, rejection, log, audit,
+  dashboard, evidence, policy, or AI payloads.
 - **FR-032**: Unknown enum values, invalid coordinates, overlong strings, unsafe encodings,
   and excessive nesting MUST fail closed.
 
@@ -273,6 +285,8 @@ security and capacity approval and may force `RESTRICTED` isolation.
 - Scanner responsibility is unambiguous and test-enforced.
 - Every implementation input and output is represented by a shared contract without source
   content or credential-value fields.
+- Every pre-fingerprint finding candidate passes the versioned redaction gate, while a
+  secret-bearing identity field fails closed without a matched-value or pre-redaction digest.
 - Rule promotion and production readiness have measurable fail-closed gates.
 - Stable identity behavior is independent of line, branch, and commit changes.
 - Coverage and failure matrices cannot authorize external publication when incomplete.

--- a/specs/006-production-sast-runtime-design/spec.md
+++ b/specs/006-production-sast-runtime-design/spec.md
@@ -178,10 +178,15 @@ incomplete, stale, quarantined, or security-blocked scan.
   window before and after redaction. Display-only title, description, and optional symbol
   values MUST replace detected platform values, private keys, credentials, supported
   provider tokens, secret assignments, JWTs, and high-entropy tokens with one fixed marker.
-  A detected value in a batch binding, path, semantic identity, scanner identity hint,
-  rule/package/version, symbol anchor, or sink kind MUST reject the complete batch rather
-  than create a secret-derived fingerprint input. Successful output MUST be a fresh,
-  deterministic, still non-durable candidate batch with explicit redaction decisions.
+  A detected value in a batch binding or normalized path, semantic rule identity, symbol
+  anchor, sink kind, scanner version/match identity, rule provenance identifier/revision,
+  dependency vulnerability/package/type/installed/fixed-version identity, secret category,
+  or IaC check type/AVD identity MUST reject the complete batch rather than create a
+  secret-derived fingerprint input. The gate MUST reject more than 8,000,000 inspected
+  UTF-16 code units and yield between bounded chunks of at most 64 candidates or 32,768
+  inspected code units. Successful output MUST be a fresh, deterministic, still non-durable
+  candidate batch with explicit redaction decisions whose canonical digests are recomputed
+  at every receiving trust boundary.
   Matched values, value lengths, matched-value digests, raw candidates, and the
   pre-redaction candidate-batch digest MUST NOT enter output, rejection, log, audit,
   dashboard, evidence, policy, or AI payloads.

--- a/specs/006-production-sast-runtime-design/tasks.md
+++ b/specs/006-production-sast-runtime-design/tasks.md
@@ -51,7 +51,7 @@
 - [x] T032 Implement versioned OpenGrep SARIF normalization with golden fixtures
 - [x] T033 Implement versioned Trivy JSON normalization with golden fixtures
 - [x] T034 Implement versioned CycloneDX SBOM validation and inventory ingestion
-- [ ] T035 Redact secret values before normalized persistence, logs, audit, or evidence
+- [x] T035 Redact secret values before normalized persistence, logs, audit, or evidence
 
 ## Phase 7: Finding Identity and Coverage
 

--- a/specs/006-production-sast-runtime-design/threat-model.md
+++ b/specs/006-production-sast-runtime-design/threat-model.md
@@ -47,6 +47,10 @@ exfiltrate data, or gain Control/AI/Data-Security authority.
 | Rule identity forgery | Scanner-local rule ID is presented as a platform semantic identity | Resolve semantic ID/revision only from unique signed bundle-manifest metadata; bind plan digest in every candidate | Golden mismatched-ID corpus; whole-batch rejection |
 | Coordinate-attestation downgrade | Supplied unverified or drifted attestation is treated as unavailable metadata | Distinguish provider absence from supplied drift; reject drift before artifact reads | Negative binding corpus; zero body-read assertion |
 | Raw SARIF retention | Snippets, fixes, code flows, or help content are copied into findings | Scalar-only streaming projection; transient candidates; T035 persistence gate | Golden privacy corpus; zero raw-payload audit/API assertions |
+| Candidate display secret smuggling | OpenGrep message, title, or symbol interpolates a repository/platform secret after raw snippets were discarded | Versioned provider/generic/exact-value redaction; one fixed marker; fresh output only | Known-format, entropy, registered-value, Unicode, overlap, and zero-leak serialization corpus |
+| Identity redaction collision | Secret in path/rule/package/anchor is replaced and distinct findings collapse to one fingerprint | Reject the complete batch; never hash or replace an identity-bearing match | Identity-field corpus; zero secret-derived decision/fingerprint preimages |
+| Redaction oracle | Rejection, match length/type, source-candidate digest, or matched-value hash allows correlation or guessing | Coarse ordered reasons and negative-storage assertions only; no rejected binding/artifact/source digest | Byte-level rejection/audit allowlist and sentinel non-occurrence tests |
+| Redaction marker forgery | Scanner text includes `[REDACTED]` and falsely claims platform processing | Reserved input marker rejects before decision construction | Forged-marker corpus and exact decision-shape validation |
 | Trivy disposition smuggling | `ExperimentalModifiedFindings` status is treated as a platform waiver, suppression, or lifecycle decision | Normalize supported modified records; preserve status only with `platformPolicyAuthority=false`; reject unknown type/status | Direct/modified golden parity and unsupported-license/status corpus |
 | Trivy capability forgery | Scanner-local metadata changes dependency, secret, or IaC semantic authority | DB-derived dependency identity; signed checks-manifest identity for secret/IaC; exact capability/result class allowlist | Cross-capability/rule/database mismatch corpus; whole-batch rejection |
 | Trivy secret-context leakage | Masked `Match` is accepted while nearby `Code`, `Statement`, or `Source` contains the secret | Never collect raw secret/context scalar values; emit deterministic platform text and explicit discard flags | Sentinel secret corpus; zero occurrence in candidates/digests/rejections |
@@ -54,7 +58,7 @@ exfiltrate data, or gain Control/AI/Data-Security authority.
 | Canonical Unicode collapse | An escaped unpaired surrogate is decoded to a replacement character before hashing | Validate raw JSON escape pairs before token decoding; NFC plus scalar-value checks | One-byte-chunk paired/unpaired surrogate corpus |
 | Retention clock rollback | A caller supplies a past payload timestamp to normalize an expired accepted object | Adapter-owned default clock checked before and after streaming; trusted test/task clock seam only; require monotonic time at or after disposition | Expiry, stream-crossing, and pre-decision clock tests |
 | Stored XSS | Rule message/path/package contains markup | Treat all strings as text; output encoding; sanitized Markdown only | Stored-XSS corpus; presentation CSP |
-| Secret leakage | Secret finding includes detected value | Scanner and platform redaction; fingerprints; no raw value in finding/audit/evidence | Secret-leak gate must remain zero |
+| Secret leakage | Finding or zero-finding binding includes a detected/platform secret | Scanner discard plus T035 display redaction, batch-binding inspection, identity fail-close, and T042 evidence re-redaction | Secret-leak gate must remain zero |
 | Cross-tenant object access | Object key or query omits tenant | Tenant/scan prefix, encryption context, tenant predicate, purpose-bound reads | Negative tests and access audit |
 | Cache poisoning | Customer content enters shared cache | Shared cache only for signed public tool/rule/database assets | Cache inventory and digest monitoring |
 | Rule supply-chain attack | Malicious rule or database promoted | Signed digest, provenance, two-person security approval, corpus gates, canary | Automatic rollback/kill switch |
@@ -145,6 +149,12 @@ The following must always remain true:
   transient inventory and every rejection/log/audit/AI surface
 - malicious filenames, package names, symbols, rule messages, HTML, Markdown, and ANSI codes
 - known token formats and high-entropy secret fixtures
+- registered platform values, private-key blocks, authorization/URL credentials, documented
+  provider prefixes, JWTs, contextual assignments, overlapping/adjacent spans, Unicode text,
+  forged markers, invalid/duplicate/over-limit value sets, and detector-order permutations
+- secrets in normalized paths, semantic IDs, scanner hints, rule/package/version/anchor/sink
+  identity, and zero-finding ingestion/scope/preflight bindings; every rejection surface must
+  omit the value, length, matched-value hash, source-candidate digest, and rejected binding
 - scanner crash/timeout/output bomb/truncation and result replay
 - signed-envelope tenant/scan/commit/digest tampering
 - cross-tenant object and query access

--- a/specs/006-production-sast-runtime-design/threat-model.md
+++ b/specs/006-production-sast-runtime-design/threat-model.md
@@ -152,9 +152,15 @@ The following must always remain true:
 - registered platform values, private-key blocks, authorization/URL credentials, documented
   provider prefixes, JWTs, contextual assignments, overlapping/adjacent spans, Unicode text,
   forged markers, invalid/duplicate/over-limit value sets, and detector-order permutations
-- secrets in normalized paths, semantic IDs, scanner hints, rule/package/version/anchor/sink
-  identity, and zero-finding ingestion/scope/preflight bindings; every rejection surface must
-  omit the value, length, matched-value hash, source-candidate digest, and rejected binding
+- secrets in normalized path, semantic rule identity, symbol anchor, sink kind, scanner
+  version/match identity, rule provenance identifier/revision, dependency
+  vulnerability/package/type/installed/fixed-version identity, secret category, IaC check
+  type/AVD identity, and zero-finding ingestion/scope/preflight bindings; every rejection
+  surface must omit the value, length, matched-value hash, source-candidate digest, and
+  rejected binding
+- event-loop starvation or CPU amplification from maximum-size candidate batches; reject
+  above 8,000,000 inspected UTF-16 code units and yield at the 64-candidate or
+  32,768-code-unit chunk boundary
 - scanner crash/timeout/output bomb/truncation and result replay
 - signed-envelope tenant/scan/commit/digest tampering
 - cross-tenant object and query access

--- a/test/github-actions/active-feature.test.mjs
+++ b/test/github-actions/active-feature.test.mjs
@@ -485,6 +485,16 @@ test('SAST T035 secret redaction is deterministic, fail-closed, and still non-du
   assert.match(service, /SECRET_REDACTION_IDENTITY_FIELD_BLOCKED/);
   assert.match(service, /mergeSpans/);
   assert.match(service, /shannonEntropy/);
+  assert.match(service, /async redact\(/);
+  assert.match(service, /protected async yieldEventLoop/);
+  assert.match(service, /await this\.yieldEventLoop\(\)/);
+  assert.match(service, /await yieldToEventLoop\(\)/);
+  assert.match(service, /hasInspectionWorkWithinLimit/);
+  assert.match(
+    sharedRedaction,
+    /maximumInspectedCodeUnits:\s*8_000_000/
+  );
+  assert.match(sharedRedaction, /canonicalDigestMatches/);
   assert.doesNotMatch(service, /\bLogger\b|\bconsole\./u);
   assert.match(
     serviceTest,
@@ -499,10 +509,13 @@ test('SAST T035 secret redaction is deterministic, fail-closed, and still non-du
     /expect\(serialized\)\.not\.toContain\(secret\)/
   );
 
-  const exportsBlock =
-    scanPlaneModule.match(
-      /exports:\s*\[([\s\S]*?)\]\s*\}\)\s*export class/
-    )?.[1] ?? '';
+  const exportsBlock = scanPlaneModule.match(
+    /exports:\s*\[([\s\S]*?)\]\s*\}\)\s*export class/
+  )?.[1];
+  assert.ok(
+    exportsBlock,
+    'Expected to locate the ScanPlaneModule exports array'
+  );
   assert.match(exportsBlock, /SastSecretRedactionService/);
   assert.doesNotMatch(exportsBlock, /OpenGrepSarifNormalizer/);
   assert.doesNotMatch(exportsBlock, /TrivyJsonNormalizer/);
@@ -522,6 +535,21 @@ test('SAST T035 secret redaction is deterministic, fail-closed, and still non-du
     qualityGates,
     /Exactly zero matched values, matched-value digests/
   );
+  const canonicalIdentityRejection =
+    /scanner\s+version\/match\s+identity,[\s\S]{0,200}rule\s+provenance\s+identifier\/revision,[\s\S]{0,250}secret\s+category,[\s\S]{0,120}IaC\s+check\s+type\/AVD\s+identity/;
+  for (const document of [
+    contract,
+    spec,
+    plan,
+    research,
+    dataModel,
+    threatModel,
+    qualityGates,
+    quickstart
+  ]) {
+    assert.match(document, canonicalIdentityRejection);
+  }
+  assert.doesNotMatch(dataModel, /\bdurable handoff\b/);
 });
 
 test('SAST design completion gate stays synchronized between quickstart and CI', () => {

--- a/test/github-actions/active-feature.test.mjs
+++ b/test/github-actions/active-feature.test.mjs
@@ -31,6 +31,8 @@ const files = {
   sharedSastTrivyNormalizationTest: new URL('../../packages/shared/test/sast-trivy-normalization.test.mjs', import.meta.url),
   sharedSastSbomInventory: new URL('../../packages/shared/src/types/sast-sbom-inventory.ts', import.meta.url),
   sharedSastSbomInventoryTest: new URL('../../packages/shared/test/sast-sbom-inventory.test.mjs', import.meta.url),
+  sharedSastSecretRedaction: new URL('../../packages/shared/src/types/sast-secret-redaction.ts', import.meta.url),
+  sharedSastSecretRedactionTest: new URL('../../packages/shared/test/sast-secret-redaction.test.mjs', import.meta.url),
   apiSastPlanner: new URL('../../apps/api/src/control-plane/sast-scan-planner.service.ts', import.meta.url),
   apiSastQueueAdmission: new URL('../../apps/api/src/control-plane/sast-queue-admission.service.ts', import.meta.url),
   apiSastPlanningController: new URL('../../apps/api/src/control-plane/sast-planning.controller.ts', import.meta.url),
@@ -48,6 +50,9 @@ const files = {
   apiSyftCycloneDxIngestorTest: new URL('../../apps/api/test/scan-plane/syft-cyclonedx-inventory-ingestor.e2e-spec.ts', import.meta.url),
   syftCycloneDxGoldenFixture: new URL('../../apps/api/test/fixtures/syft-cyclonedx/upstream-compatible.cdx.json', import.meta.url),
   syftCycloneDxExpectedFixture: new URL('../../apps/api/test/fixtures/syft-cyclonedx/upstream-compatible.expected.json', import.meta.url),
+  apiSastSecretRedaction: new URL('../../apps/api/src/scan-plane/sast-secret-redaction.service.ts', import.meta.url),
+  apiSastSecretRedactionTest: new URL('../../apps/api/test/scan-plane/sast-secret-redaction.e2e-spec.ts', import.meta.url),
+  apiScanPlaneModule: new URL('../../apps/api/src/scan-plane/scan-plane.module.ts', import.meta.url),
   completedDeploymentQuickstart: new URL('../../specs/005-production-deployment-operations/quickstart.md', import.meta.url),
   completedDeploymentTasks: new URL('../../specs/005-production-deployment-operations/tasks.md', import.meta.url),
   completedDeploymentChecklist: new URL('../../specs/005-production-deployment-operations/checklists/requirements.md', import.meta.url),
@@ -420,7 +425,7 @@ test('SAST T034 Syft CycloneDX ingestion is inventory-only, transient, and fixtu
   assert.match(tasks, /- \[x\] T034\b/);
   assert.match(
     quickstart,
-    /T035 secret redaction is therefore\s+the next implementation task/
+    /T035 secret redaction is complete/
   );
   assert.match(contract, /Syft CycloneDX inventory adapter v1/);
   assert.match(spec, /FR-031b/);
@@ -432,6 +437,91 @@ test('SAST T034 Syft CycloneDX ingestion is inventory-only, transient, and fixtu
   assert.match(dataModel, /SyftCycloneDxInventoryBatch/);
   assert.match(threatModel, /CycloneDX inventory cannot smuggle finding/);
   assert.match(qualityGates, /Syft v1\.44\.0 CycloneDX JSON 1\.6/);
+});
+
+test('SAST T035 secret redaction is deterministic, fail-closed, and still non-durable', () => {
+  const sharedRedaction = readNormalizedText(
+    files.sharedSastSecretRedaction
+  );
+  const sharedIndex = readNormalizedText(files.sharedIndex);
+  const sharedRedactionTest = readNormalizedText(
+    files.sharedSastSecretRedactionTest
+  );
+  const service = readNormalizedText(files.apiSastSecretRedaction);
+  const serviceTest = readNormalizedText(
+    files.apiSastSecretRedactionTest
+  );
+  const scanPlaneModule = readNormalizedText(files.apiScanPlaneModule);
+  const tasks = readNormalizedText(files.tasks);
+  const quickstart = readNormalizedText(files.quickstart);
+  const contract = readNormalizedText(files.contract);
+  const spec = readNormalizedText(files.spec);
+  const plan = readNormalizedText(files.plan);
+  const research = readNormalizedText(files.research);
+  const dataModel = readNormalizedText(files.dataModel);
+  const threatModel = readNormalizedText(files.threatModel);
+  const qualityGates = readNormalizedText(files.qualityGates);
+
+  assert.match(
+    sharedRedaction,
+    /SAST_SECRET_REDACTION_VERSION\s*=[\s\S]*'sast-secret-redaction-v1'/
+  );
+  assert.match(
+    sharedIndex,
+    /export \* from '.\/types\/sast-secret-redaction';/
+  );
+  assert.match(
+    sharedRedaction,
+    /SAST_SECRET_REDACTION_TOKEN\s*=\s*'\[REDACTED\]'/
+  );
+  assert.match(sharedRedaction, /matchedValueDigestStored:\s*false/);
+  assert.match(sharedRedaction, /sourceCandidateDigestStored:\s*false/);
+  assert.match(sharedRedaction, /durablePersistenceAllowed:\s*false/);
+  assert.match(
+    sharedRedactionTest,
+    /canonical transient redacted-candidate batch/
+  );
+  assert.match(service, /class SastSecretRedactionService/);
+  assert.match(service, /SECRET_REDACTION_IDENTITY_FIELD_BLOCKED/);
+  assert.match(service, /mergeSpans/);
+  assert.match(service, /shannonEntropy/);
+  assert.doesNotMatch(service, /\bLogger\b|\bconsole\./u);
+  assert.match(
+    serviceTest,
+    /known-format, entropy, and registered-value corpus/
+  );
+  assert.match(
+    serviceTest,
+    /rejects secret-bearing batch bindings even when there are no findings/
+  );
+  assert.match(
+    serviceTest,
+    /expect\(serialized\)\.not\.toContain\(secret\)/
+  );
+
+  const exportsBlock =
+    scanPlaneModule.match(
+      /exports:\s*\[([\s\S]*?)\]\s*\}\)\s*export class/
+    )?.[1] ?? '';
+  assert.match(exportsBlock, /SastSecretRedactionService/);
+  assert.doesNotMatch(exportsBlock, /OpenGrepSarifNormalizer/);
+  assert.doesNotMatch(exportsBlock, /TrivyJsonNormalizer/);
+
+  assert.match(tasks, /- \[x\] T035\b/);
+  assert.match(quickstart, /T036 `sast-fingerprint-v1` identity construction/);
+  assert.match(contract, /Secret redaction gate v1/);
+  assert.match(spec, /FR-031c/);
+  assert.match(plan, /`sast-secret-redaction-v1` gate/);
+  assert.match(
+    research,
+    /Redact Display Text and Reject Secret-Bearing Identity/
+  );
+  assert.match(dataModel, /SastSecretRedactionBatch/);
+  assert.match(threatModel, /Identity redaction collision/);
+  assert.match(
+    qualityGates,
+    /Exactly zero matched values, matched-value digests/
+  );
 });
 
 test('SAST design completion gate stays synchronized between quickstart and CI', () => {


### PR DESCRIPTION
## 🎋 작업 중인 브랜치 및 이슈

- 브랜치: `feat/266-006-secret-value-redaction`
- 이슈: #266
- 선행 PR: #265

## 🔎 주요 변경 사항

- `sast-secret-redaction-v1` shared 계약으로 고정 `[REDACTED]` 토큰, canonical detector/field/rejection ordering, candidate·batch decision digest와 bounded audit projection을 정의했습니다.
- T032 OpenGrep/T033 Trivy normalized batch의 exact shape와 canonical digest, T031 `ACCEPTED` disposition, validation·ingestion·scope·plan·preflight·provenance binding을 redaction 전 재검증합니다.
- retention을 처리 전후에 단조 시계로 재검증하고 malformed, tampered, unknown-adapter, over-limit 입력을 payload 없는 bounded reason code로 fail closed 처리합니다.
- 표시용 title/description/symbol에서 platform-provided value, private key, authorization/URL credential, AWS·GitHub·GitLab·Slack·Google·Stripe·SendGrid 토큰, JWT, secret assignment, high-entropy token을 deterministic span 방식으로 제거합니다.
- 등록 비밀값은 호출 단위 Aho-Corasick matcher로 선형 검사하며 중첩·인접·포함 관계의 span을 하나의 고정 토큰으로 병합합니다.
- path, semantic identity, anchor/sink, scanner hint, rule provenance, Trivy package/version/category/check identity에서 비밀값이 감지되면 secret-derived hash나 대체 identity를 만들지 않고 전체 배치를 거부합니다.
- 출력은 fresh sanitized copy만 반환하며 raw candidate, matched value, matched-value digest, source candidate digest를 저장·로그·audit·evidence·AI payload에 전달하지 않습니다.
- zero-finding batch도 ingestion/scope/scanner/preflight binding 8개를 검사하고 완전히 결속된 redaction batch를 생성하며 `durablePersistenceAllowed=false`를 유지합니다.
- Scan Plane 외부 export에서 raw OpenGrep/Trivy normalizer를 제거하고 T035 redaction gate만 노출해 T036 fingerprint 이전 durable persistence를 차단합니다.
- known-format·entropy·registered-value corpus, Unicode/NFC, overlap/adjacency/nesting, digest tamper, invalid platform values, identity secret, retention race, empty/over-limit batch, zero-leak serialization 회귀 테스트를 추가했습니다.
- prefixed·quoted·escaped low-entropy assignment를 포함한 secret 문법을 보강하고, 동일 문법이 identity field에 나타나면 전체 배치를 거부하는 회귀 검증을 추가했습니다.
- 최대 8,000,000 UTF-16 code-unit 작업량과 64-candidate/32,768-code-unit event-loop yield 경계를 적용해 대규모 입력의 CPU 점유를 제한했습니다.
- candidate·batch·rejection·audit 수신 경계에서 trusted SHA-256 digester로 canonical preimage를 재계산하고, 검사 필드 목록·요약 count가 단일 shared 정의에서 파생되도록 강화했습니다.
- 006 contract/data model/research/threat model/quality gates/spec/plan/quickstart/tasks와 active-feature CI guard를 T035 완료 및 T036 진입점으로 동기화했습니다.

## ✅ 컨벤션 확인

- [x] 브랜치명이 `type/issue-number-short-feature` 형식을 따르나요?
- [x] 이슈 제목과 PR 제목을 동일하게 작성했나요?
- [x] 커밋 메시지가 `<type>: <description>` 형식을 따르나요?

## Check List

- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지 전 반드시 **CI가 정상적으로 작동하는지 확인**했나요?

## 검증

- `corepack pnpm lint`
- `corepack pnpm test` (API 84 suites / 489 tests, Web 54 tests, shared 61 tests, GitHub contract 23 tests)
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm --filter @aegisai/api prisma:validate`
- `node --test test/runtime/*.test.mjs` (1 test)
- focused T035 secret-redaction 16 tests
- `git diff --check`

## 006 진행 상태

- T035 완료
- 다음 작업: T036 `sast-fingerprint-v1` identity construction

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a SAST secret-redaction pipeline that detects sensitive values and replaces them with a standard `[REDACTED]` marker.
  * Rejects entire batches when secrets appear in identity-related fields or when validation, retention, or integrity checks fail.
  * Provides deterministic, sanitized redaction results and safe audit metadata.

* **Security**
  * Prevents raw secrets, sensitive candidate data, and related digests from appearing in outputs or downstream persistence.

* **Tests**
  * Added comprehensive coverage for successful redaction, rejection scenarios, validation, determinism, and secret-leak prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->